### PR TITLE
Upgrade to Android R (API 30)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "de.dennisguse.opentracks"
@@ -73,7 +73,7 @@ android {
 
 
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/src/androidTest/java/de/dennisguse/opentracks/content/provider/ShareContentProviderTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/provider/ShareContentProviderTest.java
@@ -11,7 +11,14 @@ import de.dennisguse.opentracks.io.file.TrackFileFormat;
 public class ShareContentProviderTest {
 
     @Test
-    public void testCreateandParseURI() {
+    public void testCreateandParseURI_invalid() {
+        Uri uri = Uri.parse("content://de.dennisguse.opentracks.debug.content/tracks/1");
+
+        Assert.assertArrayEquals(new long[]{}, ShareContentProvider.parseURI(uri));
+    }
+
+    @Test
+    public void testCreateandParseURI_valid() {
         long[] trackIds = {1, 3, 5};
         Pair<Uri, String> shareURIandMIME = ShareContentProvider.createURI(trackIds, "TrackName", TrackFileFormat.KML_ONLY_TRACK);
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -111,6 +111,13 @@ limitations under the License.
 
         <activity android:name=".settings.SettingsActivity" />
 
+        <activity android:name=".util.IntentUtils$ShowOnMapProxyActivity">
+            <intent-filter android:label="@string/open_track_as_file">
+                <action android:name="Intent.OpenTracks-Dashboard" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <provider
             android:name=".content.provider.ShareContentProvider"
             android:authorities="${applicationId}.content"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -111,8 +111,14 @@ limitations under the License.
 
         <activity android:name=".settings.SettingsActivity" />
 
-        <activity android:name=".util.IntentUtils$ShowOnMapProxyActivity">
-            <intent-filter android:label="@string/open_track_as_file">
+        <activity android:name=".ShowOnMapProxyActivity$KMZ">
+            <intent-filter android:label="@string/open_track_as_KMZ">
+                <action android:name="Intent.OpenTracks-Dashboard" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity android:name=".ShowOnMapProxyActivity$GPX">
+            <intent-filter android:label="@string/open_track_as_GPX">
                 <action android:name="Intent.OpenTracks-Dashboard" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -16,7 +16,14 @@ limitations under the License.
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.dennisguse.opentracks"
     android:installLocation="auto">
-    <!-- Permission to initialize services -->
+
+    <supports-screens
+        android:anyDensity="true"
+        android:largeScreens="true"
+        android:normalScreens="true"
+        android:smallScreens="true"
+        android:xlargeScreens="true" />
+
     <application
         android:name=".Startup"
         android:allowBackup="false"
@@ -128,12 +135,7 @@ limitations under the License.
             android:icon="@drawable/ic_logo_color_24dp"
             android:label="@string/recording_service" />
     </application>
-    <supports-screens
-        android:anyDensity="true"
-        android:largeScreens="true"
-        android:normalScreens="true"
-        android:smallScreens="true"
-        android:xlargeScreens="true" />
+
     <!-- Permissions to record locations -->
     <uses-feature
         android:name="android.hardware.location.gps"

--- a/src/main/java/de/dennisguse/opentracks/ShowOnMapProxyActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/ShowOnMapProxyActivity.java
@@ -1,0 +1,69 @@
+package de.dennisguse.opentracks;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Pair;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import de.dennisguse.opentracks.content.data.TrackPointsColumns;
+import de.dennisguse.opentracks.content.provider.ShareContentProvider;
+import de.dennisguse.opentracks.io.file.TrackFileFormat;
+import de.dennisguse.opentracks.util.IntentDashboardUtils;
+
+/**
+ * Used to convert IntentDashboardUtils.startDashboard-requests into {@link TrackFileFormat}.
+ */
+public abstract class ShowOnMapProxyActivity extends AppCompatActivity {
+
+    private TrackFileFormat trackFileFormat;
+
+    protected ShowOnMapProxyActivity(TrackFileFormat trackFileFormat) {
+        this.trackFileFormat = trackFileFormat;
+    }
+
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        long[] trackIds = IntentDashboardUtils.extractTrackIdsFromIntent(getIntent());
+
+        showTrackTrackfileFormat(this, trackFileFormat, trackIds);
+
+        finish();
+    }
+
+    /**
+     * Send intent to show tracks on a map (needs an another app) as KMZ.
+     *
+     * @param context  the context
+     * @param trackIds the track ids
+     */
+    private static void showTrackTrackfileFormat(Context context, TrackFileFormat trackFileFormat, long[] trackIds) {
+        if (trackIds.length == 0) {
+            return;
+        }
+
+        Intent intent = new Intent(android.content.Intent.ACTION_VIEW);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.putExtra(TrackPointsColumns.TRACKID, trackIds[0]);
+        Pair<Uri, String> uriAndMime = ShareContentProvider.createURI(trackIds, "SharingTrack", trackFileFormat);
+        intent.setDataAndType(uriAndMime.first, uriAndMime.second);
+
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+        context.startActivity(Intent.createChooser(intent, context.getString(R.string.open_track_as_trackfileformat, trackFileFormat.getExtension())));
+    }
+
+    public static class KMZ extends ShowOnMapProxyActivity {
+        public KMZ() {
+            super(TrackFileFormat.KMZ_WITH_TRACKDETAIL);
+        }
+    }
+
+    public static class GPX extends ShowOnMapProxyActivity {
+        public GPX() {
+            super(TrackFileFormat.GPX);
+        }
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -56,6 +56,7 @@ import de.dennisguse.opentracks.services.TrackRecordingServiceConnection;
 import de.dennisguse.opentracks.services.TrackRecordingServiceInterface;
 import de.dennisguse.opentracks.settings.SettingsActivity;
 import de.dennisguse.opentracks.util.ActivityUtils;
+import de.dennisguse.opentracks.util.IntentDashboardUtils;
 import de.dennisguse.opentracks.util.IntentUtils;
 import de.dennisguse.opentracks.util.ListItemUtils;
 import de.dennisguse.opentracks.util.PreferencesUtils;
@@ -477,7 +478,7 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
         Intent intent;
         switch (itemId) {
             case R.id.list_context_menu_show_on_map:
-                IntentUtils.showTrackOnMapDashboard(this, trackIds);
+                IntentDashboardUtils.startDashboard(this, trackIds);
                 return true;
             case R.id.list_context_menu_share:
                 intent = IntentUtils.newShareFileIntent(this, trackIds);

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -171,9 +171,7 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
     private final Runnable bindChangedCallback = new Runnable() {
         @Override
         public void run() {
-            /*
-             * After binding changes (e.g., becomes available), update the total time in trackController.
-             */
+            // After binding changes (e.g., becomes available), update the total time in trackController.
             runOnUiThread(() -> trackController.update(PreferencesUtils.isRecording(recordingTrackId), recordingTrackPaused));
 
             if (!startGps) {
@@ -479,7 +477,7 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
         Intent intent;
         switch (itemId) {
             case R.id.list_context_menu_show_on_map:
-                IntentUtils.showTrackOnMap(this, trackIds);
+                IntentUtils.showTrackOnMapDashboard(this, trackIds);
                 return true;
             case R.id.list_context_menu_share:
                 intent = IntentUtils.newShareFileIntent(this, trackIds);

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -39,6 +39,7 @@ import de.dennisguse.opentracks.fragments.ConfirmDeleteDialogFragment;
 import de.dennisguse.opentracks.fragments.StatisticsRecordedFragment;
 import de.dennisguse.opentracks.services.TrackRecordingServiceConnection;
 import de.dennisguse.opentracks.settings.SettingsActivity;
+import de.dennisguse.opentracks.util.IntentDashboardUtils;
 import de.dennisguse.opentracks.util.IntentUtils;
 import de.dennisguse.opentracks.util.PreferencesUtils;
 import de.dennisguse.opentracks.util.TrackIconUtils;
@@ -186,7 +187,7 @@ public class TrackRecordedActivity extends AbstractListActivity implements Choos
                 startActivity(intent);
                 return true;
             case R.id.track_detail_menu_show_on_map:
-                IntentUtils.showTrackOnMapDashboard(this, new long[]{trackId});
+                IntentDashboardUtils.startDashboard(this, trackId);
                 return true;
             case R.id.track_detail_markers:
                 intent = IntentUtils.newIntent(this, MarkerListActivity.class)

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -186,7 +186,7 @@ public class TrackRecordedActivity extends AbstractListActivity implements Choos
                 startActivity(intent);
                 return true;
             case R.id.track_detail_menu_show_on_map:
-                IntentUtils.showTrackOnMap(this, new long[]{trackId});
+                IntentUtils.showTrackOnMapDashboard(this, new long[]{trackId});
                 return true;
             case R.id.track_detail_markers:
                 intent = IntentUtils.newIntent(this, MarkerListActivity.class)

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -338,7 +338,7 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
                 startActivity(intent);
                 return true;
             case R.id.track_detail_menu_show_on_map:
-                IntentUtils.showTrackOnMap(this, new long[]{trackId});
+                IntentUtils.showTrackOnMapDashboard(this, new long[]{trackId});
                 return true;
             case R.id.track_detail_markers:
                 intent = IntentUtils.newIntent(this, MarkerListActivity.class)

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -29,6 +29,7 @@ import de.dennisguse.opentracks.fragments.StatisticsRecordingFragment;
 import de.dennisguse.opentracks.services.TrackRecordingServiceConnection;
 import de.dennisguse.opentracks.services.TrackRecordingServiceInterface;
 import de.dennisguse.opentracks.settings.SettingsActivity;
+import de.dennisguse.opentracks.util.IntentDashboardUtils;
 import de.dennisguse.opentracks.util.IntentUtils;
 import de.dennisguse.opentracks.util.PreferencesUtils;
 import de.dennisguse.opentracks.util.TrackIconUtils;
@@ -338,7 +339,7 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
                 startActivity(intent);
                 return true;
             case R.id.track_detail_menu_show_on_map:
-                IntentUtils.showTrackOnMapDashboard(this, new long[]{trackId});
+                IntentDashboardUtils.startDashboard(this, trackId);
                 return true;
             case R.id.track_detail_markers:
                 intent = IntentUtils.newIntent(this, MarkerListActivity.class)

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -910,5 +910,4 @@ public class ContentProviderUtils {
     public static String[] parseTrackIdsFromUri(Uri url) {
         return TextUtils.split(url.getLastPathSegment(), ID_SEPARATOR);
     }
-
 }

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ShareContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ShareContentProvider.java
@@ -92,7 +92,7 @@ public class ShareContentProvider extends CustomContentProvider implements ICont
 
     static long[] parseURI(Uri uri) {
         List<String> uriPaths = uri.getPathSegments();
-        if (uriPaths == null || uriPaths.size() < 2) {
+        if (uriPaths == null || uriPaths.size() < 3) {
             Log.d(TAG, "URI does not contain any trackIds.");
             return new long[]{};
         }

--- a/src/main/java/de/dennisguse/opentracks/util/IntentDashboardUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/IntentDashboardUtils.java
@@ -5,8 +5,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+
 import java.util.ArrayList;
 
+import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.content.data.TrackPointsColumns;
 import de.dennisguse.opentracks.content.data.TracksColumns;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
@@ -24,10 +27,13 @@ public class IntentDashboardUtils {
     private static final String EXTRAS_SHOULD_KEEP_SCREEN_ON = "EXTRAS_SHOULD_KEEP_SCREEN_ON";
     private static final String EXTRAS_SHOW_WHEN_LOCKED = "EXTRAS_SHOULD_KEEP_SCREEN_ON";
 
+    private static int TRACK_URI_INDEX = 0;
+    private static int TRACKPOINTS_URI_INDEX = 1;
+
     private IntentDashboardUtils() {
     }
 
-    public static boolean startDashboard(Context context, long[] trackIds) {
+    public static void startDashboard(Context context, long[] trackIds) {
         ArrayList<Uri> uris = new ArrayList<>();
         String trackIdList = ContentProviderUtils.formatIdListForUri(trackIds);
 
@@ -42,16 +48,23 @@ public class IntentDashboardUtils {
         intent.putExtra(EXTRAS_SHOW_WHEN_LOCKED, PreferencesUtils.shouldShowStatsOnLockscreen(context));
 
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        ClipData clipData = ClipData.newRawUri(null, uris.get(0));
-        clipData.addItem(new ClipData.Item(uris.get(1)));
+        ClipData clipData = ClipData.newRawUri(null, uris.get(TRACK_URI_INDEX));
+        clipData.addItem(new ClipData.Item(uris.get(TRACKPOINTS_URI_INDEX)));
         intent.setClipData(clipData);
 
-        if (intent.resolveActivity(context.getPackageManager()) != null) {
-            context.startActivity(Intent.createChooser(intent, null));
-            return true;
-        }
-
-        return false;
+        context.startActivity(Intent.createChooser(intent, context.getString(R.string.open_track_using_dashboard)));
     }
 
+    public static long[] extractTrackIdsFromIntent(@NonNull Intent intent) {
+        final ArrayList<Uri> uris = intent.getParcelableArrayListExtra(ACTION_DASHBOARD_PAYLOAD);
+        final Uri tracksUri = uris.get(TRACK_URI_INDEX);
+
+        String[] trackIdsString = ContentProviderUtils.parseTrackIdsFromUri(tracksUri);
+        long[] trackIds = new long[trackIdsString.length];
+        for (int i = 0; i < trackIdsString.length; i++) {
+            trackIds[i] = Long.parseLong(trackIdsString[i]);
+        }
+
+        return trackIds;
+    }
 }

--- a/src/main/java/de/dennisguse/opentracks/util/IntentDashboardUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/IntentDashboardUtils.java
@@ -9,7 +9,6 @@ import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
 
-import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.content.data.TrackPointsColumns;
 import de.dennisguse.opentracks.content.data.TracksColumns;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
@@ -33,7 +32,17 @@ public class IntentDashboardUtils {
     private IntentDashboardUtils() {
     }
 
+    /**
+     * Send intent to show tracks on a map (needs an another app) as resource URIs.
+     *
+     * @param context  the context
+     * @param trackIds the track ids
+     */
     public static void startDashboard(Context context, long[] trackIds) {
+        if (trackIds.length == 0) {
+            return;
+        }
+
         ArrayList<Uri> uris = new ArrayList<>();
         String trackIdList = ContentProviderUtils.formatIdListForUri(trackIds);
 
@@ -52,7 +61,11 @@ public class IntentDashboardUtils {
         clipData.addItem(new ClipData.Item(uris.get(TRACKPOINTS_URI_INDEX)));
         intent.setClipData(clipData);
 
-        context.startActivity(Intent.createChooser(intent, context.getString(R.string.open_track_using_dashboard)));
+        context.startActivity(intent);
+    }
+
+    public static void startDashboard(Context context, long trackId) {
+        startDashboard(context, new long[]{trackId});
     }
 
     public static long[] extractTrackIdsFromIntent(@NonNull Intent intent) {

--- a/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
@@ -19,12 +19,10 @@ package de.dennisguse.opentracks.util;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Bundle;
 import android.provider.MediaStore;
 import android.util.Log;
 import android.util.Pair;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.FileProvider;
 
 import java.io.File;
@@ -35,11 +33,9 @@ import java.util.Date;
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.content.DescriptionGenerator;
 import de.dennisguse.opentracks.content.data.Track;
-import de.dennisguse.opentracks.content.data.TrackPointsColumns;
 import de.dennisguse.opentracks.content.data.Waypoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 import de.dennisguse.opentracks.content.provider.ShareContentProvider;
-import de.dennisguse.opentracks.io.file.TrackFileFormat;
 
 /**
  * Utilities for creating intents.
@@ -51,8 +47,6 @@ public class IntentUtils {
     private static final String TAG = IntentUtils.class.getSimpleName();
 
     private static final String JPEG_EXTENSION = "jpeg";
-
-    private static final TrackFileFormat SHOWONMAP_TRACKFILEFORMAT = TrackFileFormat.KMZ_WITH_TRACKDETAIL;
 
     private IntentUtils() {
     }
@@ -160,41 +154,6 @@ public class IntentUtils {
     }
 
 
-    /**
-     * Send intent to show tracks on a map (needs an another app) as resource URIs.
-     *
-     * @param context  the context
-     * @param trackIds the track ids
-     */
-    public static void showTrackOnMapDashboard(Context context, long[] trackIds) {
-        if (trackIds.length == 0) {
-            return;
-        }
-
-        IntentDashboardUtils.startDashboard(context, trackIds);
-    }
-
-    /**
-     * Send intent to show tracks on a map (needs an another app) as KMZ.
-     *
-     * @param context  the context
-     * @param trackIds the track ids
-     */
-    public static void showTrackOnMapKMZ(Context context, long[] trackIds) {
-        if (trackIds.length == 0) {
-            return;
-        }
-
-        Intent intent = new Intent(android.content.Intent.ACTION_VIEW);
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        intent.putExtra(TrackPointsColumns.TRACKID, trackIds[0]);
-        Pair<Uri, String> uriAndMime = ShareContentProvider.createURI(trackIds, "SharingTrack", SHOWONMAP_TRACKFILEFORMAT);
-        intent.setDataAndType(uriAndMime.first, uriAndMime.second);
-
-        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
-        context.startActivity(Intent.createChooser(intent, context.getString(R.string.open_track_as_trackfileformat, SHOWONMAP_TRACKFILEFORMAT.getExtension())));
-    }
 
     /**
      * Sends a take picture request to the camera app.
@@ -214,20 +173,5 @@ public class IntentUtils {
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE)
                 .putExtra(MediaStore.EXTRA_OUTPUT, photoUri);
         return new Pair<>(intent, photoUri);
-    }
-
-    /**
-     * Used to convert showTrackOnMapDashboard-requests to showTrackOnMapKMZ.
-     */
-    public static class ShowOnMapProxyActivity extends AppCompatActivity {
-
-        protected void onCreate(final Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            long[] trackIds = IntentDashboardUtils.extractTrackIdsFromIntent(getIntent());
-
-            showTrackOnMapKMZ(this, trackIds);
-
-            finish();
-        }
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -95,6 +95,10 @@ limitations under the License.
         g) do whatever you think helps OpenTracks.
     </string>
 
+    <string name="open_track_using_dashboard">Open using OpenTracks-Dashboard</string>
+    <string name="open_track_as_file">Open as file</string>
+    <string name="open_track_as_trackfileformat">Open as %1$s</string>
+
     <!-- Activity Type -->
     <string name="activity_type_airplane">airplane</string>
     <string name="activity_type_atv">ATV</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -96,7 +96,8 @@ limitations under the License.
     </string>
 
     <string name="open_track_using_dashboard">Open using OpenTracks-Dashboard</string>
-    <string name="open_track_as_file">Open as file</string>
+    <string name="open_track_as_KMZ">Open as KMZ</string>
+    <string name="open_track_as_GPX">Open as GPX</string>
     <string name="open_track_as_trackfileformat">Open as %1$s</string>
 
     <!-- Activity Type -->


### PR DESCRIPTION
As of Android R querying for installed applications is limited (I love this change).
However, we used this functionality for _show on map_.

So far, we check if OSMDashboard is installed (implicit intent) using this feature and if it was not installed, we were falling back to KMZ.

I changed this, so that we OpenTracks provides a "Open as KMZ" activity that takes the provided DashboardAPI URIs to actual KMZ URIs that are hosted by the ShareContentProvider.
When this activity is selected in the IntentChooser for the DashboardAPI, it creates a new IntentChooser for KMZ.

Works like charm in the emulator and on Android 9.

Nitpick: whenever you want to open OSMDashboard now always a IntentChooser is presented.
