### PR TITLE
Tests should not use production database

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -56,7 +56,8 @@ public class ContentProviderUtils {
     private static final int MAX_LATITUDE = 90000000;
 
     // The authority (the first part of the URI) for the app's content provider.
-    static final String AUTHORITY_PACKAGE = BuildConfig.APPLICATION_ID + ".content";
+    @VisibleForTesting
+    public static final String AUTHORITY_PACKAGE = BuildConfig.APPLICATION_ID + ".content";
 
     // The base URI for the app's content provider.
     public static final String CONTENT_BASE_URI = "content://" + AUTHORITY_PACKAGE;

--- a/src/main/java/de/dennisguse/opentracks/content/provider/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/CustomContentProvider.java
@@ -42,7 +42,7 @@ import de.dennisguse.opentracks.content.data.WaypointsColumns;
  *
  * @author Leif Hendrik Wilden
  */
-public abstract class CustomContentProvider extends ContentProvider {
+public class CustomContentProvider extends ContentProvider {
 
     private static final String TAG = CustomContentProvider.class.getSimpleName();
 

--- a/src/main/java/de/dennisguse/opentracks/content/provider/CustomSQLiteOpenHelper.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/CustomSQLiteOpenHelper.java
@@ -20,13 +20,14 @@ import de.dennisguse.opentracks.util.UUIDUtils;
  * Database helper for creating and upgrading the database.
  */
 @VisibleForTesting
-class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
+public class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
 
     private static final String TAG = CustomSQLiteOpenHelper.class.getSimpleName();
 
     private static final int DATABASE_VERSION = 26;
 
-    private static final String DATABASE_NAME = "database.db";
+    @VisibleForTesting
+    public static final String DATABASE_NAME = "database.db";
 
     public CustomSQLiteOpenHelper(Context context) {
         this(context, DATABASE_NAME);


### PR DESCRIPTION
Here is a draft for SearchEngineTest using a separate database that is deleted after each test.