### PR TITLE
Added vector variant of pushpin marker

### DIFF
--- a/drawable-svg/ic_marker_blue_pushpin.svg
+++ b/drawable-svg/ic_marker_blue_pushpin.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="KMLbluepushpin.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 210 297"
+   height="297mm"
+   width="210mm">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient871"
+       inkscape:collect="always">
+      <stop
+         id="stop867"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop869"
+         offset="1"
+         style="stop-color:#898d8d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="rotate(22.027833,208.46275,168.26892)"
+       gradientUnits="userSpaceOnUse"
+       y2="266.72339"
+       x2="95.902588"
+       y1="266.48581"
+       x1="91.712517"
+       id="linearGradient873"
+       xlink:href="#linearGradient871"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="1080"
+     inkscape:window-x="0"
+     inkscape:window-height="1012"
+     inkscape:window-width="1920"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="703.42945"
+     inkscape:cx="-19.199416"
+     inkscape:zoom="0.35"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Ebene 1">
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path865"
+       d="M 70.603317,174.30832 33.024148,288.94657 94.566672,183.19473 Z"
+       style="fill:url(#linearGradient873);fill-opacity:1;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.265501" />
+    <ellipse
+       transform="rotate(22.027833)"
+       style="fill:#0299cc;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="ellipse26"
+       ry="39.974442"
+       rx="70.318817"
+       cy="113.06232"
+       cx="144.42586" />
+    <ellipse
+       transform="rotate(22.027833)"
+       cx="145.017"
+       cy="105.23625"
+       rx="70.318817"
+       ry="39.974442"
+       id="ellipse30"
+       style="fill:#33b4e2;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583" />
+    <path
+       d="m 85.662408,24.322061 c -0.890996,8.350369 2.928035,17.133472 6.825491,25.923906 l -23.333902,57.672763 -0.730686,1.80598 0.248621,0.10059 a 42.43035,17.360788 22.027833 0 0 33.303948,30.10067 42.43035,17.360788 22.027833 0 0 44.86507,1.52585 l 0.13892,0.0562 0.24519,-0.60599 a 42.43035,17.360788 22.027833 0 0 0.59472,-1.15581 42.43035,17.360788 22.027833 0 0 0.37668,-1.24514 l 22.45185,-55.492655 c 9.28986,-2.66566 20.09069,-6.13552 24.76397,-13.17485 z"
+       style="fill:#0098cc;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="rect28" />
+    <ellipse
+       transform="rotate(22.027833)"
+       cx="148.14029"
+       cy="-10.262156"
+       rx="59.409279"
+       ry="23.966745"
+       id="path24"
+       style="fill:#30a9d5;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583" />
+  </g>
+</svg>


### PR DESCRIPTION
# Thanks for your contribution.

**Describe the pull request**
I created a vector variant of the file ic_marker_blue_pushpin.png and put it into /drawable-svg/ because @dennisguse asked for it :)

**Link to the the issue**
This commit might be a first step to solve #115 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
The graphic itself is manually vectorised, that means I drew it by myself but I used the png graphic as a template. Depending on the jurisdiction I have no right to grant any right; or I do have it; or this isn't even a "work" (but a "copy"). So from my point of view I don't claim any © on this graphic do with whatever you think is right and legal.