### PR TITLE
Share pictures from marker.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/fragments/MarkerDetailFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/MarkerDetailFragment.java
@@ -60,6 +60,8 @@ public class MarkerDetailFragment extends Fragment {
 
     private static final long HIDE_TEXT_DELAY = 4 * UnitConversions.ONE_SECOND_MS;
 
+    private MenuItem shareMarkerImageMenuItem;
+
     private ContentProviderUtils contentProviderUtils;
     private Handler handler;
     private ImageView photoView;
@@ -145,6 +147,7 @@ public class MarkerDetailFragment extends Fragment {
         // Need to update the waypoint in case returning after an edit
         updateWaypoint(true);
         updateUi();
+        updateMenuItems();
     }
 
     @Override
@@ -170,8 +173,14 @@ public class MarkerDetailFragment extends Fragment {
     @Override
     public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.marker_detail, menu);
-
+        shareMarkerImageMenuItem = menu.findItem(R.id.marker_detail_share);
         updateWaypoint(false);
+        updateMenuItems();
+    }
+
+    private void updateMenuItems() {
+        if (shareMarkerImageMenuItem != null)
+            shareMarkerImageMenuItem.setVisible(waypoint.hasPhoto());
     }
 
     @Override
@@ -187,6 +196,13 @@ public class MarkerDetailFragment extends Fragment {
                 intent = IntentUtils.newIntent(fragmentActivity, MarkerEditActivity.class)
                         .putExtra(MarkerEditActivity.EXTRA_MARKER_ID, markerId);
                 startActivity(intent);
+                return true;
+            case R.id.marker_detail_share:
+                if (waypoint.hasPhoto()) {
+                    intent = IntentUtils.newShareImageIntent(getContext(), waypoint.getPhotoURI());
+                    intent = Intent.createChooser(intent, null);
+                    startActivity(intent);
+                }
                 return true;
             case R.id.marker_detail_delete:
                 DeleteMarkerDialogFragment.showDialog(getChildFragmentManager(), new long[]{markerId});

--- a/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
@@ -107,6 +107,30 @@ public class IntentUtils {
                 .putExtra(Intent.EXTRA_TEXT, context.getString(R.string.share_track_share_file_body, trackDescription));
     }
 
+    /**
+     * Creates an intent to share a waypoint image with an app.
+     *
+     * @param context the context.
+     * @param uri     uri with the image to share.
+     */
+    public static Intent newShareImageIntent(Context context, Uri uri) {
+        String mime = context.getContentResolver().getType(uri);
+
+        /*
+         * Because the #166 bug, when you import KMZ tracks then it creates file:/// from markers with photo.
+         * The photos should be content:/// not file:/// because getType(uri) always returns null for file:///
+         * In .setType, to avoid side effects because the #166 bug described above it checks if mime is null.
+         * If it is then it hardcode "images/*".
+         */
+        return new Intent(Intent.ACTION_SEND)
+                .setType(mime != null ? mime : "image/*")
+                .setAction(Intent.ACTION_SEND)
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                .putExtra(Intent.EXTRA_STREAM, uri)
+                .putExtra(Intent.EXTRA_SUBJECT, context.getString(R.string.share_image_subject))
+                .putExtra(Intent.EXTRA_TEXT, context.getString(R.string.share_image_body));
+    }
+
     public static void showCoordinateOnMap(Context context, Waypoint waypoint) {
         showCoordinateOnMap(context, waypoint.getLocation().getLatitude(), waypoint.getLocation().getLongitude(), waypoint.getName());
     }

--- a/src/main/res/menu/marker_detail.xml
+++ b/src/main/res/menu/marker_detail.xml
@@ -21,6 +21,11 @@ limitations under the License.
         android:title="@string/menu_show_on_map"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/marker_detail_share"
+        android:icon="@drawable/ic_share_24dp"
+        android:title="@string/menu_share"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/marker_detail_edit"
         android:icon="@drawable/ic_edit_24dp"
         android:title="@string/menu_edit"

--- a/src/main/res/values-b+es+419/strings.xml
+++ b/src/main/res/values-b+es+419/strings.xml
@@ -446,4 +446,7 @@
     <string name="waypoint_type_waterfall">cascada</string>
     <string name="waypoint_type_water_fountain">fuente de agua</string>
     <string name="waypoint_type_waypoint">punto de referencia</string>
+    <!-- Share image -->
+    <string name="share_image_subject">Me gustaría compartir una imagen contigo</string>
+    <string name="share_image_body">Creo que esta imagen podría interesarte.</string>
 </resources>

--- a/src/main/res/values-ca/strings.xml
+++ b/src/main/res/values-ca/strings.xml
@@ -448,4 +448,7 @@ es vegi el cel. Torneu-ho a provar més tard.</string>
     <string name="waypoint_type_waterfall">salt d\'aigua</string>
     <string name="waypoint_type_water_fountain">font d\'aigua</string>
     <string name="waypoint_type_waypoint">punt de ruta</string>
+    <!-- Share image -->
+    <string name="share_image_subject">Vull compartir una imatge amb tu</string>
+    <string name="share_image_body">Crec que aquesta imatge et podria interessar.</string>
 </resources>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -450,4 +450,7 @@
     <string name="waypoint_type_waterfall">cascada</string>
     <string name="waypoint_type_water_fountain">fuente de agua</string>
     <string name="waypoint_type_waypoint">Punto de ruta</string>
+    <!-- Share image -->
+    <string name="share_image_subject">Me gustaría compartir una imagen contigo</string>
+    <string name="share_image_body">Creo que esta imagen te podría interesar.</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -595,4 +595,7 @@ limitations under the License.
     <string name="waypoint_type_waterfall">waterfall</string>
     <string name="waypoint_type_water_fountain">water fountain</string>
     <string name="waypoint_type_waypoint">waypoint</string>
+    <!-- Share image -->
+    <string name="share_image_subject">I would like to share an image with you</string>
+    <string name="share_image_body">I think you might be interested in this image.</string>
 </resources>


### PR DESCRIPTION
Fixes #89.

**Describe the pull request**
I added a new menu option in `MarkerDetailFragment` that only is visible in markers with photo/image. This option can be used to share the photo/image of a marker.

Also, I added new strings in english, spanish and catalan languages for images shared (a subject and a text).

I would like to point out a issue that I think you have to think about: 

I would like to point out an issue that I think you have to think about: I've added a new method in IntentUtils that can be used to share an image but nobody avoid that somebody use this method for share any other file because the only thing it needs is a URI (and an URI can be any kind of file). Do you think, this method should be test that URI is a file before to share, something like that:

```
public static Intent newShareImageIntent(Context context, Uri uri) {
        if (uri is not an image) {
                throw new RuntimeException("The file to share has to be an image.");
        }

        ...
}
```

I thought on that but I'd like to know what do you think.

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/89

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).