### PR TITLE
Import/Export speed in GPX and KML files.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
@@ -65,6 +65,7 @@ public class TestDataUtil {
         trackPoint.setAccuracy((float) i / 100.0f);
         trackPoint.setAltitude(i * ALTITUDE_INTERVAL);
         trackPoint.setTime(i + 1);
+        trackPoint.setSpeed(5f + (i / 10));
 
         trackPoint.setHeartRate_bpm(100f + i);
         trackPoint.setCyclingCadence_rpm(200f + i);

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertNotNull;
  * Export a track to {@link TrackFileFormat} and verify that the import is identical.
  * <p>
  * TODO: test ignores {@link TrackStatistics} for now.
- * TODO: enable verify speed.
  */
 @RunWith(JUnit4.class)
 public class ExportImportTest {
@@ -130,7 +129,7 @@ public class ExportImportTest {
         assertWaypoints();
 
         // 3. trackpoints
-        assertTrackpoints(true, false, false, false);
+        assertTrackpoints(false, false, false);
     }
 
     @LargeTest
@@ -165,7 +164,7 @@ public class ExportImportTest {
         assertWaypoints();
 
         // 3. trackpoints
-        assertTrackpoints(true, true, true, true);
+        assertTrackpoints(true, true, true);
     }
 
     @LargeTest
@@ -230,7 +229,7 @@ public class ExportImportTest {
         assertWaypoints();
 
         // 3. trackpoints
-        assertTrackpoints(true, false, false, false);
+        assertTrackpoints(false, false, false);
     }
 
     private void assertWaypoints() {
@@ -252,7 +251,7 @@ public class ExportImportTest {
         }
     }
 
-    private void assertTrackpoints(boolean verifySpeed, boolean verifyPower, boolean verifyHeartrate, boolean verifyCadence) {
+    private void assertTrackpoints(boolean verifyPower, boolean verifyHeartrate, boolean verifyCadence) {
         List<TrackPoint> importedTrackPoints = contentProviderUtils.getTrackPoints(importTrackId);
         assertEquals(trackPoints.size(), importedTrackPoints.size());
 
@@ -268,9 +267,7 @@ public class ExportImportTest {
             assertEquals(trackPoint.getLatitude(), importedTrackPoint.getLatitude(), 0.001);
             assertEquals(trackPoint.getLongitude(), importedTrackPoint.getLongitude(), 0.001);
             assertEquals(trackPoint.getAltitude(), importedTrackPoint.getAltitude(), 0.001);
-            if (verifySpeed) {
-                assertEquals(trackPoint.getSpeed(), importedTrackPoint.getSpeed(), 0.001);
-            }
+            assertEquals(trackPoint.getSpeed(), importedTrackPoint.getSpeed(), 0.001);
             if (verifyHeartrate) {
                 assertEquals(trackPoint.getHeartRate_bpm(), importedTrackPoint.getHeartRate_bpm(), 0.01);
             }

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -130,7 +130,7 @@ public class ExportImportTest {
         assertWaypoints();
 
         // 3. trackpoints
-        assertTrackpoints(false, false, false, false);
+        assertTrackpoints(true, false, false, false);
     }
 
     @LargeTest
@@ -165,7 +165,7 @@ public class ExportImportTest {
         assertWaypoints();
 
         // 3. trackpoints
-        assertTrackpoints(false, true, true, true);
+        assertTrackpoints(true, true, true, true);
     }
 
     @LargeTest
@@ -230,8 +230,7 @@ public class ExportImportTest {
         assertWaypoints();
 
         // 3. trackpoints
-        //TODO Verify speed
-        assertTrackpoints(false, false, false, false);
+        assertTrackpoints(true, false, false, false);
     }
 
     private void assertWaypoints() {
@@ -270,7 +269,7 @@ public class ExportImportTest {
             assertEquals(trackPoint.getLongitude(), importedTrackPoint.getLongitude(), 0.001);
             assertEquals(trackPoint.getAltitude(), importedTrackPoint.getAltitude(), 0.001);
             if (verifySpeed) {
-                assertEquals(trackPoint.getSpeed(), importedTrackPoint.getSpeed(), 0.01);
+                assertEquals(trackPoint.getSpeed(), importedTrackPoint.getSpeed(), 0.001);
             }
             if (verifyHeartrate) {
                 assertEquals(trackPoint.getHeartRate_bpm(), importedTrackPoint.getHeartRate_bpm(), 0.01);

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GpxTrackWriter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GpxTrackWriter.java
@@ -176,6 +176,7 @@ public class GpxTrackWriter implements TrackWriter {
             }
             printWriter.println(
                     "<time>" + StringUtils.formatDateTimeIso8601(trackPoint.getTime()) + "</time>");
+            printWriter.println("<speed>" + trackPoint.getSpeed() + "</speed>");
             printWriter.println("</trkpt>");
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
@@ -39,6 +39,7 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
     private static final String TAG_GPX = "gpx";
     private static final String TAG_NAME = "name";
     private static final String TAG_TIME = "time";
+    private static final String TAG_SPEED = "speed";
     private static final String TAG_TRACK = "trk";
     private static final String TAG_TRACK_POINT = "trkpt";
     private static final String TAG_TRACK_SEGMENT = "trkseg";
@@ -115,6 +116,11 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
                     time = content.trim();
                 }
                 break;
+            case TAG_SPEED:
+                if (content != null) {
+                    speed = content.trim();
+                }
+                break;
             case TAG_ELEVATION:
                 if (content != null) {
                     altitude = content.trim();
@@ -149,6 +155,7 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
         longitude = attributes.getValue(ATTRIBUTE_LON);
         altitude = null;
         time = null;
+        speed = null;
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
@@ -292,6 +292,7 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
         switch (extendedDataType) {
             case KmlTrackWriter.EXTENDED_DATA_TYPE_SPEED:
                 speedList.add(value);
+                break;
             case KmlTrackWriter.EXTENDED_DATA_TYPE_POWER:
                 powerList.add(value);
                 break;

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
@@ -61,8 +61,9 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
     private static final String ATTRIBUTE_NAME = "name";
 
     private boolean trackStarted = false;
-    private String sensorType;
+    private String extendedDataType;
     private ArrayList<TrackPoint> trackPoints;
+    private ArrayList<Float> speedList;
     private ArrayList<Float> cadenceList;
     private ArrayList<Float> heartRateList;
     private ArrayList<Float> powerList;
@@ -102,7 +103,7 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
                 onTrackSegmentStart();
                 break;
             case TAG_GX_SIMPLE_ARRAY_DATA:
-                onSensorDataStart(attributes);
+                onExtendedDataStart(attributes);
                 break;
         }
     }
@@ -124,7 +125,7 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
         } else if (tag.equals(TAG_GX_COORD)) {
             onTrackPointEnd();
         } else if (tag.equals(TAG_GX_VALUE)) {
-            onSensorValueEnd();
+            onExtendedDataValueEnd();
         } else if (tag.equals(TAG_NAME)) {
             if (content != null) {
                 name = content.trim();
@@ -209,6 +210,7 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
     protected void onTrackSegmentStart() {
         super.onTrackSegmentStart();
         trackPoints = new ArrayList<>();
+        speedList = new ArrayList<>();
         heartRateList = new ArrayList<>();
         cadenceList = new ArrayList<>();
         powerList = new ArrayList<>();
@@ -222,6 +224,9 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
         for (int i = 0; i < trackPoints.size(); i++) {
             TrackPoint trackPoint = trackPoints.get(i);
 
+            if (i < speedList.size()) {
+                trackPoint.setSpeed(speedList.get(i));
+            }
             if (i < heartRateList.size()) {
                 trackPoint.setHeartRate_bpm(heartRateList.get(i));
             }
@@ -261,16 +266,16 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
     }
 
     /**
-     * On sensor data start. gx:SimpleArrayData start tag.
+     * On extended data start. gx:SimpleArrayData start tag.
      */
-    private void onSensorDataStart(Attributes attributes) {
-        sensorType = attributes.getValue(ATTRIBUTE_NAME);
+    private void onExtendedDataStart(Attributes attributes) {
+        extendedDataType = attributes.getValue(ATTRIBUTE_NAME);
     }
 
     /**
-     * On sensor value end. gx:value end tag.
+     * On extended data value end. gx:value end tag.
      */
-    private void onSensorValueEnd() throws SAXException {
+    private void onExtendedDataValueEnd() throws SAXException {
         if (content == null) {
             return;
         }
@@ -284,18 +289,20 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
         } catch (NumberFormatException e) {
             throw new SAXException(createErrorMessage("Unable to parse gx:value:" + content), e);
         }
-        switch (sensorType) {
-            case KmlTrackWriter.SENSOR_TYPE_POWER:
+        switch (extendedDataType) {
+            case KmlTrackWriter.EXTENDED_DATA_TYPE_SPEED:
+                speedList.add(value);
+            case KmlTrackWriter.EXTENDED_DATA_TYPE_POWER:
                 powerList.add(value);
                 break;
-            case KmlTrackWriter.SENSOR_TYPE_HEART_RATE:
+            case KmlTrackWriter.EXTENDED_DATA_TYPE_HEART_RATE:
                 heartRateList.add(value);
                 break;
-            case KmlTrackWriter.SENSOR_TYPE_CADENCE:
+            case KmlTrackWriter.EXTENDED_DATA_TYPE_CADENCE:
                 cadenceList.add(value);
                 break;
             default:
-                Log.w(TAG, "Data from sensor " + sensorType + " is not (yet) supported.");
+                Log.w(TAG, "Data from extended data " + extendedDataType + " is not (yet) supported.");
         }
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -193,6 +193,7 @@ limitations under the License.
     <string name="description_pace_imperial">Pace (min/mi)</string>
     <string name="description_pace_metric">Pace (min/km)</string>
     <string name="description_recorded_time">Recorded: %1$s</string>
+    <string name="description_speed_ms">Speed (m/s)</string>
     <string name="description_sensor_cadence">Cadence (rpm)</string>
     <string name="description_sensor_heart_rate">Heart rate (bpm)</string>
     <string name="description_sensor_power">Power (W)</string>


### PR DESCRIPTION
**Describe the pull request**
Adds speed into GPX and KML files when exporting.

When importing a GPX/KML file with speed all #275 issues are fixed but the total time. Total time in export/import process seem be always less than real total time. That's because of #192.

These data are the same when you export and import:
- Distance.
- Moving time.
- Max. Speed.
- Avg. Speed.

The only thing is not fixed is the total time.

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/300

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).