### PR TITLE
Workaround for GPS week rollover (happening every 19.7 years).

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/util/TrackPointUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/TrackPointUtilsTest.java
@@ -1,0 +1,52 @@
+package de.dennisguse.opentracks.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import de.dennisguse.opentracks.content.data.TrackPoint;
+
+public class TrackPointUtilsTest {
+
+    @Test
+    public void fixTime_none() {
+        // given
+        long time = System.currentTimeMillis();
+        TrackPoint trackPoint = new TrackPoint();
+        trackPoint.setTime(time);
+
+        // when
+        TrackPointUtils.fixTime(trackPoint);
+
+        // then
+        Assert.assertEquals(time, trackPoint.getTime());
+    }
+
+    @Test
+    public void fixTime_0() {
+        // given
+        long time = System.currentTimeMillis();
+        TrackPoint trackPoint = new TrackPoint();
+        trackPoint.setTime(0);
+
+        // when
+        TrackPointUtils.fixTime(trackPoint);
+
+        // then
+        Assert.assertEquals(time, trackPoint.getTime(), 1000);
+    }
+
+    @Test
+    public void fixTime_gpsWeekRollover() {
+        // given
+        long time = System.currentTimeMillis();
+        TrackPoint trackPoint = new TrackPoint();
+        trackPoint.setTime(time - 1024 * UnitConversions.ONE_WEEK_MS);
+
+        // when
+        TrackPointUtils.fixTime(trackPoint);
+
+        // then
+        Assert.assertEquals(time, trackPoint.getTime());
+    }
+
+}

--- a/src/main/java/de/dennisguse/opentracks/util/TrackPointUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/TrackPointUtils.java
@@ -17,13 +17,23 @@ public class TrackPointUtils {
     }
 
     /**
-     * Ancient fix for phones that do not set the time in {@link android.location.Location}.
+     * 1. Ancient fix for phones that do not set the time in {@link android.location.Location}.
+     * 2. Fix for GPS time rollover happening every 19.7 years: https://en.wikipedia.org/wiki/GPS_Week_Number_Rollover
      */
-    //TODO Necessary?
     public static void fixTime(@NonNull TrackPoint trackPoint) {
         if (trackPoint.getTime() == 0L) {
             Log.w(TAG, "Time of provided location was 0. Using current time.");
             trackPoint.setTime(System.currentTimeMillis());
+            return;
+        }
+
+        {
+            long timeDiff = Math.abs(trackPoint.getTime() - System.currentTimeMillis());
+
+            if (timeDiff > 1023 * UnitConversions.ONE_WEEK_MS) {
+                Log.w(TAG, "GPS week rollover.");
+                trackPoint.setTime(trackPoint.getTime() + 1024 * UnitConversions.ONE_WEEK_MS);
+            }
         }
     }
 

--- a/src/main/java/de/dennisguse/opentracks/util/UnitConversions.java
+++ b/src/main/java/de/dennisguse/opentracks/util/UnitConversions.java
@@ -29,6 +29,9 @@ public class UnitConversions {
     // 1 second in milliseconds
     public static final long ONE_SECOND_MS = UnitConversions.S_TO_MS;
     public static final long ONE_MINUTE_MS = (long) (UnitConversions.MIN_TO_S * UnitConversions.S_TO_MS);
+    public static final long ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+    public static final long ONE_DAY_MS = 24 * ONE_HOUR_MS;
+    public static final long ONE_WEEK_MS = 7 * ONE_DAY_MS;
 
     // multiplication factor to convert milliseconds to seconds
     public static final double MS_TO_S = 1d / S_TO_MS;


### PR DESCRIPTION
https://en.wikipedia.org/wiki/GPS_Week_Number_Rollover

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/155

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).