### PR TITLE
While track is recording user can change the name.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -461,12 +461,6 @@ public class TrackRecordingService extends Service {
                 // Update the recording track time
                 updateTrackTotalTime(track);
             }
-
-            String trackName = TrackNameUtils.getTrackName(this, trackId, track.getTrackStatistics().getStartTime_ms());
-            if (trackName != null && !trackName.equals(track.getName())) {
-                track.setName(trackName);
-                contentProviderUtils.updateTrack(track);
-            }
         }
         endRecording(true);
     }


### PR DESCRIPTION
**Describe the pull request**
When a recording starts it sets a name with started date time.

When recording ends It's not needed to set the name, only sets the name if track's name is empty or null.

Maybe all the code that sets a name in endCurrentTrack can be removed. In fact, I think is unnecessary. Anyway, if "something" between start and stop recording would set a null name then this would correct it.

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/209

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).