### PR TITLE
Bugfix: export all failed trying to convert to string the Track.Id.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/fragments/ExportProgressDialogFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/ExportProgressDialogFragment.java
@@ -209,7 +209,7 @@ public class ExportProgressDialogFragment extends DialogFragment {
             TrackExporter trackExporter = trackFileFormat.newTrackExporter(context);
 
             //TODO Move to helper function
-            String fileName = track.getId() + "." + trackFileFormat.getExtension();
+            String fileName = track.getId().getId() + "." + trackFileFormat.getExtension();
 
             // Overwrite a file if it exists; DocumentFile.createFile() creates a new file appending a suffix if the displayname already exists.
             DocumentFile file = directory.findFile(fileName);


### PR DESCRIPTION
**Describe the pull request**
OpenTracks cracked when you tried to export.

In `ExportProgressDialogFragment` Track.Id is used to create the file name:
```java
String fileName = track.getId() + "." + trackFileFormat.getExtension();
```

So here the code is trying to convert to string the Track.Id object that trigger a `RuntimeException` with "Not supported".

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).