### PR TITLE
ignore invalid waypoints when importing tracks

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -289,7 +289,8 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
         TrackPoint trackPoint = createTrackPoint();
 
         if (!LocationUtils.isValidLocation(trackPoint.getLocation())) {
-            throw new SAXException(createErrorMessage("Invalid location detected: " + trackPoint));
+            Log.w(TAG, "Invalid location skipped: " + trackPoint);
+            return;
         }
         Waypoint waypoint = new Waypoint(trackPoint.getLocation());
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportAsyncTask.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportAsyncTask.java
@@ -168,6 +168,7 @@ class ImportAsyncTask extends AsyncTask<Void, Integer, Boolean> {
             }
         }
 
+        Log.d(TAG, "Importing file: " + file.getName());
         try (InputStream inputStream = importActivity.getContentResolver().openInputStream(file.getUri())) {
             lastSuccessfulTrackId = trackImporter.importFile(inputStream);
             return lastSuccessfulTrackId != -1L;

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
@@ -178,7 +178,7 @@ public class KmzTrackImporter implements TrackImporter {
                 if (KmzTrackExporter.KMZ_KML_FILE.equals(fileName)) {
                     trackId = parseKml(zipInputStream);
                     if (trackId == -1L) {
-                        Log.d(TAG, "Unable to parse kml in kmz");
+                        Log.d(TAG, "Unable to parse kml in kmz: " + fileName);
                         return -1L;
                     }
                 }


### PR DESCRIPTION
I got a new phone and tried to transfer all tracks from the old phone to the new phone via `Export all` and `Import all` function.
But from 90 tracks I could only import 29.

After some debugging I found out that one track is completely discarded if one of the TrackPoints is invalid. But the Tracks were exported by OpenTracks itself. I searched a little bit more and found that most often the start TrackPoint had coordinates 180.0 and 100.0, which is considered invalid. I changed the code to "just" skip those invalid TrackPoints and was able to import all 90 tracks.

