### PR TITLE
Added KMZ without photos, photo details to export menu

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/fragments/FileTypeDialogFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/FileTypeDialogFragment.java
@@ -67,12 +67,14 @@ public class FileTypeDialogFragment extends DialogFragment {
     @Override
     @NonNull
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        final TrackFileFormat[] trackFileFormats = {TrackFileFormat.KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES, TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA, TrackFileFormat.GPX};
+        final TrackFileFormat[] trackFileFormats = {TrackFileFormat.KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES, TrackFileFormat.KMZ_WITH_TRACKDETAIL_AND_SENSORDATA, TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA, TrackFileFormat.GPX};
         String[] choices = new String[trackFileFormats.length];
         for (int i = 0; i < choices.length; i++) {
             TrackFileFormat trackFileFormat = trackFileFormats[i];
             String trackFileFormatUpperCase = trackFileFormat.getExtension().toUpperCase(Locale.US); //ASCII upper case
-            choices[i] = getString(optionId, trackFileFormatUpperCase);
+            int photoMessageId = trackFileFormat.includesPhotos() ? R.string.export_with_photos : R.string.export_without_photos;
+            String trackFileFormatDisplayName = String.format("%s (%s)", trackFileFormatUpperCase, getString(photoMessageId));
+            choices[i] = getString(optionId, trackFileFormatDisplayName);
         }
         return new AlertDialog.Builder(getActivity())
                 .setNegativeButton(R.string.generic_cancel, new OnClickListener() {

--- a/src/main/java/de/dennisguse/opentracks/io/file/TrackFileFormat.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/TrackFileFormat.java
@@ -86,6 +86,11 @@ public enum TrackFileFormat {
         public String getExtension() {
             return "kmz";
         }
+
+        @Override
+        public boolean includesPhotos() {
+            return exportPhotos;
+        }
     },
     KMZ_WITH_TRACKDETAIL {
 
@@ -108,6 +113,12 @@ public enum TrackFileFormat {
         public String getExtension() {
             return "kmz";
         }
+
+        @Override
+        public boolean includesPhotos() {
+            return exportPhotos;
+        }
+
     },
     KMZ_WITH_TRACKDETAIL_AND_SENSORDATA {
 
@@ -130,6 +141,13 @@ public enum TrackFileFormat {
         public String getExtension() {
             return "kmz";
         }
+
+        @Override
+        public boolean includesPhotos() {
+            return exportPhotos;
+        }
+
+
     },
     KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES {
 
@@ -152,6 +170,12 @@ public enum TrackFileFormat {
         public String getExtension() {
             return "kmz";
         }
+
+        @Override
+        public boolean includesPhotos() {
+            return exportPhotos;
+        }
+
     },
     GPX {
         @Override
@@ -204,6 +228,11 @@ public enum TrackFileFormat {
      * Returns the file extension for each format.
      */
     public abstract String getExtension();
+
+    /**
+     * Returns whether the format supports photos.
+     */
+    public boolean includesPhotos() { return false; };
 
     /**
      * Returns the name of for each format.

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -102,6 +102,8 @@
     <string name="description_track_segment">Segment</string>
     <string name="export_all_option">Alle als %1$s</string>
     <string name="export_all_title">In externen Speicher exportieren</string>
+    <string name="export_with_photos">mit Fotos</string>
+    <string name="export_without_photos">ohne Fotos</string>
     <string name="export_external_storage">Externer Speicher</string>
     <string name="export_external_storage_error">%1$d von %2$s in %3$s exportiert</string>
     <string name="export_external_storage_option">als %1$s in %2$s</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -102,6 +102,8 @@
     <string name="description_track_segment">Segmento</string>
     <string name="export_all_option">Todo como %1$s</string>
     <string name="export_all_title">Exportar a unidad de almacenamiento externa</string>
+    <string name="export_with_photos">con fotos</string>
+    <string name="export_without_photos">sin fotos</string>
     <string name="export_external_storage">Unidad de almacenamiento externa</string>
     <string name="export_external_storage_error">Se exportaron %1$d de %2$s a %3$s</string>
     <string name="export_external_storage_option">como %1$s a %2$s</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -167,6 +167,8 @@ At the moment, the recorded locations as well as the timestamps are send to an A
     <!-- Export -->
     <string name="export_all_option">All as %1$s</string>
     <string name="export_all_title">Export to external storage</string>
+    <string name="export_with_photos">with photos</string>
+    <string name="export_without_photos">without photos</string>
     <string name="export_external_storage">External storage</string>
     <string name="export_external_storage_error">Exported %1$d of %2$s to %3$s</string>
     <string name="export_external_storage_option">as %1$s to %2$s</string>


### PR DESCRIPTION
Solves #17 

Before:
All as KMZ to <>
All as KML to <>
All as GPX to <>

After:
All as KMZ (with photos) to <>
All as KMZ (without photos) to <>
All as KML (without photos)  to <>
All as GPX (without photos) to <>

There's likely a more idiomatic way to do this, I also did not do any testing on the added file format (KMZ_WITH_TRACKDETAIL_AND_SENSORDATA) but can do that later if needed
