### PR TITLE
Add android:key in PreferenceCategory with expandable.

### DIFF
--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -198,4 +198,6 @@
         <item>@string/settings_recording_track_name_date_iso_8601_option</item>
         <item>@string/settings_recording_track_name_number_option</item>
     </string-array>
+
+    <string name="settings_recording_key" translatable="false">settingsRecordingKey</string>
 </resources>

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -55,6 +55,7 @@ limitations under the License.
 
     <PreferenceCategory
         android:title="@string/settings_recording"
+        android:key="@string/settings_recording_key"
         app:initialExpandedChildrenCount="4">
         <SwitchPreferenceCompat
             android:defaultValue="@bool/stats_show_on_lockscreen_while_recording_default"


### PR DESCRIPTION
Fixes #163.

**Describe the pull request**
Added an `android:key` in `PreferenceCategory` with expandable (advanced settings). Without `android:key` logcat fire an error.

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/163

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).