### PR TITLE
TrackRecordingServiceConnection

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/util/ServiceUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/ServiceUtils.java
@@ -18,7 +18,7 @@ public class ServiceUtils {
      *
      * @param context the current context
      */
-    @Deprecated
+    @Deprecated //TODO This method must be removed as the service will nowadays always be started
     public static boolean isTrackRecordingServiceRunning(Context context) {
         ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         if (activityManager == null) {


### PR DESCRIPTION
Always start the service as we cannot check (anymore) if a service is actually running.
Actually, we can, but we should not.
I guess, it was a memory/performance optimization.

Reworking GPSStatus will remove ServiceUtils completely.