### PR TITLE
Edit marker: if user deletes photo then photo is deleted from storage too.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/MarkerEditActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/MarkerEditActivity.java
@@ -315,6 +315,6 @@ public class MarkerEditActivity extends AbstractActivity {
         waypoint.setDescription(waypointDescription.getText().toString());
         waypoint.setPhotoUrl(photoUri != null ? photoUri.toString() : null);
 
-        new ContentProviderUtils(this).updateWaypoint(waypoint);
+        new ContentProviderUtils(this).updateWaypoint(this, waypoint);
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -382,17 +382,7 @@ public class ContentProviderUtils {
 
     public void deleteWaypoint(Context context, long waypointId) {
         final Waypoint waypoint = getWaypoint(waypointId);
-        if (waypoint != null && waypoint.hasPhoto()) {
-            Uri uri = waypoint.getPhotoURI();
-            File file = FileUtils.getPhotoFileIfExists(context, waypoint.getTrackId(), uri);
-            if (file.exists()) {
-                File parent = file.getParentFile();
-                file.delete();
-                if (parent.listFiles().length == 0) {
-                    parent.delete();
-                }
-            }
-        }
+        deleteWaypointPhoto(context, waypoint);
         contentResolver.delete(WaypointsColumns.CONTENT_URI, WaypointsColumns._ID + "=?", new String[]{Long.toString(waypointId)});
     }
 
@@ -515,13 +505,37 @@ public class ContentProviderUtils {
     }
 
     /**
+     * Delete waypoint's photo if any.
+     *
+     * @param context  the context object.
+     * @param waypoint the waypoint object.
+     */
+    private void deleteWaypointPhoto(Context context, Waypoint waypoint) {
+        if (waypoint != null && waypoint.hasPhoto()) {
+            Uri uri = waypoint.getPhotoURI();
+            File file = FileUtils.getPhotoFileIfExists(context, waypoint.getTrackId(), uri);
+            if (file.exists()) {
+                File parent = file.getParentFile();
+                file.delete();
+                if (parent.listFiles().length == 0) {
+                    parent.delete();
+                }
+            }
+        }
+    }
+
+    /**
      * Updates a waypoint.
      * Returns true if successful.
      *
-     * @param waypoint the waypoint
+     * @param updatedWaypoint the waypoint with updated data.
      */
-    public boolean updateWaypoint(Waypoint waypoint) {
-        int rows = contentResolver.update(WaypointsColumns.CONTENT_URI, createContentValues(waypoint), WaypointsColumns._ID + "=?", new String[]{Long.toString(waypoint.getId())});
+    public boolean updateWaypoint(Context context, Waypoint updatedWaypoint) {
+        Waypoint savedWaypoint = getWaypoint(updatedWaypoint.getId());
+        if (!updatedWaypoint.hasPhoto()) {
+            deleteWaypointPhoto(context, savedWaypoint);
+        }
+        int rows = contentResolver.update(WaypointsColumns.CONTENT_URI, createContentValues(updatedWaypoint), WaypointsColumns._ID + "=?", new String[]{Long.toString(updatedWaypoint.getId())});
         return rows == 1;
     }
 


### PR DESCRIPTION
**Describe the pull request**
When user edits a marker and deletes the photo from marker then this photo is deleted from storage too. This Fixes #208.

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/208

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).