### PR TITLE
expose waypoints to dashboard

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -64,7 +64,12 @@ limitations under the License.
             </intent-filter>
         </activity>
 
-        <activity android:name=".MarkerDetailActivity" />
+        <activity android:name=".MarkerDetailActivity">
+            <intent-filter>
+                <action android:name="de.dennisguse.opentracks.MarkerDetails"/>
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
 
         <activity android:name=".MarkerEditActivity" />
 

--- a/src/main/java/de/dennisguse/opentracks/content/data/WaypointsColumns.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/WaypointsColumns.java
@@ -30,6 +30,7 @@ public interface WaypointsColumns extends BaseColumns {
 
     String TABLE_NAME = "waypoints";
     Uri CONTENT_URI = Uri.parse(ContentProviderUtils.CONTENT_BASE_URI + "/" + TABLE_NAME);
+    Uri CONTENT_URI_BY_TRACKID = Uri.parse(ContentProviderUtils.CONTENT_BASE_URI + "/" + TABLE_NAME + "/trackid");
     String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.de.dennisguse.waypoint";
     String CONTENT_ITEMTYPE = "vnd.android.cursor.item/vnd.de.dennisguse.waypoint";
     String DEFAULT_SORT_ORDER = "_id";

--- a/src/main/java/de/dennisguse/opentracks/content/provider/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/CustomContentProvider.java
@@ -63,6 +63,7 @@ public abstract class CustomContentProvider extends ContentProvider {
 
         uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, WaypointsColumns.CONTENT_URI.getPath(), UrlType.WAYPOINTS.ordinal());
         uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, WaypointsColumns.CONTENT_URI.getPath() + "/#", UrlType.WAYPOINTS_BY_ID.ordinal());
+        uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, WaypointsColumns.CONTENT_URI_BY_TRACKID.getPath() + "/*", UrlType.WAYPOINTS_BY_TRACKID.ordinal());
     }
 
     @Override
@@ -140,6 +141,7 @@ public abstract class CustomContentProvider extends ContentProvider {
             case WAYPOINTS:
                 return WaypointsColumns.CONTENT_TYPE;
             case WAYPOINTS_BY_ID:
+            case WAYPOINTS_BY_TRACKID:
                 return WaypointsColumns.CONTENT_ITEMTYPE;
             default:
                 throw new IllegalArgumentException("Unknown URL " + url);
@@ -218,6 +220,10 @@ public abstract class CustomContentProvider extends ContentProvider {
             case WAYPOINTS_BY_ID:
                 queryBuilder.setTables(WaypointsColumns.TABLE_NAME);
                 queryBuilder.appendWhere(WaypointsColumns._ID + "=" + ContentUris.parseId(url));
+                break;
+            case WAYPOINTS_BY_TRACKID:
+                queryBuilder.setTables(WaypointsColumns.TABLE_NAME);
+                queryBuilder.appendWhere(WaypointsColumns.TRACKID + " IN (" + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
                 break;
             default:
                 throw new IllegalArgumentException("Unknown url " + url);
@@ -382,6 +388,7 @@ public abstract class CustomContentProvider extends ContentProvider {
         TRACKS,
         TRACKS_BY_ID,
         WAYPOINTS,
-        WAYPOINTS_BY_ID
+        WAYPOINTS_BY_ID,
+        WAYPOINTS_BY_TRACKID
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/util/IntentDashboardUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/IntentDashboardUtils.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 
 import de.dennisguse.opentracks.content.data.TrackPointsColumns;
 import de.dennisguse.opentracks.content.data.TracksColumns;
+import de.dennisguse.opentracks.content.data.WaypointsColumns;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 
 /**
@@ -28,6 +29,7 @@ public class IntentDashboardUtils {
 
     private static int TRACK_URI_INDEX = 0;
     private static int TRACKPOINTS_URI_INDEX = 1;
+    private static int WAYPOINTS_URI_INDEX = 2;
 
     private IntentDashboardUtils() {
     }
@@ -48,6 +50,7 @@ public class IntentDashboardUtils {
         ArrayList<Uri> uris = new ArrayList<>();
         uris.add(TRACK_URI_INDEX, Uri.withAppendedPath(TracksColumns.CONTENT_URI, trackIdList));
         uris.add(TRACKPOINTS_URI_INDEX, Uri.withAppendedPath(TrackPointsColumns.CONTENT_URI_BY_TRACKID, trackIdList));
+        uris.add(WAYPOINTS_URI_INDEX, Uri.withAppendedPath(WaypointsColumns.CONTENT_URI_BY_TRACKID, trackIdList));
 
         Intent intent = new Intent(ACTION_DASHBOARD);
         intent.putParcelableArrayListExtra(ACTION_DASHBOARD_PAYLOAD, uris);
@@ -59,6 +62,7 @@ public class IntentDashboardUtils {
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         ClipData clipData = ClipData.newRawUri(null, uris.get(TRACK_URI_INDEX));
         clipData.addItem(new ClipData.Item(uris.get(TRACKPOINTS_URI_INDEX)));
+        clipData.addItem(new ClipData.Item(uris.get(WAYPOINTS_URI_INDEX)));
         intent.setClipData(clipData);
 
         context.startActivity(intent);


### PR DESCRIPTION
Necessary for https://github.com/OpenTracksApp/OSMDashboard/issues/48

Exposes the waypoints URI for the Dashboard and makes MarkerDetailActivity callable via Intent.