### PR TITLE
GPX: export heartrate, cadence, and speed via TrackPointExtension/v2

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/SearchEngineTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/SearchEngineTest.java
@@ -58,7 +58,6 @@ public class SearchEngineTest {
 
     private final Context context = ApplicationProvider.getApplicationContext();
 
-
     @Before
     public void setUp() {
         providerUtils = new ContentProviderUtils(context);

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -103,8 +103,7 @@ public class ExportImportTest {
         // given
         Track track = contentProviderUtils.getTrack(trackId);
 
-        TrackFileFormat trackFileFormat = TrackFileFormat.KML_WITH_TRACKDETAIL;
-        TrackExporter trackExporter = trackFileFormat.newTrackExporter(context, new Track[]{track});
+        TrackExporter trackExporter = TrackFileFormat.KML_WITH_TRACKDETAIL.newTrackExporter(context, new Track[]{track});
 
         // when
         // 1. export
@@ -138,8 +137,7 @@ public class ExportImportTest {
         // given
         Track track = contentProviderUtils.getTrack(trackId);
 
-        TrackFileFormat trackFileFormat = TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA;
-        TrackExporter trackExporter = trackFileFormat.newTrackExporter(context, new Track[]{track});
+        TrackExporter trackExporter = TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA.newTrackExporter(context, new Track[]{track});
 
         // when
         // 1. export
@@ -201,8 +199,7 @@ public class ExportImportTest {
         // given
         Track track = contentProviderUtils.getTrack(trackId);
 
-        TrackFileFormat trackFileFormat = TrackFileFormat.GPX;
-        TrackExporter trackExporter = trackFileFormat.newTrackExporter(context, new Track[]{track});
+        TrackExporter trackExporter = TrackFileFormat.GPX.newTrackExporter(context, new Track[]{track});
 
         // when
         // 1. export
@@ -229,7 +226,7 @@ public class ExportImportTest {
         assertWaypoints();
 
         // 3. trackpoints
-        assertTrackpoints(false, false, false);
+        assertTrackpoints(false, true, true);
     }
 
     private void assertWaypoints() {

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GpxTrackWriter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GpxTrackWriter.java
@@ -38,6 +38,8 @@ public class GpxTrackWriter implements TrackWriter {
 
     private static final NumberFormat ELEVATION_FORMAT = NumberFormat.getInstance(Locale.US);
     private static final NumberFormat COORDINATE_FORMAT = NumberFormat.getInstance(Locale.US);
+    private static final NumberFormat HEARTRATE_FORMAT = NumberFormat.getInstance(Locale.US);
+    private static final NumberFormat CADENCE_FORMAT = NumberFormat.getInstance(Locale.US);
 
     static {
         /*
@@ -50,6 +52,12 @@ public class GpxTrackWriter implements TrackWriter {
         COORDINATE_FORMAT.setMaximumFractionDigits(6);
         COORDINATE_FORMAT.setMaximumIntegerDigits(3);
         COORDINATE_FORMAT.setGroupingUsed(false);
+
+        HEARTRATE_FORMAT.setMaximumFractionDigits(1);
+        HEARTRATE_FORMAT.setGroupingUsed(false);
+
+        CADENCE_FORMAT.setMaximumFractionDigits(1);
+        CADENCE_FORMAT.setGroupingUsed(false);
     }
 
     private final String creator;
@@ -85,7 +93,8 @@ public class GpxTrackWriter implements TrackWriter {
             printWriter.println("xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1"
                     + " http://www.topografix.com/GPX/1/1/gpx.xsd"
                     + " http://www.topografix.com/GPX/Private/TopoGrafix/0/1"
-                    + " http://www.topografix.com/GPX/Private/TopoGrafix/0/1/topografix.xsd\">");
+                    + " http://www.topografix.com/GPX/Private/TopoGrafix/0/1/topografix.xsd\"");
+            printWriter.println("xmlns:gpxtpx=\"http://www.garmin.com/xmlschemes/TrackPointExtension/v1\">");
             printWriter.println("<metadata>");
             Track track = tracks[0];
             printWriter.println("<name>" + StringUtils.formatCData(track.getName()) + "</name>");
@@ -171,9 +180,21 @@ public class GpxTrackWriter implements TrackWriter {
     public void writeTrackPoint(TrackPoint trackPoint) {
         if (printWriter != null) {
             printWriter.println("<trkpt " + formatLocation(trackPoint.getLocation()) + ">");
-            if (trackPoint.hasAltitude()) {
-                printWriter.println("<ele>" + ELEVATION_FORMAT.format(trackPoint.getAltitude()) + "</ele>");
+            if (trackPoint.hasAltitude()) { printWriter.println("<ele>" + ELEVATION_FORMAT.format(trackPoint.getAltitude()) + "</ele>"); }
+
+            if (trackPoint.hasHeartRate() || trackPoint.hasCyclingCadence()) {
+                printWriter.println("<extensions><gpxtpx:TrackPointExtension>");
+                if (trackPoint.hasHeartRate()) {
+                    printWriter.println("<gpxtpx:hr>" + HEARTRATE_FORMAT.format(trackPoint.getHeartRate_bpm()) + "</gpxtpx:hr>");
+                }
+
+                if (trackPoint.hasCyclingCadence()) {
+                    printWriter.println("<gpxtpx:cad>" + HEARTRATE_FORMAT.format(trackPoint.getCyclingCadence_rpm()) + "</gpxtpx:cad>");
+                }
+
+                printWriter.println("</gpxtpx:TrackPointExtension></extensions>");
             }
+
             printWriter.println(
                     "<time>" + StringUtils.formatDateTimeIso8601(trackPoint.getTime()) + "</time>");
             printWriter.println("<speed>" + trackPoint.getSpeed() + "</speed>");

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -83,6 +83,9 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
     protected String altitude;
     protected String time;
     protected String speed;
+    protected String heartrate;
+    protected String cadence;
+    protected String power;
     protected String waypointType;
     protected String photoUrl;
     protected String uuid;
@@ -248,14 +251,12 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
             trackData.track.setName(name);
         }
 
-        UUID uuidParsed;
         try {
-            uuidParsed = UUID.fromString(uuid);
+            trackData.track.setUuid(UUID.fromString(uuid));
         } catch (IllegalArgumentException | NullPointerException e) {
             Log.w(TAG, "could not parse Track UUID, generating a new one.");
-            uuidParsed = UUID.randomUUID();
+            trackData.track.setUuid(UUID.randomUUID());
         }
-        trackData.track.setUuid(uuidParsed);
 
         if (description != null) {
             trackData.track.setDescription(description);
@@ -416,43 +417,54 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
         if (latitude == null || longitude == null) {
             return null;
         }
-        double latitudeValue;
-        double longitudeValue;
+
+        TrackPoint trackPoint = new TrackPoint();
+
         try {
-            latitudeValue = Double.parseDouble(latitude);
-            longitudeValue = Double.parseDouble(longitude);
+            trackPoint.setLatitude(Double.parseDouble(latitude));
+            trackPoint.setLongitude(Double.parseDouble(longitude));
         } catch (NumberFormatException e) {
             throw new SAXException(createErrorMessage(String.format(Locale.US, "Unable to parse latitude longitude: %s %s", latitude, longitude)), e);
         }
-        Double altitudeValue = null;
-        if (altitude != null) {
-            try {
-                altitudeValue = Double.parseDouble(altitude);
-            } catch (NumberFormatException e) {
-                throw new SAXException(createErrorMessage(String.format(Locale.US, "Unable to parse altitude: %s", altitude)), e);
-            }
-        }
 
-        long timeValue;
         if (time == null) {
-            timeValue = trackData.importTime;
+            trackPoint.setTime(trackData.importTime);
         } else {
             try {
-                timeValue = StringUtils.parseTime(time);
+                trackPoint.setTime(StringUtils.parseTime(time));
             } catch (Exception e) {
                 throw new SAXException(createErrorMessage(String.format(Locale.US, "Unable to parse time: %s", time)), e);
             }
         }
 
-        TrackPoint trackPoint = new TrackPoint(latitudeValue, longitudeValue, altitudeValue, timeValue);
+        if (altitude != null) {
+            try {
+                trackPoint.setAltitude(Double.parseDouble(altitude));
+            } catch (NumberFormatException e) {
+                throw new SAXException(createErrorMessage(String.format(Locale.US, "Unable to parse altitude: %s", altitude)), e);
+            }
+        }
 
-        float speedValue;
         if (speed != null) {
             try {
-                speedValue = Float.parseFloat(speed);
-                trackPoint.setSpeed(speedValue);
+                trackPoint.setSpeed(Float.parseFloat(speed));
             } catch (Exception e) {
                 throw new SAXException(createErrorMessage(String.format(Locale.US, "Unable to parse speed: %s", speed)), e);
+            }
+        }
+        if (heartrate != null) {
+            try {
+                trackPoint.setHeartRate_bpm(Float.parseFloat(heartrate));
+            } catch (Exception e) {
+                throw new SAXException(createErrorMessage(String.format(Locale.US, "Unable to parse heart rate: %s", heartrate)), e);
+            }
+        }
+
+        if (cadence != null) {
+            try {
+                trackPoint.setCyclingCadence_rpm(Float.parseFloat(cadence));
+            } catch (Exception e) {
+                throw new SAXException(createErrorMessage(String.format(Locale.US, "Unable to parse cadence: %s", cadence)), e);
             }
         }
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
@@ -40,6 +40,7 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
     private static final String TAG_NAME = "name";
     private static final String TAG_TIME = "time";
     private static final String TAG_SPEED = "speed";
+    private static final String TAG_HEARTRATE = "gpx:hr";
     private static final String TAG_TRACK = "trk";
     private static final String TAG_TRACK_POINT = "trkpt";
     private static final String TAG_TRACK_SEGMENT = "trkseg";
@@ -119,6 +120,10 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
             case TAG_SPEED:
                 if (content != null) {
                     speed = content.trim();
+                }
+            case TAG_HEARTRATE:
+                if (content != null) {
+                    heartrate = content.trim();
                 }
                 break;
             case TAG_ELEVATION:

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
@@ -28,6 +28,7 @@ import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 
 /**
  * Imports a GPX file.
+ * Uses https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd
  *
  * @author Jimmy Shih
  */
@@ -39,8 +40,6 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
     private static final String TAG_GPX = "gpx";
     private static final String TAG_NAME = "name";
     private static final String TAG_TIME = "time";
-    private static final String TAG_SPEED = "speed";
-    private static final String TAG_HEARTRATE = "gpx:hr";
     private static final String TAG_TRACK = "trk";
     private static final String TAG_TRACK_POINT = "trkpt";
     private static final String TAG_TRACK_SEGMENT = "trkseg";
@@ -49,6 +48,10 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
 
     private static final String ATTRIBUTE_LAT = "lat";
     private static final String ATTRIBUTE_LON = "lon";
+
+    private static final String TAG_EXTENSION_SPEED = "gpxtpx:speed";
+    private static final String TAG_EXTENSION_HEARTRATE = "gpxtpx:hr";
+    private static final String TAG_EXTENSION_CADENCE = "gpxtpx:cad";
 
     /**
      * Constructor.
@@ -117,15 +120,6 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
                     time = content.trim();
                 }
                 break;
-            case TAG_SPEED:
-                if (content != null) {
-                    speed = content.trim();
-                }
-            case TAG_HEARTRATE:
-                if (content != null) {
-                    heartrate = content.trim();
-                }
-                break;
             case TAG_ELEVATION:
                 if (content != null) {
                     altitude = content.trim();
@@ -134,6 +128,20 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
             case TAG_COMMENT:
                 if (content != null) {
                     waypointType = content.trim();
+                }
+                break;
+            case TAG_EXTENSION_SPEED:
+                if (content != null) {
+                    speed = content.trim();
+                }
+            case TAG_EXTENSION_HEARTRATE:
+                if (content != null) {
+                    heartrate = content.trim();
+                }
+                break;
+            case TAG_EXTENSION_CADENCE:
+                if (content != null) {
+                    cadence = content.trim();
                 }
                 break;
         }


### PR DESCRIPTION
This is a breaking change as speed exported with v3.7.6 cannot be imported.

Fixes #181.
Follow-up to #336.

@ronajon i fixed some smaller things (added missing members to AbstractFileImporter, enabled the tests, and changed speed to also use TrackPointExtension/v2.)
Well prepared :+1: 
It was just easier for to create a branch in the main repo...