### PR TITLE
Orientation change: editing marker with photo.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/MarkerEditActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/MarkerEditActivity.java
@@ -151,6 +151,7 @@ public class MarkerEditActivity extends AbstractActivity {
 
         if (savedInstanceState != null) {
             photoUri = savedInstanceState.getParcelable(BUNDLE_PHOTO_URI);
+            waypoint.setPhotoUrl(photoUri != null ? photoUri.toString() : null);
         }
         if (photoUri != null) {
             setWaypointImageView(photoUri);


### PR DESCRIPTION
**Describe the pull request**
When you are editing a marker with a photo, click on photo delete button and change the orientation the delete button is not hidden.

To reproduce:
- Click on track with a marker with photo.
- Click on track menu -> markers.
- Click on marker with photo.
- Click on menu -> edit.
- Click on delete button on photo.
- Photo and button vanish.
- Change the orientation.
- The delete button is shown but the image is hidden.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).