### PR TITLE
Images/folders are deleted when tracks/waypoints are deleted. This fixes #189.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
@@ -88,7 +88,7 @@ public class TestDataUtil {
      * @param location The location.
      * @return the Waypoint created.
      */
-    public static  Waypoint createWaypointWithPhoto(Context context, long trackId, Location location) {
+    public static  Waypoint createWaypointWithPhoto(Context context, long trackId, Location location) throws IOException {
         String photoUrl = "";
         try {
             File dstFile = new File(FileUtils.getImageUrl(context, trackId));
@@ -96,7 +96,7 @@ public class TestDataUtil {
             Uri photoUri = FileUtils.getUriForFile(context, dstFile);
             photoUrl = photoUri.toString();
         } catch (IOException ioe) {
-            throw new RuntimeException(ioe);
+            throw ioe;
         }
 
         return new Waypoint("Waypoint name", "Waypoint description", "Waypoint category", "", trackId, 0.0, 0, location, photoUrl);

--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
@@ -1,9 +1,15 @@
 package de.dennisguse.opentracks.content.data;
 
+import android.content.Context;
 import android.location.Location;
+import android.net.Uri;
 import android.util.Pair;
 
+import java.io.File;
+import java.io.IOException;
+
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
+import de.dennisguse.opentracks.util.FileUtils;
 
 public class TestDataUtil {
 
@@ -72,5 +78,27 @@ public class TestDataUtil {
     public static void insertTrackWithLocations(ContentProviderUtils contentProviderUtils, Track track, TrackPoint[] trackPoints) {
         contentProviderUtils.insertTrack(track);
         contentProviderUtils.bulkInsertTrackPoint(trackPoints, track.getId());
+    }
+
+    /**
+     * Creates a Waypoint with a photo.
+     *
+     * @param context  The context.
+     * @param trackId  The track id.
+     * @param location The location.
+     * @return the Waypoint created.
+     */
+    public static  Waypoint createWaypointWithPhoto(Context context, long trackId, Location location) {
+        String photoUrl = "";
+        try {
+            File dstFile = new File(FileUtils.getImageUrl(context, trackId));
+            dstFile.createNewFile();
+            Uri photoUri = FileUtils.getUriForFile(context, dstFile);
+            photoUrl = photoUri.toString();
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+
+        return new Waypoint("Waypoint name", "Waypoint description", "Waypoint category", "", trackId, 0.0, 0, location, photoUrl);
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -225,7 +226,7 @@ public class CustomContentProviderUtilsTest {
      * Tests the method {@link ContentProviderUtils#deleteAllTracks(Context)}
      */
     @Test
-    public void testDeleteAllTracks_withWaypointAndPhoto() {
+    public void testDeleteAllTracks_withWaypointAndPhoto() throws IOException {
         // Insert track, points and waypoint with photo at first.
         long trackId = System.currentTimeMillis();
         Track track = TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
@@ -298,7 +299,7 @@ public class CustomContentProviderUtilsTest {
      * Tests the method {@link ContentProviderUtils#deleteTrack(Context, long)}.
      */
     @Test
-    public void testDeleteTrack_withWaypointPhoto() {
+    public void testDeleteTrack_withWaypointPhoto() throws IOException {
         // Insert three tracks.
         long trackId = System.currentTimeMillis();
         TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
@@ -509,7 +510,7 @@ public class CustomContentProviderUtilsTest {
      * when there is only one waypoint in the track.
      */
     @Test
-    public void testDeleteWaypoint_onlyOneWayPointWithPhotoUrl() {
+    public void testDeleteWaypoint_onlyOneWayPointWithPhotoUrl() throws IOException {
         long trackId = System.currentTimeMillis();
         TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
 

--- a/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
@@ -77,17 +77,6 @@ public class CustomContentProviderUtilsTest {
         contentProviderUtils.deleteAllTracks(context);
     }
 
-    private void cleanPhotoDir(File file) {
-        if (file != null && file.exists() && file.isDirectory()) {
-            for (File child : file.listFiles()) {
-                cleanPhotoDir(child);
-            }
-            file.delete();
-        } else if (file != null && file.isFile()) {
-            file.delete();
-        }
-    }
-
     @Test
     public void testLocationIterator_noPoints() {
         testIterator(1, 0, 1, false);

--- a/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -44,6 +45,7 @@ import de.dennisguse.opentracks.content.data.TracksColumns;
 import de.dennisguse.opentracks.content.data.Waypoint;
 import de.dennisguse.opentracks.content.data.WaypointsColumns;
 import de.dennisguse.opentracks.stats.TrackStatistics;
+import de.dennisguse.opentracks.util.FileUtils;
 
 import static org.mockito.Mockito.when;
 
@@ -73,6 +75,17 @@ public class CustomContentProviderUtilsTest {
     public void setUp() {
         contentProviderUtils = new ContentProviderUtils(context);
         contentProviderUtils.deleteAllTracks(context);
+    }
+
+    private void cleanPhotoDir(File file) {
+        if (file != null && file.exists() && file.isDirectory()) {
+            for (File child : file.listFiles()) {
+                cleanPhotoDir(child);
+            }
+            file.delete();
+        } else if (file != null && file.isFile()) {
+            file.delete();
+        }
     }
 
     @Test
@@ -220,6 +233,44 @@ public class CustomContentProviderUtilsTest {
     }
 
     /**
+     * Tests the method {@link ContentProviderUtils#deleteAllTracks(Context)}
+     */
+    @Test
+    public void testDeleteAllTracks_withWaypointAndPhoto() {
+        // Insert track, points and waypoint with photo at first.
+        long trackId = System.currentTimeMillis();
+        Track track = TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
+
+        TrackPoint trackPoint = contentProviderUtils.getLastValidTrackPoint(trackId);
+        Waypoint waypoint = TestDataUtil.createWaypointWithPhoto(context, trackId, trackPoint.getLocation());
+        contentProviderUtils.insertWaypoint(waypoint);
+
+        ContentResolver contentResolver = context.getContentResolver();
+        Cursor tracksCursor = contentResolver.query(TracksColumns.CONTENT_URI, null, null, null, TracksColumns._ID);
+        Assert.assertEquals(1, tracksCursor.getCount());
+        Cursor tracksPointsCursor = contentResolver.query(TrackPointsColumns.CONTENT_URI_BY_ID, null, null, null, TrackPointsColumns._ID);
+        Assert.assertEquals(10, tracksPointsCursor.getCount());
+        Cursor waypointCursor = contentResolver.query(WaypointsColumns.CONTENT_URI, null, null, null, WaypointsColumns._ID);
+        Assert.assertEquals(1, waypointCursor.getCount());
+        // Check waypoint has photo and it's in the external storage.
+        Assert.assertTrue(waypoint.hasPhoto());
+        File dir = FileUtils.getPhotoDir(context, trackId);
+        Assert.assertTrue(dir.isDirectory());
+        Assert.assertEquals(1, dir.list().length);
+        Assert.assertTrue(dir.exists());
+        // Delete all.
+        contentProviderUtils.deleteAllTracks(context);
+        // Check whether all have been deleted.
+        tracksCursor = contentResolver.query(TracksColumns.CONTENT_URI, null, null, null, TracksColumns._ID);
+        Assert.assertEquals(0, tracksCursor.getCount());
+        tracksPointsCursor = contentResolver.query(TrackPointsColumns.CONTENT_URI_BY_ID, null, null, null, TrackPointsColumns._ID);
+        Assert.assertEquals(0, tracksPointsCursor.getCount());
+        waypointCursor = contentResolver.query(WaypointsColumns.CONTENT_URI, null, null, null, WaypointsColumns._ID);
+        Assert.assertEquals(0, waypointCursor.getCount());
+        Assert.assertFalse(dir.exists());
+    }
+
+    /**
      * Tests the method {@link ContentProviderUtils#deleteTrack(Context, long)}.
      */
     @Test
@@ -252,6 +303,56 @@ public class CustomContentProviderUtilsTest {
         Assert.assertEquals(20, tracksPointsCursor.getCount());
         waypointCursor = contentResolver.query(WaypointsColumns.CONTENT_URI, null, null, null, WaypointsColumns._ID);
         Assert.assertEquals(0, waypointCursor.getCount());
+    }
+
+    /**
+     * Tests the method {@link ContentProviderUtils#deleteTrack(Context, long)}.
+     */
+    @Test
+    public void testDeleteTrack_withWaypointPhoto() {
+        // Insert three tracks.
+        long trackId = System.currentTimeMillis();
+        TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
+        TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId + 1, 10);
+        TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId + 2, 10);
+
+        // Insert a waypoint in tracks trackId and trackId + 1.
+        TrackPoint trackPoint1 = contentProviderUtils.getLastValidTrackPoint(trackId);
+        Waypoint waypoint1 = TestDataUtil.createWaypointWithPhoto(context, trackId, trackPoint1.getLocation());
+        contentProviderUtils.insertWaypoint(waypoint1);
+        File dir1 = FileUtils.getPhotoDir(context, trackId);
+
+        TrackPoint trackPoint2 = contentProviderUtils.getLastValidTrackPoint(trackId + 1);
+        Waypoint waypoint2 = TestDataUtil.createWaypointWithPhoto(context, trackId + 1, trackPoint2.getLocation());
+        contentProviderUtils.insertWaypoint(waypoint2);
+        File dir2 = FileUtils.getPhotoDir(context, trackId + 1);
+
+        // Check.
+        ContentResolver contentResolver = context.getContentResolver();
+        Cursor tracksCursor = contentResolver.query(TracksColumns.CONTENT_URI, null, null, null, TracksColumns._ID);
+        Assert.assertEquals(3, tracksCursor.getCount());
+        Cursor tracksPointsCursor = contentResolver.query(TrackPointsColumns.CONTENT_URI_BY_ID, null, null, null, TrackPointsColumns._ID);
+        Assert.assertEquals(30, tracksPointsCursor.getCount());
+        Cursor waypointCursor = contentResolver.query(WaypointsColumns.CONTENT_URI, null, null, null, WaypointsColumns._ID);
+        Assert.assertEquals(2, waypointCursor.getCount());
+        Assert.assertTrue(waypoint1.hasPhoto());
+        Assert.assertTrue(dir1.isDirectory());
+        Assert.assertEquals(1, dir1.list().length);
+        Assert.assertTrue(dir1.exists());
+        Assert.assertTrue(dir2.isDirectory());
+        Assert.assertEquals(1, dir2.list().length);
+        Assert.assertTrue(dir2.exists());
+        // Delete one track.
+        contentProviderUtils.deleteTrack(context, trackId);
+        // Check whether all data of a track has been deleted.
+        tracksCursor = contentResolver.query(TracksColumns.CONTENT_URI, null, null, null, TracksColumns._ID);
+        Assert.assertEquals(2, tracksCursor.getCount());
+        tracksPointsCursor = contentResolver.query(TrackPointsColumns.CONTENT_URI_BY_ID, null, null, null, TrackPointsColumns._ID);
+        Assert.assertEquals(20, tracksPointsCursor.getCount());
+        waypointCursor = contentResolver.query(WaypointsColumns.CONTENT_URI, null, null, null, WaypointsColumns._ID);
+        Assert.assertEquals(1, waypointCursor.getCount());
+        Assert.assertFalse(dir1.exists());
+        Assert.assertTrue(dir2.exists());
     }
 
     /**
@@ -387,7 +488,7 @@ public class CustomContentProviderUtilsTest {
 
     /**
      * Tests the method
-     * {@link ContentProviderUtils#deleteWaypoint(long)}
+     * {@link ContentProviderUtils#deleteWaypoint(Context, long)}
      * when there is only one waypoint in the track.
      */
     @Test
@@ -401,14 +502,56 @@ public class CustomContentProviderUtilsTest {
         waypoint1.setTrackId(trackId);
         contentProviderUtils.insertWaypoint(waypoint1);
 
-        // Delete
-        contentProviderUtils.deleteWaypoint(1);
+        // Check insert was done.
+        Assert.assertEquals(contentProviderUtils.getWaypointCount(trackId), 1);
 
-        Assert.assertNull(contentProviderUtils.getWaypoint(1));
+        // Get waypoint id that needs to delete.
+        long waypoint1Id = ContentUris.parseId(contentProviderUtils.insertWaypoint(waypoint1));
+
+        // Delete
+        contentProviderUtils.deleteWaypoint(context, waypoint1Id);
+
+        Assert.assertNull(contentProviderUtils.getWaypoint(waypoint1Id));
     }
 
     /**
-     * Tests the method {@link ContentProviderUtils#deleteWaypoint(long)} when there is more than one waypoint in the track.
+     * Tests the method
+     * {@link ContentProviderUtils#deleteWaypoint(Context, long)}
+     * when there is only one waypoint in the track.
+     */
+    @Test
+    public void testDeleteWaypoint_onlyOneWayPointWithPhotoUrl() {
+        long trackId = System.currentTimeMillis();
+        TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
+
+        // Insert at first.
+        TrackPoint trackPoint = contentProviderUtils.getLastValidTrackPoint(trackId);
+        Waypoint waypoint1 = TestDataUtil.createWaypointWithPhoto(context, trackId, trackPoint.getLocation());
+        contentProviderUtils.insertWaypoint(waypoint1);
+
+        // Check insert was done.
+        Assert.assertEquals(contentProviderUtils.getWaypointCount(trackId), 1);
+
+        // Get waypoint id that needs to delete.
+        long waypoint1Id = ContentUris.parseId(contentProviderUtils.insertWaypoint(waypoint1));
+
+        // Check waypoint has photo and it's in the external storage.
+        Assert.assertTrue(waypoint1.hasPhoto());
+        File dir = FileUtils.getPhotoDir(context, trackId);
+        Assert.assertTrue(dir.isDirectory());
+        Assert.assertEquals(1, dir.list().length);
+        Assert.assertTrue(dir.exists());
+
+        // Delete
+        contentProviderUtils.deleteWaypoint(context, waypoint1Id);
+
+        // Check waypoint doesn't exists and photo folder was deleted.
+        Assert.assertNull(contentProviderUtils.getWaypoint(waypoint1Id));
+        Assert.assertFalse(dir.exists());
+    }
+
+    /**
+     * Tests the method {@link ContentProviderUtils#deleteWaypoint(Context, long)} when there is more than one waypoint in the track.
      */
     @Test
     public void testDeleteWaypoint_hasNextWayPoint() {
@@ -444,7 +587,7 @@ public class CustomContentProviderUtilsTest {
 
         // Delete
         Assert.assertNotNull(contentProviderUtils.getWaypoint(waypoint1Id));
-        contentProviderUtils.deleteWaypoint(waypoint1Id);
+        contentProviderUtils.deleteWaypoint(context, waypoint1Id);
         Assert.assertNull(contentProviderUtils.getWaypoint(waypoint1Id));
 
         Assert.assertEquals(MOCK_DESC, contentProviderUtils.getWaypoint(waypoint2Id).getDescription());

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -171,7 +171,7 @@ public class ContentProviderUtils {
         contentResolver.delete(TracksColumns.CONTENT_URI, null, null);
 
         File dir = FileUtils.getPhotoDir(context);
-        deleteDirectoryRecurse(dir);
+        FileUtils.deleteDirectoryRecurse(dir);
     }
 
     /**
@@ -183,7 +183,7 @@ public class ContentProviderUtils {
         deleteTrackPointsAndWaypoints(context, trackId);
 
         // Delete track folder resources.
-        deleteDirectoryRecurse(FileUtils.getPhotoDir(context, trackId));
+        FileUtils.deleteDirectoryRecurse(FileUtils.getPhotoDir(context, trackId));
 
         // Delete track last since it triggers a database vacuum call
         contentResolver.delete(TracksColumns.CONTENT_URI, TracksColumns._ID + "=?", new String[]{Long.toString(trackId)});
@@ -200,22 +200,6 @@ public class ContentProviderUtils {
         contentResolver.delete(TrackPointsColumns.CONTENT_URI_BY_ID, where, selectionArgs);
 
         contentResolver.delete(WaypointsColumns.CONTENT_URI, WaypointsColumns.TRACKID + "=?", new String[]{Long.toString(trackId)});
-    }
-
-    /**
-     * Delete the directory recursively.
-     *
-     * @param file the directory
-     */
-    private void deleteDirectoryRecurse(File file) {
-        if (file != null && file.exists() && file.isDirectory()) {
-            for (File child : file.listFiles()) {
-                deleteDirectoryRecurse(child);
-            }
-            file.delete();
-        } else if (file != null && file.isFile()) {
-            file.delete();
-        }
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/fragments/DeleteMarkerDialogFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/DeleteMarkerDialogFragment.java
@@ -85,7 +85,7 @@ public class DeleteMarkerDialogFragment extends DialogFragment {
                             public void run() {
                                 ContentProviderUtils contentProviderUtils = new ContentProviderUtils(fragmentActivity);
                                 for (long markerId : markerIds) {
-                                    contentProviderUtils.deleteWaypoint(markerId);
+                                    contentProviderUtils.deleteWaypoint(getContext(), markerId);
                                 }
                                 caller.onDeleteMarkerDone();
                             }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
@@ -189,7 +189,6 @@ public class KmzTrackImporter implements TrackImporter {
 
                 zipInputStream.closeEntry();
             }
-
             return trackId;
         } catch (IOException e) {
             Log.e(TAG, "Unable to import file", e);
@@ -240,16 +239,6 @@ public class KmzTrackImporter implements TrackImporter {
         if (PreferencesUtils.isRecording(trackId)) {
             ContentProviderUtils contentProviderUtils = new ContentProviderUtils(context);
             contentProviderUtils.deleteTrack(context, trackId);
-        }
-
-        if (importTrackId != -1L) {
-            File dir = FileUtils.getPhotoDir(context, importTrackId);
-            if (dir.exists() && dir.isDirectory()) {
-                for (File file : dir.listFiles()) {
-                    file.delete();
-                }
-                dir.delete();
-            }
         }
     }
 

--- a/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
@@ -284,4 +284,20 @@ public class FileUtils {
 
         return file;
     }
+
+    /**
+     * Delete the directory recursively.
+     *
+     * @param file the directory
+     */
+    public static void deleteDirectoryRecurse(File file) {
+        if (file != null && file.exists() && file.isDirectory()) {
+            for (File child : file.listFiles()) {
+                deleteDirectoryRecurse(child);
+            }
+            file.delete();
+        } else if (file != null && file.isFile()) {
+            file.delete();
+        }
+    }
 }


### PR DESCRIPTION
**Describe the pull request**
Fixes two bugs:
- When a track with waypoint's photos was deleted, the folder with these photos weren't deleted.
- When a waypoint with a photo was deleted, the photo wasn't deleted.

These two bugs resulted in waste of external storage with the remaining files photos.

Also, I've added some new tests:
- All tracks are delete (with waypoint's photo): checks that all folders with waypoint's photos from tracks deleted are deleted from external storage.
- Delete a track (with waypoint's photo): checks that track's deleted folder is deleted but not the others tracks.
- Delete waypoint (with photo): checks that the waypoint's photo is delete too.

With these tests (I hope) any change about deleting tracks/waypoints in the code guarantee that will be well done.

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/189

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).