### PR TITLE
Improve import/export

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/DescriptionGeneratorTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/DescriptionGeneratorTest.java
@@ -88,6 +88,40 @@ public class DescriptionGeneratorTest {
         Assert.assertEquals(expected, descriptionGenerator.generateTrackDescription(track, true));
     }
 
+    @Test
+    public void testGenerateTrackDescriptionWithoutMaxMinElevation() {
+        Track track = new Track();
+        TrackStatistics stats = new TrackStatistics();
+        stats.setTotalDistance(20000);
+        stats.setTotalTime(600000);
+        stats.setMovingTime(300000);
+        stats.setMaxSpeed(100);
+        stats.setMaxElevation(Double.POSITIVE_INFINITY);
+        stats.setMinElevation(Double.NEGATIVE_INFINITY);
+        stats.setTotalElevationGain(6000);
+        stats.setStartTime_ms(START_TIME);
+        track.setTrackStatistics(stats);
+        track.setCategory("hiking");
+        String expected = //"Created by"
+                "<a href='https://github.com/OpenTracksApp/OpenTracks'>OpenTracks</a><p>"
+                        + "Name: -<br>"
+                        + "Activity type: hiking<br>"
+                        + "Description: -<br>"
+                        + "Total distance: 20.00 km (12.4 mi)<br>"
+                        + "Total time: 10:00<br>"
+                        + "Moving time: 05:00<br>"
+                        + "Average speed: 120.00 km/h (74.6 mi/h)<br>"
+                        + "Average moving speed: 240.00 km/h (149.1 mi/h)<br>"
+                        + "Max speed: 360.00 km/h (223.7 mi/h)<br>"
+                        + "Average pace: 0:30 min/km (0:48 min/mi)<br>"
+                        + "Average moving pace: 0:15 min/km (0:24 min/mi)<br>"
+                        + "Fastest pace: 0:10 min/km (0:16 min/mi)<br>"
+                        + "Elevation gain: 6000 m (19685 ft)<br>"
+                        + "Recorded: " + StringUtils.formatDateTime(context, START_TIME) + "<br>";
+
+        Assert.assertEquals(expected, descriptionGenerator.generateTrackDescription(track, true));
+    }
+
 
     /**
      * Tests {@link DescriptionGenerator#writeDistance(double, StringBuilder, int, String)}.

--- a/src/main/java/de/dennisguse/opentracks/content/DescriptionGenerator.java
+++ b/src/main/java/de/dennisguse/opentracks/content/DescriptionGenerator.java
@@ -126,10 +126,14 @@ public class DescriptionGenerator {
         writePace(stats.getMaxSpeed(), builder, R.string.description_fastest_pace_in_minute, lineBreak);
 
         // Max elevation
-        writeElevation(stats.getMaxElevation(), builder, R.string.description_max_elevation, lineBreak);
+        if (stats.hasElevationMax()) {
+            writeElevation(stats.getMaxElevation(), builder, R.string.description_max_elevation, lineBreak);
+        }
 
         // Min elevation
-        writeElevation(stats.getMinElevation(), builder, R.string.description_min_elevation, lineBreak);
+        if (stats.hasElevationMin()) {
+            writeElevation(stats.getMinElevation(), builder, R.string.description_min_elevation, lineBreak);
+        }
 
         // Elevation gain
         writeElevation(stats.getTotalElevationGain(), builder, R.string.description_elevation_gain, lineBreak);

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
@@ -32,6 +32,7 @@ import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.data.Waypoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 import de.dennisguse.opentracks.content.sensor.SensorDataSet;
+import de.dennisguse.opentracks.util.FileUtils;
 import de.dennisguse.opentracks.util.StringUtils;
 
 /**
@@ -162,7 +163,8 @@ public class KmlTrackWriter implements TrackWriter {
     @Override
     public void writeWaypoint(Waypoint waypoint) {
         if (printWriter != null && exportTrackDetail) {
-            if (waypoint.hasPhoto() && exportPhotos) {
+            boolean existsPhoto = FileUtils.getPhotoFileIfExists(context, waypoint.getTrackId(), waypoint.getPhotoURI()) != null;
+            if (waypoint.hasPhoto() && exportPhotos && existsPhoto) {
                 float heading = getHeading(waypoint.getTrackId(), waypoint.getLocation());
                 writePhotoOverlay(waypoint.getName(), waypoint.getCategory(), waypoint.getDescription(), waypoint.getLocation(), waypoint.getPhotoUrl(), heading);
             } else {

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
@@ -166,7 +166,7 @@ public class KmlTrackWriter implements TrackWriter {
             boolean existsPhoto = FileUtils.getPhotoFileIfExists(context, waypoint.getTrackId(), waypoint.getPhotoURI()) != null;
             if (waypoint.hasPhoto() && exportPhotos && existsPhoto) {
                 float heading = getHeading(waypoint.getTrackId(), waypoint.getLocation());
-                writePhotoOverlay(waypoint.getName(), waypoint.getCategory(), waypoint.getDescription(), waypoint.getLocation(), waypoint.getPhotoUrl(), heading);
+                writePhotoOverlay(waypoint, heading);
             } else {
                 writePlacemark(waypoint.getName(), waypoint.getCategory(), waypoint.getDescription(), WAYPOINT_STYLE, waypoint.getLocation());
             }
@@ -324,32 +324,29 @@ public class KmlTrackWriter implements TrackWriter {
     }
 
     /**
-     * Writes a photo overlay.
-     *  @param name        the name
-     * @param category    the category
-     * @param description the description
-     * @param location    the location
-     * @param photoUrl    the photo url
-     * @param heading     the heading
+     * Writes a photo overlay from waypoint.
+     *
+     * @param waypoint Waypoint object.
+     * @param heading  the heading.
      */
-    private void writePhotoOverlay(String name, String category, String description, Location location, String photoUrl, float heading) {
-        if (location != null && exportTrackDetail) {
+    private void writePhotoOverlay(Waypoint waypoint, float heading) {
+        if (waypoint.getLocation() != null && exportTrackDetail) {
             printWriter.println("<PhotoOverlay>");
-            printWriter.println("<name>" + StringUtils.formatCData(name) + "</name>");
-            printWriter.println("<description>" + StringUtils.formatCData(description) + "</description>");
+            printWriter.println("<name>" + StringUtils.formatCData(waypoint.getName()) + "</name>");
+            printWriter.println("<description>" + StringUtils.formatCData(waypoint.getDescription()) + "</description>");
             printWriter.print("<Camera>");
-            printWriter.print("<longitude>" + location.getLongitude() + "</longitude>");
-            printWriter.print("<latitude>" + location.getLatitude() + "</latitude>");
+            printWriter.print("<longitude>" + waypoint.getLocation().getLongitude() + "</longitude>");
+            printWriter.print("<latitude>" + waypoint.getLocation().getLatitude() + "</latitude>");
             printWriter.print("<altitude>20</altitude>");
             printWriter.print("<heading>" + heading + "</heading>");
             printWriter.print("<tilt>90</tilt>");
             printWriter.println("</Camera>");
-            printWriter.println("<TimeStamp><when>" + getTime(location) + "</when></TimeStamp>");
+            printWriter.println("<TimeStamp><when>" + getTime(waypoint.getLocation()) + "</when></TimeStamp>");
             printWriter.println("<styleUrl>#" + KmlTrackWriter.WAYPOINT_STYLE + "</styleUrl>");
-            writeCategory(category);
+            writeCategory(waypoint.getCategory());
 
             if (exportPhotos) {
-                printWriter.println("<Icon><href>" + KmzTrackExporter.buildKmzImageFilePath(Uri.parse(photoUrl)) + "</href></Icon>");
+                printWriter.println("<Icon><href>" + KmzTrackExporter.buildKmzImageFilePath(waypoint) + "</href></Icon>");
             }
 
             printWriter.print("<ViewVolume>");
@@ -360,7 +357,7 @@ public class KmlTrackWriter implements TrackWriter {
             printWriter.print("<topFov>45</topFov>");
             printWriter.println("</ViewVolume>");
             printWriter.println("<Point>");
-            printWriter.println("<coordinates>" + getCoordinates(location, ",") + "</coordinates>");
+            printWriter.println("<coordinates>" + getCoordinates(waypoint.getLocation(), ",") + "</coordinates>");
             printWriter.println("</Point>");
             printWriter.println("</PhotoOverlay>");
         }

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
@@ -330,7 +330,7 @@ public class KmlTrackWriter implements TrackWriter {
      * @param heading  the heading.
      */
     private void writePhotoOverlay(Waypoint waypoint, float heading) {
-        if (waypoint.getLocation() != null && exportTrackDetail) {
+        if (exportTrackDetail) {
             printWriter.println("<PhotoOverlay>");
             printWriter.println("<name>" + StringUtils.formatCData(waypoint.getName()) + "</name>");
             printWriter.println("<description>" + StringUtils.formatCData(waypoint.getDescription()) + "</description>");

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
@@ -115,7 +115,7 @@ public class KmzTrackExporter implements TrackExporter {
                             Uri uriPhoto = waypoint.getPhotoURI();
                             boolean existsPhoto = FileUtils.getPhotoFileIfExists(context, track.getId(), uriPhoto) != null;
                             if (existsPhoto) {
-                                addImage(context, zipOutputStream, uriPhoto);
+                                addImage(context, zipOutputStream, uriPhoto, waypoint);
                             }
                         }
 
@@ -126,9 +126,9 @@ public class KmzTrackExporter implements TrackExporter {
         }
     }
 
-    private void addImage(Context context, ZipOutputStream zipOutputStream, Uri uri) throws IOException {
+    private void addImage(Context context, ZipOutputStream zipOutputStream, Uri uri, Waypoint waypoint) throws IOException {
         try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
-            ZipEntry zipEntry = new ZipEntry(buildKmzImageFilePath(uri));
+            ZipEntry zipEntry = new ZipEntry(buildKmzImageFilePath(waypoint));
             zipOutputStream.putNextEntry(zipEntry);
 
             if (inputStream == null) throw new FileNotFoundException();
@@ -151,11 +151,13 @@ public class KmzTrackExporter implements TrackExporter {
     }
 
     /**
-     * Builds and returns the path for the file that will be saved inside KMZ_IMAGES_DIR.
+     * Builds and returns the path for the image that will be saved inside KMZ_IMAGES_DIR for the waypoint.
      *
-     * @param uri URI object.
+     * @param waypoint Waypoint object.
      */
-    public static String buildKmzImageFilePath(Uri uri) {
-        return KMZ_IMAGES_DIR + File.separatorChar + FileUtils.sanitizeFileName(uri.getLastPathSegment());
+    public static String buildKmzImageFilePath(Waypoint waypoint) {
+        String ext = FileUtils.getExtension(waypoint.getPhotoUrl());
+        ext = ext == null ? "" : "." + ext;
+        return KMZ_IMAGES_DIR + File.separatorChar + FileUtils.sanitizeFileName(waypoint.getId() + ext);
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
@@ -112,7 +112,11 @@ public class KmzTrackExporter implements TrackExporter {
                         }
                         Waypoint waypoint = contentProviderUtils.createWaypoint(cursor);
                         if (waypoint.hasPhoto()) {
-                            addImage(context, zipOutputStream, waypoint.getPhotoUrl());
+                            Uri uriPhoto = waypoint.getPhotoURI();
+                            boolean existsPhoto = FileUtils.getPhotoFileIfExists(context, track.getId(), uriPhoto) != null;
+                            if (existsPhoto) {
+                                addImage(context, zipOutputStream, uriPhoto);
+                            }
                         }
 
                         cursor.moveToNext();
@@ -122,9 +126,7 @@ public class KmzTrackExporter implements TrackExporter {
         }
     }
 
-    private void addImage(Context context, ZipOutputStream zipOutputStream, String photoUrl) throws IOException {
-        Uri uri = Uri.parse(photoUrl);
-
+    private void addImage(Context context, ZipOutputStream zipOutputStream, Uri uri) throws IOException {
         try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
             ZipEntry zipEntry = new ZipEntry(buildKmzImageFilePath(uri));
             zipOutputStream.putNextEntry(zipEntry);

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -383,7 +383,8 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
             return null;
         }
 
-        File file = FileUtils.getPhotoFileIfExists(context, importTrackId, Uri.parse(externalPhotoUrl));
+        String importFileName = KmzTrackImporter.importNameForFilename(externalPhotoUrl);
+        File file = FileUtils.getPhotoFileIfExists(context, importTrackId, Uri.parse(importFileName));
         if (file != null) {
             Uri photoUri = FileUtils.getUriForFile(context, file);
             return "" + photoUri;

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -313,6 +313,9 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
      */
     protected TrackPoint getTrackPoint() throws SAXException {
         TrackPoint trackPoint = createTrackPoint();
+        if (trackPoint == null) {
+            throw new SAXException(createErrorMessage("Invalid location detected: " + trackPoint));
+        }
 
         // Calculate derived attributes from the previous point
         if (trackData.lastLocationInCurrentSegment != null && trackData.lastLocationInCurrentSegment.getTime() != 0) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -393,10 +393,13 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
 
         File dir = FileUtils.getPhotoDir(context, importTrackId);
         File file = new File(dir, filename);
-
-        Uri photoUri = FileUtils.getUriForFile(context, file);
-
-        return "" + photoUri;
+        if (file.exists()) {
+            Uri photoUri = FileUtils.getUriForFile(context, file);
+            return "" + photoUri;
+        }
+        else {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -380,20 +380,8 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
             return null;
         }
 
-        Uri externalPhotoUri = Uri.parse(externalPhotoUrl);
-        if (externalPhotoUri == null) {
-            Log.w(TAG, "Could not parse external photo url.");
-            return null;
-        }
-        String filename = externalPhotoUri.getLastPathSegment();
-        if (filename == null) {
-            Log.w(TAG, "External photo contains no filename.");
-            return null;
-        }
-
-        File dir = FileUtils.getPhotoDir(context, importTrackId);
-        File file = new File(dir, filename);
-        if (file.exists()) {
+        File file = FileUtils.getPhotoFileIfExists(context, importTrackId, Uri.parse(externalPhotoUrl));
+        if (file != null) {
             Uri photoUri = FileUtils.getUriForFile(context, file);
             return "" + photoUri;
         }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportAsyncTask.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportAsyncTask.java
@@ -186,7 +186,7 @@ class ImportAsyncTask extends AsyncTask<Void, Integer, Boolean> {
                 Uri uri = contentProviderUtils.insertTrack(new Track());
                 long newId = Long.parseLong(uri.getLastPathSegment());
 
-                trackImporter = new KmzTrackImporter(importActivity, newId);
+                trackImporter = new KmzTrackImporter(importActivity, newId, file.getUri());
             }
         }
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportAsyncTask.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportAsyncTask.java
@@ -99,7 +99,7 @@ class ImportAsyncTask extends AsyncTask<Void, Integer, Boolean> {
         for (DocumentFile candidate : file.listFiles()) {
             if (!candidate.isDirectory()) {
                 String extension = FileUtils.getExtension(candidate.getName());
-                if (trackFileFormat.getExtension().equals(extension)) {
+                if (extension != null && trackFileFormat.getExtension().equals(extension)) {
                     files.add(candidate);
                 }
             } else {

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
@@ -27,6 +27,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -46,12 +47,7 @@ public class KmzTrackImporter implements TrackImporter {
 
     private static final String TAG = KmzTrackImporter.class.getSimpleName();
 
-    public static final List<String> KMZ_IMAGES_EXT = new ArrayList<>();
-    static {
-        KMZ_IMAGES_EXT.add("jpeg");
-        KMZ_IMAGES_EXT.add("jpg");
-        KMZ_IMAGES_EXT.add("png");
-    }
+    public static final List<String> KMZ_IMAGES_EXT = Arrays.asList("jpeg", "jpg", "png");
 
     private static final int BUFFER_SIZE = 4096;
 
@@ -158,10 +154,8 @@ public class KmzTrackImporter implements TrackImporter {
             return false;
         }
 
-        for (String ext : KMZ_IMAGES_EXT) {
-            if (fileExt.equals(ext)) {
-                return true;
-            }
+        if (KMZ_IMAGES_EXT.contains(fileExt)) {
+            return true;
         }
 
         return false;

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -176,6 +176,10 @@ public class TrackStatistics {
         this.maxSpeed_mps = maxSpeed;
     }
 
+    public boolean hasElevationMin() {
+        return !Double.isInfinite(getMinElevation());
+    }
+
     /**
      * Gets the minimum elevation.
      * This is calculated from the smoothed elevation, so this can actually be more than the current elevation.
@@ -191,6 +195,10 @@ public class TrackStatistics {
      */
     public void setMinElevation(double elevation) {
         elevationExtremities.setMin(elevation);
+    }
+
+    public boolean hasElevationMax() {
+        return !Double.isInfinite(getMaxElevation());
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
@@ -95,11 +95,15 @@ public class FileUtils {
 
     /**
      * Gets the extension from a file name.
-     * Returns null if there is no extension.
+     * Returns null if there is no extension or fileName is null.
      *
      * @param fileName the file name
      */
     public static String getExtension(String fileName) {
+        if (fileName == null) {
+            return null;
+        }
+
         int index = fileName.lastIndexOf('.');
         if (index == -1) {
             return null;

--- a/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
@@ -250,4 +250,34 @@ public class FileUtils {
     public static Uri getUriForFile(Context context, File file) {
         return FileProvider.getUriForFile(context, FileUtils.FILEPROVIDER, file);
     }
+
+    /**
+     * Checks that there is a file inside track photo directory whose name is the same that uri file.
+     * If there is a file inside photo directory whose name is the same that uri then returns File. Otherwise returns null.
+     *
+     * @param context the Context.
+     * @param trackId the id of the Track.
+     * @param uri     the uri to check.
+     * @return        File object or null.
+     */
+    public static File getPhotoFileIfExists(Context context, long trackId, Uri uri) {
+        if (uri == null) {
+            Log.w(TAG, "URI object is null.");
+            return null;
+        }
+
+        String filename = uri.getLastPathSegment();
+        if (filename == null) {
+            Log.w(TAG, "External photo contains no filename.");
+            return null;
+        }
+
+        File dir = FileUtils.getPhotoDir(context, trackId);
+        File file = new File(dir, filename);
+        if (!file.exists()) {
+            return null;
+        }
+
+        return file;
+    }
 }

--- a/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
@@ -95,9 +95,9 @@ public class FileUtils {
 
     /**
      * Gets the extension from a file name.
-     * Returns null if there is no extension or fileName is null.
      *
      * @param fileName the file name
+     * @return null if there is no extension or fileName is null.
      */
     public static String getExtension(String fileName) {
         if (fileName == null) {


### PR DESCRIPTION
### Describe the pull request
**For KMZ importer**
- First: It reads the images inside KMZ file and copy them to OpenTracks external storage.
- Second: It parses doc.kml that is inside KMZ file checking that href in waypoint's tag points to an existing image in OpenTracks storage. If exists it creates a marker with photo. Otherwise only the marker.

It needs to open two times KMZ file. The first one to find images and the second one to parses doc.kml inside KMZ.

**For KMZ exporter**
- It creates the waypoint with image in the doc.kml file only if this image exists inside OpenTracks external storage. Otherwise it creates the waypoint in the doc.kml file without href.
- When it generates description for kml file it adds min/max elevation only if these data are valid.
- Added tests for this last point.

**A little bug**
The method `createTrackPoint` in `AbstractFileTrackImporter` can return null. In that case a `SAXException` must be raised because that means that `org.xml.sax` couldn't parse a point in the file.

I found this bug doing test with GPX files. The App before cracked and now informs to user that there was an error parsing a file.

### Link to the the issue
#180 

### License agreement
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).