### PR TITLE
Preferred rate is used for aggregated stats

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/AggregatedStatisticsActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/AggregatedStatisticsActivity.java
@@ -23,15 +23,12 @@ public class AggregatedStatisticsActivity extends AbstractActivity {
         listView.setEmptyView(findViewById(R.id.aggregated_stats_empty_view));
 
         final AggregatedStatisticsModel viewModel = new ViewModelProvider(this).get(AggregatedStatisticsModel.class);
-        viewModel.getAggregatedStats().observe(this, new Observer<AggregatedStatistics>() {
-            @Override
-            public void onChanged(AggregatedStatistics aggregatedStatistics) {
-                if (aggregatedStatistics != null) {
-                    adapter = new AggregatedStatisticsAdapter(getApplicationContext(), aggregatedStatistics);
-                    listView.setAdapter(adapter);
-                }
-                adapter.notifyDataSetChanged();
+        viewModel.getAggregatedStats().observe(this, aggregatedStatistics -> {
+            if (aggregatedStatistics != null) {
+                adapter = new AggregatedStatisticsAdapter(getApplicationContext(), aggregatedStatistics);
+                listView.setAdapter(adapter);
             }
+            adapter.notifyDataSetChanged();
         });
     }
 

--- a/src/main/java/de/dennisguse/opentracks/adapters/AggregatedStatisticsAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/adapters/AggregatedStatisticsAdapter.java
@@ -83,12 +83,15 @@ public class AggregatedStatisticsAdapter extends BaseAdapter {
         protected TextView distanceUnit;
         protected TextView time;
         protected boolean metricsUnits;
+        protected boolean reportSpeed;
 
         public ViewHolder() {
             metricsUnits = PreferencesUtils.isMetricUnits(context);
         }
 
         public void setValues(View view, int iconDrawable, String name, AggregatedStatistics.AggregatedStatistic aggregatedStats) {
+            reportSpeed = PreferencesUtils.isReportSpeed(context, name);
+
             sportIcon = view.findViewById(R.id.aggregated_stats_sport_icon);
             typeLabel = view.findViewById(R.id.aggregated_stats_type_label);
             numTracks = view.findViewById(R.id.aggregated_stats_num_tracks);
@@ -128,14 +131,14 @@ public class AggregatedStatisticsAdapter extends BaseAdapter {
             maxSpeedLabel = view.findViewById(R.id.aggregated_stats_max_rate_label);
 
             {
-                Pair<String, String> parts = StringUtils.getSpeedParts(context, aggregatedStats.getTrackStatistics().getAverageMovingSpeed(), metricsUnits, true);
+                Pair<String, String> parts = StringUtils.getSpeedParts(context, aggregatedStats.getTrackStatistics().getAverageMovingSpeed(), metricsUnits, reportSpeed);
                 avgSpeed.setText(parts.first);
                 avgSpeedUnit.setText(parts.second);
                 avgSpeedLabel.setText(context.getString(R.string.stats_average_moving_speed));
             }
 
             {
-                Pair<String, String> parts = StringUtils.getSpeedParts(context, aggregatedStats.getTrackStatistics().getMaxSpeed(), metricsUnits, true);
+                Pair<String, String> parts = StringUtils.getSpeedParts(context, aggregatedStats.getTrackStatistics().getMaxSpeed(), metricsUnits, reportSpeed);
                 maxSpeed.setText(parts.first);
                 maxSpeedUnit.setText(parts.second);
                 maxSpeedLabel.setText(context.getString(R.string.stats_max_speed));
@@ -164,14 +167,14 @@ public class AggregatedStatisticsAdapter extends BaseAdapter {
             maxPaceLabel = view.findViewById(R.id.aggregated_stats_max_rate_label);
 
             {
-                Pair<String, String> parts = StringUtils.getSpeedParts(context, aggregatedStats.getTrackStatistics().getAverageMovingSpeed(), metricsUnits, false);
+                Pair<String, String> parts = StringUtils.getSpeedParts(context, aggregatedStats.getTrackStatistics().getAverageMovingSpeed(), metricsUnits, reportSpeed);
                 avgPace.setText(parts.first);
                 avgPaceUnit.setText(parts.second);
                 avgPaceLabel.setText(R.string.stats_average_moving_pace);
             }
 
             {
-                Pair<String, String> parts = StringUtils.getSpeedParts(context, aggregatedStats.getTrackStatistics().getMaxSpeed(), metricsUnits, false);
+                Pair<String, String> parts = StringUtils.getSpeedParts(context, aggregatedStats.getTrackStatistics().getMaxSpeed(), metricsUnits, reportSpeed);
                 maxPace.setText(parts.first);
                 maxPaceUnit.setText(parts.second);
                 maxPaceLabel.setText(R.string.stats_fastest_pace);


### PR DESCRIPTION
**Describe the pull request**
Aggregated stats didn't use Preferred Rate from Preferences. This was not coherent. Fixed in this PR.

By the way, I've changed the observer from Anonymous class to Lambda expression.

**Link to the the issue**
#321 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).