### PR TITLE
Settings/Help: links are clickable. Fixes #232.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/AboutActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/AboutActivity.java
@@ -2,11 +2,13 @@ package de.dennisguse.opentracks;
 
 import android.os.Bundle;
 import android.view.Menu;
+import android.view.ViewGroup;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 
 import de.dennisguse.opentracks.util.SystemUtils;
+import de.dennisguse.opentracks.util.ViewUtils;
 
 public class AboutActivity extends AbstractActivity {
 
@@ -27,6 +29,8 @@ public class AboutActivity extends AbstractActivity {
 
         TextView textURL = findViewById(R.id.about_app_url);
         textURL.setText(getString(R.string.about_url, getString(R.string.app_web_url)));
+
+        ViewUtils.makeClickableLinks((ViewGroup) findViewById(android.R.id.content));
     }
 
     protected int getLayoutResId() {

--- a/src/main/java/de/dennisguse/opentracks/HelpActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/HelpActivity.java
@@ -1,6 +1,19 @@
 package de.dennisguse.opentracks;
 
+import android.os.Bundle;
+import android.view.ViewGroup;
+
+import androidx.annotation.Nullable;
+
+import de.dennisguse.opentracks.util.ViewUtils;
+
 public class HelpActivity extends AbstractActivity {
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ViewUtils.makeClickableLinks((ViewGroup) findViewById(android.R.id.content));
+    }
 
     @Override
     protected int getLayoutResId() {

--- a/src/main/java/de/dennisguse/opentracks/util/ViewUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/ViewUtils.java
@@ -1,0 +1,30 @@
+package de.dennisguse.opentracks.util;
+
+import android.text.method.LinkMovementMethod;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+public class ViewUtils {
+
+    private ViewUtils() {
+    }
+
+    /**
+     * Traverses all childs of {@link View} recursively and makes links within {@link TextView}s clickable.
+     */
+    public static void makeClickableLinks(ViewGroup view) {
+        if (view == null) {
+            return;
+        }
+
+        for (int i = 0; i < view.getChildCount(); i++) {
+            final View child = view.getChildAt(i);
+            if (child instanceof ViewGroup) {
+                makeClickableLinks((ViewGroup) child);
+            } else if (child instanceof TextView) {
+                ((TextView) child).setMovementMethod(LinkMovementMethod.getInstance());
+            }
+        }
+    }
+}

--- a/src/main/res/layout/about.xml
+++ b/src/main/res/layout/about.xml
@@ -6,82 +6,95 @@
 
     <include layout="@layout/toolbar" />
 
-    <ImageView
-        android:id="@+id/imageView"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="239dp"
-        android:contentDescription="@string/app_name"
-        android:scaleType="fitCenter"
-        android:src="@drawable/ic_logo_color_24dp" />
+        android:layout_height="wrap_content">
 
-    <TextView
-        style="@style/TextLarge"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="@string/app_name"
-        android:textSize="24sp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="20dp">
 
-    <View style="@style/StatsHorizontalLine" />
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="match_parent"
+                android:layout_height="239dp"
+                android:contentDescription="@string/app_name"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_logo_color_24dp" />
 
-    <TextView
-        android:id="@+id/about_text_description"
-        style="@style/TextMedium"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:padding="12dp" />
+            <TextView
+                style="@style/TextLarge"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/app_name"
+                android:textSize="24sp" />
 
-    <View style="@style/StatsHorizontalLine" />
+            <View style="@style/StatsHorizontalLine" />
 
-    <TextView
-        android:id="@+id/about_text_version_name"
-        style="@style/TextSmall"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:padding="6dp" />
+            <TextView
+                android:id="@+id/about_text_description"
+                style="@style/TextMedium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="12dp" />
 
-    <TextView
-        android:id="@+id/about_text_version_code"
-        style="@style/TextSmall"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:padding="6dp" />
+            <View style="@style/StatsHorizontalLine" />
 
-    <TextView
-        android:id="@+id/about_app_url"
-        style="@style/TextSmall"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:autoLink="web"
-        android:gravity="center"
-        android:padding="6dp" />
+            <TextView
+                android:id="@+id/about_text_version_name"
+                style="@style/TextSmall"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="6dp" />
 
-    <TextView
-        style="@style/TextSmall"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:autoLink="web"
-        android:gravity="center"
-        android:padding="6dp"
-        android:text="@string/about_history" />
+            <TextView
+                android:id="@+id/about_text_version_code"
+                style="@style/TextSmall"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="6dp" />
 
-    <View style="@style/StatsHorizontalLine" />
+            <TextView
+                android:id="@+id/about_app_url"
+                style="@style/TextSmall"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:autoLink="web"
+                android:gravity="center"
+                android:padding="6dp" />
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:padding="12dp"
-        android:text="@string/about_libraries" />
+            <TextView
+                style="@style/TextSmall"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="6dp"
+                android:linksClickable="true"
+                android:text="@string/about_history" />
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:autoLink="web"
-        android:gravity="center"
-        android:text="@string/third_party_libraries" />
+            <View style="@style/StatsHorizontalLine" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="12dp"
+                android:text="@string/about_libraries" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:linksClickable="true"
+                android:text="@string/third_party_libraries" />
+
+        </LinearLayout>
+    </ScrollView>
 
 </LinearLayout>


### PR DESCRIPTION
**Describe the pull request**
Links already clickable. I've tested it in API 21 and API 29.

With android:autoLink="web" in xml layout only links like this works:
`https://github.com/OpenTracksApp/OpenTracks`

but not links like this:
`<a href="https://github.com/OpenTracksApp/OpenTracks">OpenTracks</a>`

So I've decided to use `setMovementMethod` method on `TextView` with links.

**Link to the the issue**
#232 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).