### PR TITLE
Activity between List and Detail for start service and start/end tracks.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -81,6 +81,10 @@ limitations under the License.
         </activity>
 
         <activity
+            android:name=".TrackStartEndActivity"
+            android:screenOrientation="userPortrait" />
+
+        <activity
             android:name=".TrackDetailActivity"
             android:screenOrientation="userPortrait" />
 

--- a/src/main/java/de/dennisguse/opentracks/TrackDetailActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackDetailActivity.java
@@ -152,8 +152,12 @@ public class TrackDetailActivity extends AbstractListActivity implements ChooseA
     private final OnClickListener stopListener = new OnClickListener() {
         @Override
         public void onClick(View v) {
-            trackRecordingServiceConnection.stopRecording(TrackDetailActivity.this, true);
             updateMenuItems(true);
+            trackRecordingServiceConnection.pauseTrack();
+            trackController.update(true, true);
+            Intent intent = IntentUtils.newIntent(TrackDetailActivity.this, TrackStartEndActivity.class)
+                    .putExtra(TrackStartEndActivity.EXTRA_COMMAND, TrackStartEndActivity.COMMAND_FINISH);
+            startActivity(intent);
         }
     };
 
@@ -387,9 +391,12 @@ public class TrackDetailActivity extends AbstractListActivity implements ChooseA
                 return;
             }
             trackId = waypoint.getTrackId();
+            if (trackId == -1L) {
+                finish();
+                return;
+            }
         }
         if (trackId == -1L) {
-            finish();
             return;
         }
         Track track = contentProviderUtils.getTrack(trackId);

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -166,13 +166,15 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
         @Override
         public void onClick(View v) {
             updateMenuItems(false, false);
-            trackRecordingServiceConnection.stopRecording(TrackListActivity.this, true);
+            trackRecordingServiceConnection.pauseTrack();
+            trackController.update(true, true);
+            Intent intent = IntentUtils.newIntent(TrackListActivity.this, TrackStartEndActivity.class)
+                    .putExtra(TrackStartEndActivity.EXTRA_COMMAND, TrackStartEndActivity.COMMAND_FINISH);
+            startActivity(intent);
         }
     };
 
     private boolean startGps = false; // true to start gps
-
-    private boolean startNewRecording = false; // true to start a new recording
 
     // Callback when the trackRecordingServiceConnection binding changes.
     private final Runnable bindChangedCallback = new Runnable() {
@@ -188,7 +190,7 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
                 }
             });
 
-            if (!startGps && !startNewRecording) {
+            if (!startGps) {
                 return;
             }
 
@@ -196,17 +198,6 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
             if (service == null) {
                 Log.d(TAG, "service not available to start gps or a new recording");
                 return;
-            }
-            if (startNewRecording) {
-                startGps = false;
-
-                long trackId = service.startNewTrack();
-                startNewRecording = false;
-                Intent intent = IntentUtils.newIntent(TrackListActivity.this, TrackDetailActivity.class)
-                        .putExtra(TrackDetailActivity.EXTRA_TRACK_ID, trackId);
-                startActivity(intent);
-                Toast.makeText(TrackListActivity.this, R.string.track_list_record_success, Toast.LENGTH_SHORT)
-                        .show();
             }
             if (startGps) {
                 service.startGps();
@@ -220,18 +211,20 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
             if (!PreferencesUtils.isRecording(recordingTrackId)) {
                 // Not recording -> Recording
                 updateMenuItems(false, true);
-                startRecording();
+                Intent newIntent = IntentUtils.newIntent(TrackListActivity.this, TrackStartEndActivity.class)
+                        .putExtra(TrackStartEndActivity.EXTRA_COMMAND, TrackStartEndActivity.COMMAND_START);
+                startActivity(newIntent);
             } else if (recordingTrackPaused) {
-                    // Paused -> Resume
-                    updateMenuItems(false, true);
-                    trackRecordingServiceConnection.resumeTrack();
-                    trackController.update(true, false);
-                } else {
-                    // Recording -> Paused
-                    updateMenuItems(false, true);
-                    trackRecordingServiceConnection.pauseTrack();
-                    trackController.update(true, true);
-                }
+                // Paused -> Resume
+                updateMenuItems(false, true);
+                trackRecordingServiceConnection.resumeTrack();
+                trackController.update(true, false);
+            } else {
+                // Recording -> Paused
+                updateMenuItems(false, true);
+                trackRecordingServiceConnection.pauseTrack();
+                trackController.update(true, true);
+            }
         }
     };
 
@@ -487,21 +480,6 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
                 startGpsMenuItem.setIcon(isGpsStarted ? R.drawable.ic_gps_fixed_24dp : R.drawable.ic_gps_off_24dp);
             }
         }
-    }
-
-    /**
-     * Starts a new recording.
-     */
-    private void startRecording() {
-        startNewRecording = true;
-        trackRecordingServiceConnection.startAndBind(this);
-
-        /*
-         * If the binding has happened, then invoke the callback to start a new recording.
-         * If the binding hasn't happened, then invoking the callback will have no effect.
-         * But when the binding occurs, the callback will get invoked.
-         */
-        bindChangedCallback.run();
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/TrackStartEndActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackStartEndActivity.java
@@ -1,0 +1,214 @@
+package de.dennisguse.opentracks;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.util.Pair;
+import android.view.View;
+import android.widget.ImageButton;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import de.dennisguse.opentracks.content.data.Track;
+import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
+import de.dennisguse.opentracks.services.TrackRecordingServiceConnection;
+import de.dennisguse.opentracks.services.TrackRecordingServiceInterface;
+import de.dennisguse.opentracks.stats.TripStatistics;
+import de.dennisguse.opentracks.util.IntentUtils;
+import de.dennisguse.opentracks.util.PreferencesUtils;
+import de.dennisguse.opentracks.util.StringUtils;
+
+/**
+ * An activity to handle the track's start, resume and save.
+ */
+public class TrackStartEndActivity extends AbstractListActivity {
+
+    private static final String TAG = TrackStartEndActivity.class.getSimpleName();
+
+    public static final String EXTRA_COMMAND = "command";
+    public static final int COMMAND_NOTHING = -1;
+    public static final int COMMAND_START = 0;
+    public static final int COMMAND_FINISH = 1;
+
+    // Views.
+    private ImageButton leftButton;
+    private ImageButton rightButton;
+    private View trackSumUpContainer;
+    private View textArrowContainer;
+    private TextView leftText;
+    private TextView rightText;
+    private TextView distanceValue;
+    private TextView distanceUnit;
+    private TextView movingTimeValue;
+
+    private int command;
+    private TrackRecordingServiceConnection trackRecordingServiceConnection;
+
+    private final Runnable bindChangedCallback = new Runnable() {
+        @Override
+        public void run() {
+            if (command == COMMAND_START) {
+                TrackRecordingServiceInterface service = trackRecordingServiceConnection.getServiceIfBound();
+                if (service == null) {
+                    Log.d(TAG, "service not available to start gps or a new recording");
+                    return;
+                }
+
+                long trackId = service.startNewTrack();
+                Intent intent = IntentUtils.newIntent(TrackStartEndActivity.this, TrackDetailActivity.class)
+                        .putExtra(TrackDetailActivity.EXTRA_TRACK_ID, trackId);
+                startActivity(intent);
+                Toast.makeText(TrackStartEndActivity.this, R.string.track_list_record_success, Toast.LENGTH_SHORT)
+                        .show();
+                finish();
+            }
+        }
+    };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        command = getIntent().getIntExtra(EXTRA_COMMAND, COMMAND_NOTHING);
+        if (command == COMMAND_NOTHING) {
+            finish();
+        }
+
+        leftButton = findViewById(R.id.start_end_left_button);
+        rightButton = findViewById(R.id.start_end_right_button);
+
+        leftText = findViewById(R.id.start_end_left_text);
+        rightText = findViewById(R.id.start_end_right_text);
+
+        trackSumUpContainer = findViewById(R.id.start_end_track_sum_up);
+        textArrowContainer = findViewById(R.id.start_end_text_arrow);
+
+        distanceValue = findViewById(R.id.start_end_distance_value);
+        distanceUnit = findViewById(R.id.start_end_distance_unit);
+
+        movingTimeValue = findViewById(R.id.start_end_moving_time_value);
+
+        if (command == COMMAND_START)  {
+            updateStartUi();
+
+        } else {
+            updateResumeFinishUi();
+        }
+
+        trackRecordingServiceConnection = new TrackRecordingServiceConnection(this, bindChangedCallback);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        trackRecordingServiceConnection.startConnection(this);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        trackRecordingServiceConnection.unbind(this);
+    }
+
+    @Override
+    protected int getLayoutResId() {
+        return R.layout.track_start_end;
+    }
+
+    private void startRecording() {
+        trackRecordingServiceConnection.startAndBind(this);
+
+        /*
+         * If the binding has happened, then invoke the callback to start a new recording.
+         * If the binding hasn't happened, then invoking the callback will have no effect.
+         * But when the binding occurs, the callback will get invoked.
+         */
+        bindChangedCallback.run();
+    }
+
+    private void updateStartUi() {
+        setTitle(getString(R.string.generic_start));
+
+        trackSumUpContainer.setVisibility(View.GONE);
+        textArrowContainer.setVisibility(View.VISIBLE);
+
+        leftText.setText(getString(R.string.generic_start));
+        leftButton.setVisibility(View.VISIBLE);
+        leftText.setVisibility(View.VISIBLE);
+
+        rightButton.setVisibility(View.INVISIBLE);
+        rightText.setVisibility(View.INVISIBLE);
+
+        leftButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                leftButton.setClickable(false);
+                startRecording();
+            }
+        });
+    }
+
+    private void updateResumeFinishUi() {
+        long recordingTrackId = PreferencesUtils.getRecordingTrackId(TrackStartEndActivity.this);
+        ContentProviderUtils contentProviderUtils = new ContentProviderUtils(this);
+        Track track = contentProviderUtils.getTrack(recordingTrackId);
+        TripStatistics tripStatistics = track != null ? track.getTripStatistics() : null;
+
+        // Set title
+        setTitle(track != null ? track.getName() : getString(R.string.generic_finish));
+
+        // Set time
+        if (tripStatistics != null) {
+            movingTimeValue.setText(StringUtils.formatElapsedTime(tripStatistics.getMovingTime()));
+        }
+
+        // Set total distance
+        {
+            boolean metricUnits = PreferencesUtils.isMetricUnits(this);
+            double totalDistance = tripStatistics == null ? Double.NaN : tripStatistics.getTotalDistance();
+            Pair<String, String> parts = StringUtils.getDistanceParts(this, totalDistance, metricUnits);
+
+            distanceValue.setText(parts.first);
+            distanceUnit.setText(parts.second);
+        }
+
+        trackSumUpContainer.setVisibility(View.VISIBLE);
+        textArrowContainer.setVisibility(View.INVISIBLE);
+
+        leftText.setText(getString(R.string.generic_resume));
+        leftButton.setVisibility(View.VISIBLE);
+        leftText.setVisibility(View.VISIBLE);
+
+        rightText.setText(getString(R.string.generic_finish));
+        rightButton.setVisibility(View.VISIBLE);
+        rightText.setVisibility(View.VISIBLE);
+
+        leftButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                leftButton.setClickable(false);
+                trackRecordingServiceConnection.resumeTrack();
+                finish();
+            }
+        });
+
+        rightButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                rightButton.setClickable(false);
+                trackRecordingServiceConnection.stopRecording(TrackStartEndActivity.this, true);
+                finish();
+            }
+        });
+    }
+
+    @Override
+    protected TrackRecordingServiceConnection getTrackRecordingServiceConnection() {
+        return trackRecordingServiceConnection;
+    }
+
+    @Override
+    protected void onDeleted() {
+
+    }
+}

--- a/src/main/res/drawable/button_finish.xml
+++ b/src/main/res/drawable/button_finish.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_button_finish_pressed" android:state_pressed="true" />
+    <item android:drawable="@drawable/ic_button_finish" />
+</selector>

--- a/src/main/res/drawable/button_start.xml
+++ b/src/main/res/drawable/button_start.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_button_start_pressed" android:state_pressed="true" />
+    <item android:drawable="@drawable/ic_button_start" />
+</selector>

--- a/src/main/res/drawable/ic_button_finish.xml
+++ b/src/main/res/drawable/ic_button_finish.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="82dp"
+    android:height="82dp"
+    android:viewportWidth="125"
+    android:viewportHeight="125">
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#00000000"
+        android:pathData="M2.516,63.008a60.239,59.73 134.879,1 0,119.968 -1.017a60.239,59.73 134.879,1 0,-119.968 1.017z"
+        android:strokeWidth="5.03194237"
+        android:strokeAlpha="1"
+        android:strokeColor="#555555" />
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#484848"
+        android:pathData="M62.5,62.5m-50,0a50,50 0,1 1,100 0a50,50 0,1 1,-100 0"
+        android:strokeWidth="6.9172821"
+        android:strokeAlpha="1"
+        android:strokeColor="#00000000" />
+</vector>

--- a/src/main/res/drawable/ic_button_finish_pressed.xml
+++ b/src/main/res/drawable/ic_button_finish_pressed.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="82dp"
+    android:height="82dp"
+    android:viewportWidth="125"
+    android:viewportHeight="125">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M2.516,63.009a60.239,59.73 134.856,1 0,119.967 -1.017a60.239,59.73 134.856,1 0,-119.967 1.017z"
+        android:strokeWidth="5.0319"
+        android:strokeColor="#555" />
+    <path android:pathData="M62.5,62.5m-0,-50a50,50 0,1 1,-0 100a50,50 0,1 1,-0 -100">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="62.5"
+                android:endY="112.5"
+                android:startX="62.5"
+                android:startY="12.5"
+                android:type="linear">
+                <item
+                    android:color="#FF404040"
+                    android:offset="0" />
+                <item
+                    android:color="#FF555555"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/src/main/res/drawable/ic_button_start.xml
+++ b/src/main/res/drawable/ic_button_start.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="82dp"
+    android:height="82dp"
+    android:viewportWidth="125"
+    android:viewportHeight="125">
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#00000000"
+        android:pathData="M62.5,62.5m-59.984,0a59.984,59.984 0,1 1,119.968 0a59.984,59.984 0,1 1,-119.968 0"
+        android:strokeWidth="5.03185225"
+        android:strokeAlpha="1"
+        android:strokeColor="#a31a1f" />
+</vector>

--- a/src/main/res/drawable/ic_button_start_pressed.xml
+++ b/src/main/res/drawable/ic_button_start_pressed.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="82dp"
+    android:height="82dp"
+    android:viewportWidth="125"
+    android:viewportHeight="125">
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#00000000"
+        android:pathData="M62.5,62.5m-59.984,0a59.984,59.984 0,1 1,119.968 0a59.984,59.984 0,1 1,-119.968 0"
+        android:strokeWidth="5.03185225"
+        android:strokeAlpha="1"
+        android:strokeColor="#a31a1f" />
+    <path
+        android:fillAlpha="0.4"
+        android:fillColor="#414141"
+        android:pathData="M62.5,62.5m-50,0a50,50 0,1 1,100 0a50,50 0,1 1,-100 0"
+        android:strokeWidth="6.9172821"
+        android:strokeAlpha="1"
+        android:strokeColor="#00000000" />
+</vector>

--- a/src/main/res/layout/track_start_end.xml
+++ b/src/main/res/layout/track_start_end.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include layout="@layout/toolbar" />
+
+    <LinearLayout
+        android:id="@+id/start_end_track_sum_up"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <!-- Distance -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            style="@style/StatsLargeItemContainer">
+
+            <TextView
+                style="@style/StatsLargeLabel"
+                android:text="@string/stats_distance" />
+
+            <LinearLayout style="@style/StatsLargeValueContainer">
+
+                <TextView
+                    android:id="@+id/start_end_distance_value"
+                    style="@style/StatsLargeValue"
+                    android:value="@string/value_unknown" />
+
+                <TextView
+                    android:id="@+id/start_end_distance_unit"
+                    style="@style/StatsUnit" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <!-- Moving time -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            style="@style/StatsLargeItemContainer">
+
+            <TextView
+                style="@style/StatsLargeLabel"
+                android:text="@string/stats_moving_time" />
+
+            <TextView
+                android:id="@+id/start_end_moving_time_value"
+                style="@style/StatsLargeValue"
+                android:value="@string/value_unknown" />
+
+        </LinearLayout>
+
+        <!-- Horizontal line -->
+        <View style="@style/StatsHorizontalLine" />
+
+    </LinearLayout>
+
+    <RelativeLayout
+        android:id="@+id/start_end_text_arrow"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1.0">
+
+        <LinearLayout
+            android:id="@+id/start_end_list_arrow_long"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:paddingTop="16dp"
+            android:paddingBottom="12dp">
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1" />
+
+            <ImageView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="10"
+                android:contentDescription="@string/image_arrow"
+                android:src="@drawable/ic_arrow_long" />
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="17" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_above="@id/start_end_list_arrow_long">
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="5" />
+
+            <TextView
+                style="@style/TextLarge"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="22"
+                android:gravity="left"
+                android:text="Are you ready?"
+                android:textColor="@color/list_empty_text" />
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1" />
+        </LinearLayout>
+    </RelativeLayout>
+
+    <LinearLayout
+        android:id="@+id/start_end_controller_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/track_controller_background"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp">
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <FrameLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="10">
+
+            <ImageButton
+                android:id="@+id/start_end_left_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/image_stop"
+                android:src="@drawable/button_start" />
+            <TextView
+                android:id="@+id/start_end_left_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/StatsSmallLabel" />
+
+        </FrameLayout>
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="6" />
+
+        <FrameLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="10">
+
+            <ImageButton
+                android:id="@+id/start_end_right_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/image_stop"
+                android:src="@drawable/button_finish" />
+            <TextView
+                android:id="@+id/start_end_right_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/StatsSmallLabel" />
+
+        </FrameLayout>
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+    </LinearLayout>
+</LinearLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -239,6 +239,9 @@ limitations under the License.
     <string name="generic_success_title">Success</string>
     <string name="generic_tracks">Tracks</string>
     <string name="generic_yes">Yes</string>
+    <string name="generic_start">Start</string>
+    <string name="generic_finish">Finish</string>
+    <string name="generic_resume">Resume</string>
     <!-- Gps -->
     <string name="gps_location_access">&#8216;Location access&#8217;</string>
     <string name="gps_disabled">GPS not enabled. Tap here to go to %1$s. Press the back button to return.</string>


### PR DESCRIPTION
**Describe the pull request**
I've added a new Activity (TrackStartEndActivity) for the next job:
- Start service and a new track.
- Resume/Finish track so the user can continue an stopped track.

If user click on record button in TrackListActivity then TrackStartEndActivity starts with a simple layout where user can start a new track (through the service).

If user click on stop button when a track is recording then TrackStartEndActivity starts with a simple layout where user can see distance and moving time. In this scenario the user has two buttons: Resume for resume the track already stopped or Finish for finishes the track.

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/103
https://github.com/OpenTracksApp/OpenTracks/issues/11

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).