### PR TITLE
Importing creates content:// for attached pictures and exporting with…

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
@@ -74,7 +74,7 @@ public class KmlTrackWriter implements TrackWriter {
     /**
      * @param context            the context
      * @param hasMultipleTracks  should encode multiple tracks into one file?
-     * @param exportTrackDetail should detailed information about the track be exported (e.g., title, description, waypoints, timing)?
+     * @param exportTrackDetail  should detailed information about the track be exported (e.g., title, description, waypoints, timing)?
      * @param exportSensorData   should {@link SensorDataSet} be exported?
      * @param exportPhotos       should pictures be exported (if true: exports to KMZ)?
      */
@@ -192,7 +192,8 @@ public class KmlTrackWriter implements TrackWriter {
         this.startTrackPoint = startTrackPoint;
         if (printWriter != null) {
             String name = context.getString(R.string.marker_label_start, track.getName());
-            writePlacemark(name, "", "", START_STYLE, startTrackPoint.getLocation());
+            Location location = startTrackPoint != null ? startTrackPoint.getLocation() : null;
+            writePlacemark(name, "", "", START_STYLE, location);
             printWriter.println("<Placemark>");
 
             if (exportTrackDetail) {
@@ -218,7 +219,8 @@ public class KmlTrackWriter implements TrackWriter {
             if (exportTrackDetail) {
                 String name = context.getString(R.string.marker_label_end, track.getName());
                 String description = descriptionGenerator.generateTrackDescription(track, false);
-                writePlacemark(name, "", description, END_STYLE, endTrackPoint.getLocation());
+                Location location = endTrackPoint != null ? endTrackPoint.getLocation() : null;
+                writePlacemark(name, "", description, END_STYLE, location);
             }
         }
     }
@@ -345,7 +347,7 @@ public class KmlTrackWriter implements TrackWriter {
             writeCategory(category);
 
             if (exportPhotos) {
-                printWriter.println("<Icon><href>" + Uri.decode(photoUrl) + "</href></Icon>");
+                printWriter.println("<Icon><href>" + KmzTrackExporter.buildKmzImageFilePath(Uri.parse(photoUrl)) + "</href></Icon>");
             }
 
             printWriter.print("<ViewVolume>");

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
@@ -126,7 +126,7 @@ public class KmzTrackExporter implements TrackExporter {
         Uri uri = Uri.parse(photoUrl);
 
         try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
-            ZipEntry zipEntry = new ZipEntry(KMZ_IMAGES_DIR + File.separatorChar + FileUtils.sanitizeFileName(uri.getLastPathSegment()));
+            ZipEntry zipEntry = new ZipEntry(buildKmzImageFilePath(uri));
             zipOutputStream.putNextEntry(zipEntry);
 
             if (inputStream == null) throw new FileNotFoundException();
@@ -146,5 +146,14 @@ public class KmzTrackExporter implements TrackExporter {
         while ((byteCount = inputStream.read(buffer)) != -1) {
             outputStream.write(buffer, 0, byteCount);
         }
+    }
+
+    /**
+     * Builds and returns the path for the file that will be saved inside KMZ_IMAGES_DIR.
+     *
+     * @param uri URI object.
+     */
+    public static String buildKmzImageFilePath(Uri uri) {
+        return KMZ_IMAGES_DIR + File.separatorChar + FileUtils.sanitizeFileName(uri.getLastPathSegment());
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -366,15 +366,32 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
     /**
      * Gets the photo url for a file.
      *
-     * @param fileName the file name
+     * @param externalPhotoUrl the file name
      */
-    protected String getPhotoUrl(String fileName) {
+    protected String getInternalPhotoUrl(String externalPhotoUrl) {
         if (importTrackId == -1L) {
+            Log.e(TAG, "Track id is invalid.");
+            return null;
+        }
+
+        if (externalPhotoUrl == null) {
+            Log.i(TAG, "External photo url is null.");
+            return null;
+        }
+
+        Uri externalPhotoUri = Uri.parse(externalPhotoUrl);
+        if (externalPhotoUri == null) {
+            Log.w(TAG, "Could not parse external photo url.");
+            return null;
+        }
+        String filename = externalPhotoUri.getLastPathSegment();
+        if (filename == null) {
+            Log.w(TAG, "External photo contains no filename.");
             return null;
         }
 
         File dir = FileUtils.getPhotoDir(context, importTrackId);
-        File file = new File(dir, fileName);
+        File file = new File(dir, externalPhotoUrl);
 
         Uri photoUri = FileUtils.getUriForFile(context, file);
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -378,7 +378,7 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
 
         Uri photoUri = FileUtils.getUriForFile(context, file);
 
-        return photoUri.toString();
+        return "" + photoUri;
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -372,9 +372,13 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
         if (importTrackId == -1L) {
             return null;
         }
+
         File dir = FileUtils.getPhotoDir(context, importTrackId);
         File file = new File(dir, fileName);
-        return Uri.fromFile(file).toString();
+
+        Uri photoUri = FileUtils.getUriForFile(context, file);
+
+        return photoUri.toString();
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
@@ -17,7 +17,6 @@
 package de.dennisguse.opentracks.io.file.importer;
 
 import android.content.Context;
-import android.net.Uri;
 import android.util.Log;
 
 import androidx.annotation.VisibleForTesting;
@@ -187,9 +186,7 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
         }
 
         // If there is photoUrl it has to be changed because that url in kml file is a relative path to the internal kmz file.
-        if (photoUrl != null) {
-            photoUrl = getPhotoUrl(Uri.parse(photoUrl).getLastPathSegment());
-        }
+        photoUrl = getInternalPhotoUrl(photoUrl);
 
         addWaypoint();
     }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
@@ -186,9 +186,9 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
             return;
         }
 
+        // If there is photoUrl it has to be changed because that url in kml file isn't a valid content:// to the imported one.
         if (photoUrl != null) {
-            Uri uri = Uri.parse(photoUrl);
-            photoUrl = getPhotoUrl(uri.getLastPathSegment());
+            photoUrl = getPhotoUrl(Uri.parse(photoUrl).getLastPathSegment());
         }
 
         addWaypoint();

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
@@ -186,7 +186,7 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
             return;
         }
 
-        // If there is photoUrl it has to be changed because that url in kml file isn't a valid content:// to the imported one.
+        // If there is photoUrl it has to be changed because that url in kml file is a relative path to the internal kmz file.
         if (photoUrl != null) {
             photoUrl = getPhotoUrl(Uri.parse(photoUrl).getLastPathSegment());
         }


### PR DESCRIPTION
…out points bug fixed. Fixes #166 and #176.


**Describe the pull request**
"Import all" option now creates content:// for attached pictures instead of file://

Also, "Export all" option doesn't results in a null exception when a file without points is exported.

**Link to the the issue**
#166 
#176 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).