### PR TITLE
Added new option in Preferred rate setting: By Default.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/fragments/ChartFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/ChartFragment.java
@@ -199,6 +199,11 @@ public class ChartFragment extends Fragment implements TrackDataListener {
             }
 
             category = track.getCategory();
+            boolean reportSpeed = PreferencesUtils.isReportSpeed(getContext(), category);
+            if (reportSpeed != chartView.getReportSpeed()) {
+                chartView.setReportSpeed(reportSpeed);
+                chartView.applyReportSpeed();
+            }
             startTime = track.getTrackStatistics().getStartTime_ms();
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/fragments/ChartFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/ChartFragment.java
@@ -75,6 +75,7 @@ public class ChartFragment extends Fragment implements TrackDataListener {
 
     //TODO Why is this needed?
     private int recordingDistanceInterval;
+    private String category = "";
 
     // Modes of operation
     private boolean chartByDistance;
@@ -100,7 +101,7 @@ public class ChartFragment extends Fragment implements TrackDataListener {
                 }
             }
             if (PreferencesUtils.isKey(getContext(), R.string.stats_rate_key, key)) {
-                boolean reportSpeed = PreferencesUtils.isReportSpeed(getContext());
+                boolean reportSpeed = PreferencesUtils.isReportSpeed(getContext(), category);
                 if (reportSpeed != chartView.getReportSpeed()) {
                     chartView.setReportSpeed(reportSpeed);
                     chartView.applyReportSpeed();
@@ -193,8 +194,11 @@ public class ChartFragment extends Fragment implements TrackDataListener {
         if (isResumed()) {
             if (track == null || track.getTrackStatistics() == null) {
                 startTime = -1L;
+                category = "";
                 return;
             }
+
+            category = track.getCategory();
             startTime = track.getTrackStatistics().getStartTime_ms();
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatsFragment.java
@@ -469,7 +469,7 @@ public class StatsFragment extends Fragment implements TrackDataListener {
         String trackIconValue = TrackIconUtils.getIconValue(getContext(), category);
 
         boolean metricUnits = PreferencesUtils.isMetricUnits(getContext());
-        boolean reportSpeed = PreferencesUtils.isReportSpeed(getContext());
+        boolean reportSpeed = PreferencesUtils.isReportSpeed(getContext(), category);
         boolean isRecording = isSelectedTrackRecording();
 
         // Set total distance
@@ -562,7 +562,7 @@ public class StatsFragment extends Fragment implements TrackDataListener {
 
     private void setLocationValues() {
         boolean metricUnits = PreferencesUtils.isMetricUnits(getContext());
-        boolean reportSpeed = PreferencesUtils.isReportSpeed(getContext());
+        boolean reportSpeed = PreferencesUtils.isReportSpeed(getContext(), category);
         boolean isRecording = isSelectedTrackRecording();
 
         // Set speed/pace

--- a/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
+++ b/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
@@ -25,6 +25,8 @@ import android.util.Log;
 
 import java.util.Locale;
 
+import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 import de.dennisguse.opentracks.services.TrackRecordingService;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.util.AnnouncementUtils;
@@ -46,6 +48,8 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
     private final Context context;
 
     private final AudioManager audioManager;
+
+    private ContentProviderUtils contentProviderUtils;
 
     private final AudioManager.OnAudioFocusChangeListener audioFocusChangeListener = new AudioManager.OnAudioFocusChangeListener() {
         @Override
@@ -103,6 +107,7 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
     AnnouncementPeriodicTask(Context context) {
         this.context = context;
         audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        contentProviderUtils = new ContentProviderUtils(context);
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
+++ b/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
@@ -26,10 +26,12 @@ import android.util.Log;
 import java.util.Locale;
 
 import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 import de.dennisguse.opentracks.services.TrackRecordingService;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.util.AnnouncementUtils;
+import de.dennisguse.opentracks.util.PreferencesUtils;
 
 /**
  * This class will periodically announce the user's {@link TrackStatistics}.
@@ -162,7 +164,9 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
             Log.i(TAG, "Speech is not allowed at this time.");
             return;
         }
-        String announcement = AnnouncementUtils.getAnnouncement(context, trackStatistics);
+        Track track = contentProviderUtils.getTrack(PreferencesUtils.getRecordingTrackId(context));
+        String category = track != null ? track.getCategory() : "";
+        String announcement = AnnouncementUtils.getAnnouncement(context, trackStatistics, category);
         speakAnnouncement(announcement);
     }
 

--- a/src/main/java/de/dennisguse/opentracks/util/AnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/AnnouncementUtils.java
@@ -9,9 +9,9 @@ public class AnnouncementUtils {
 
     private AnnouncementUtils() {}
 
-    public static String getAnnouncement(Context context, TrackStatistics trackStatistics) {
+    public static String getAnnouncement(Context context, TrackStatistics trackStatistics, String category) {
         boolean metricUnits = PreferencesUtils.isMetricUnits(context);
-        boolean reportSpeed = PreferencesUtils.isReportSpeed(context);
+        boolean reportSpeed = PreferencesUtils.isReportSpeed(context, category);
         double distance = trackStatistics.getTotalDistance() * UnitConversions.M_TO_KM;
         double distancePerTime = trackStatistics.getAverageMovingSpeed() * UnitConversions.MS_TO_KMH;
 

--- a/src/main/java/de/dennisguse/opentracks/util/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/PreferencesUtils.java
@@ -197,9 +197,14 @@ public class PreferencesUtils {
         return STATS_UNIT.equals(getString(context, R.string.stats_units_key, STATS_UNIT));
     }
 
-    public static boolean isReportSpeed(Context context) {
+    public static boolean isReportSpeed(Context context, String category) {
         final String STATS_RATE_DEFAULT = context.getString(R.string.stats_rate_default);
-        return STATS_RATE_DEFAULT.equals(getString(context, R.string.stats_rate_key, STATS_RATE_DEFAULT));
+        String currentStatsRate = getString(context, R.string.stats_rate_key, STATS_RATE_DEFAULT);
+        if (currentStatsRate.equals(getString(context, R.string.stats_rate_default_speed_or_pace, STATS_RATE_DEFAULT))) {
+            return TrackIconUtils.isSpeedIcon(context, category);
+        }
+
+        return currentStatsRate.equals(context.getString(R.string.stats_rate_speed));
     }
 
     public static boolean isRecordingTrackPaused(Context context) {

--- a/src/main/java/de/dennisguse/opentracks/util/TrackIconUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/TrackIconUtils.java
@@ -59,6 +59,21 @@ public class TrackIconUtils {
     private static final int[] SNOW_BOARDING_LIST = new int[]{R.string.activity_type_snow_boarding};
     private static final int[] WALK_LIST = new int[]{R.string.activity_type_hiking, R.string.activity_type_off_trail_hiking, R.string.activity_type_speed_walking, R.string.activity_type_trail_hiking, R.string.activity_type_walking};
 
+    // List of icons whose sports associated use speed (in km/h or mi/h).
+    private static final int[] SPEED_ICON = {
+            // Unknown.
+            R.string.activity_type_unknown,
+            // All airplane categories.
+            R.string.activity_type_airplane, R.string.activity_type_commercial_airplane, R.string.activity_type_rc_airplane,
+            // All bike categories.
+            R.string.activity_type_biking, R.string.activity_type_cycling, R.string.activity_type_dirt_bike, R.string.activity_type_motor_bike, R.string.activity_type_mountain_biking, R.string.activity_type_road_biking, R.string.activity_type_track_cycling,
+            // All boat categories.
+            R.string.activity_type_boat, R.string.activity_type_ferry, R.string.activity_type_motor_boating, R.string.activity_type_rc_boat,
+            // All drive categories.
+            R.string.activity_type_atv, R.string.activity_type_driving, R.string.activity_type_driving_bus, R.string.activity_type_driving_car,
+
+    };
+
     private static final LinkedHashMap<String, Pair<Integer, Integer>> MAP = new LinkedHashMap<>();
 
     static {
@@ -191,5 +206,15 @@ public class TrackIconUtils {
             }
         }
         return false;
+    }
+
+    /**
+     * Returns true if category is in the SPEED_ICON array. Otherwise returns false.
+     *
+     * @param context  the context.
+     * @param category the name of the category, activity type.
+     */
+    public static boolean isSpeedIcon(Context context, String category) {
+        return inList(context, category, SPEED_ICON);
     }
 }

--- a/src/main/res/values-b+es+419/strings.xml
+++ b/src/main/res/values-b+es+419/strings.xml
@@ -93,6 +93,8 @@
     <string name="description_sensor_cadence">Cadencia (rpm)</string>
     <string name="description_sensor_heart_rate">Frecuencia cardíaca (lpm)</string>
     <string name="description_sensor_power">Potencia (W)</string>
+    <string name="description_default_speed_or_pace_imperial">Por Defecto</string>
+    <string name="description_default_speed_or_pace_metric">Por Defecto</string>
     <string name="description_speed_imperial">Velocidad (mi/h)</string>
     <string name="description_speed_metric">Velocidad (km/h)</string>
     <string name="description_time">Tiempo</string>

--- a/src/main/res/values-ca/strings.xml
+++ b/src/main/res/values-ca/strings.xml
@@ -93,6 +93,8 @@
     <string name="description_sensor_cadence">Cadència (rpm)</string>
     <string name="description_sensor_heart_rate">Freqüència cardíaca (bpm)</string>
     <string name="description_sensor_power">Potència (W)</string>
+    <string name="description_default_speed_or_pace_imperial">Per Defecte</string>
+    <string name="description_default_speed_or_pace_metric">Per Defecte</string>
     <string name="description_speed_imperial">Velocitat (mi/h)</string>
     <string name="description_speed_metric">Velocitat (km/h)</string>
     <string name="description_time">Temps</string>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -153,19 +153,23 @@
     </string-array>
 
     <string name="stats_rate_key" translatable="false">statsRate</string>
-    <string name="stats_rate_default" translatable="false">@string/stats_rate_speed</string>
+    <string name="stats_rate_default" translatable="false">@string/stats_rate_default_speed_or_pace</string>
     <string-array name="stats_rate_imperial_options">
+        <item>@string/description_default_speed_or_pace_imperial</item>
         <item>@string/description_speed_imperial</item>
         <item>@string/description_pace_imperial</item>
     </string-array>
     <string-array name="stats_rate_metric_options">
+        <item>@string/description_default_speed_or_pace_metric</item>
         <item>@string/description_speed_metric</item>
         <item>@string/description_pace_metric</item>
     </string-array>
 
+    <string name="stats_rate_default_speed_or_pace" translatable="false">DEFAULT</string>
     <string name="stats_rate_pace" translatable="false">PACE</string>
     <string name="stats_rate_speed" translatable="false">SPEED</string>
     <string-array name="stats_rate_values">
+        <item>@string/stats_rate_default_speed_or_pace</item>
         <item>@string/stats_rate_speed</item>
         <item>@string/stats_rate_pace</item>
     </string-array>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -191,6 +191,8 @@ limitations under the License.
     <string name="description_sensor_cadence">Cadence (rpm)</string>
     <string name="description_sensor_heart_rate">Heart rate (bpm)</string>
     <string name="description_sensor_power">Power (W)</string>
+    <string name="description_default_speed_or_pace_imperial">By Default</string>
+    <string name="description_default_speed_or_pace_metric">By Default</string>
     <string name="description_speed_imperial">Speed (mi/hr)</string>
     <string name="description_speed_metric">Speed (km/hr)</string>
     <string name="description_time">Time</string>


### PR DESCRIPTION
**Describe the pull request**
I've added a "By Default" option in Preferred rate Settings. I think is a better text than "Auto", but it can be easily changed.

In `TrackIconUtils` I have created a new int array with all categories that use speed by default (there are sports that use speed and the other ones use pace). Every time a developer creates a new Icon has to add to this array the new sport if it uses speed by default.

From outside it can be used `isSpeedIcon` public static method to see if a category (activity type) uses speed (true) or pace (false).

Also `isReportSpeed` static method in `PreferencesUtils.java` now need a second argument: the track's category (activity type).

Those are basically all changes done.

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/151

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).