### PR TITLE
Fixed some intervals issues.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -66,6 +66,9 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
     // Preferences
     private boolean recordingTrackPaused;
 
+    // Intervals recording fragment needs Track.Id when the activity creates it.
+    private OnTrackIdListener intervalsListener;
+
     private final Runnable bindChangedCallback = new Runnable() {
         @Override
         public void run() {
@@ -82,6 +85,9 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
                 if (trackId == null) {
                     // trackId isn't initialized -> leads a new recording.
                     trackId = service.startNewTrack();
+                    if (intervalsListener != null) {
+                        intervalsListener.onTrackId(trackId);
+                    }
                 } else {
                     // trackId is initialized -> resumes the track.
                     service.resumeTrack(trackId);
@@ -409,5 +415,13 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
                     throw new RuntimeException("There isn't Fragment associated with the position: " + position);
             }
         }
+    }
+
+    public interface OnTrackIdListener {
+        void onTrackId(Track.Id trackId);
+    }
+
+    public void setTrackIdListener(OnTrackIdListener listener) {
+        this.intervalsListener = listener;
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/fragments/IntervalsRecordedFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/IntervalsRecordedFragment.java
@@ -90,4 +90,16 @@ public class IntervalsRecordedFragment extends Fragment implements IntervalListV
             }
         });
     }
+
+    @Override
+    public void unitChanged() {
+        if (viewModel != null) {
+            LiveData<IntervalStatistics> liveData = viewModel.getIntervalStats(trackId, null);
+            liveData.observe(getActivity(), intervalStatistics -> {
+            if (intervalStatistics != null) {
+                intervalListView.display(intervalStatistics.getIntervalList());
+            }
+        });
+        }
+    }
 }

--- a/src/main/java/de/dennisguse/opentracks/fragments/IntervalsRecordingFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/IntervalsRecordingFragment.java
@@ -14,6 +14,7 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModelProvider;
 
 import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.TrackRecordingActivity;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.util.UnitConversions;
 import de.dennisguse.opentracks.viewmodels.IntervalStatistics;
@@ -23,7 +24,7 @@ import de.dennisguse.opentracks.views.IntervalListView;
 /**
  * A fragment to display the intervals from recording track.
  */
-public class IntervalsRecordingFragment extends Fragment implements IntervalListView.IntervalListListener {
+public class IntervalsRecordingFragment extends Fragment implements IntervalListView.IntervalListListener, TrackRecordingActivity.OnTrackIdListener {
 
     private static final String TAG = IntervalsRecordingFragment.class.getSimpleName();
 
@@ -68,6 +69,7 @@ public class IntervalsRecordingFragment extends Fragment implements IntervalList
         super.onViewCreated(view, savedInstanceState);
 
         trackId = getArguments().getParcelable(TRACK_ID_KEY);
+        ((TrackRecordingActivity) getActivity()).setTrackIdListener(this);
 
         intervalHandler = new Handler();
 
@@ -124,4 +126,20 @@ public class IntervalsRecordingFragment extends Fragment implements IntervalList
         intervalChanged(null);
     }
 
+    @Override
+    public void unitChanged() {
+        if (viewModel != null) {
+            LiveData<IntervalStatistics> liveData = viewModel.getIntervalStats(trackId, null);
+            liveData.observe(getActivity(), intervalStatistics -> {
+                if (intervalStatistics != null) {
+                    intervalListView.display(intervalStatistics.getIntervalList());
+                }
+            });
+        }
+    }
+
+    @Override
+    public void onTrackId(Track.Id trackId) {
+        this.trackId = trackId;
+    }
 }

--- a/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsModel.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsModel.java
@@ -24,6 +24,7 @@ import de.dennisguse.opentracks.util.UnitConversions;
 public class IntervalStatisticsModel extends AndroidViewModel {
 
     private MutableLiveData<IntervalStatistics> intervalStats = new MutableLiveData<>();
+    private IntervalOption interval = IntervalOption.OPTION_1;
 
     public IntervalStatisticsModel(@NonNull Application application) {
         super(application);

--- a/src/main/java/de/dennisguse/opentracks/views/IntervalListView.java
+++ b/src/main/java/de/dennisguse/opentracks/views/IntervalListView.java
@@ -35,6 +35,7 @@ public class IntervalListView extends LinearLayout {
         if (PreferencesUtils.isKey(getContext(), R.string.stats_units_key, key) || PreferencesUtils.isKey(getContext(), R.string.stats_rate_key, key)) {
             if (spinnerIntervalsUnit != null) {
                 spinnerIntervalsUnit.setText(PreferencesUtils.isMetricUnits(getContext()) ? getContext().getString(R.string.unit_kilometer) : getContext().getString(R.string.unit_mile));
+                listener.unitChanged();
             }
         }
     };
@@ -92,6 +93,7 @@ public class IntervalListView extends LinearLayout {
 
     public interface IntervalListListener {
         void intervalChanged(IntervalStatisticsModel.IntervalOption interval);
+        void unitChanged();
     }
 
     /**


### PR DESCRIPTION
**Describe the pull request**
Recorded activity didn't initialize the intervals. Also, invalidate didn't work in view model.

Recording activity didn't show intervals because the activity passed a null Track.Id because the Track.Id is created in the Runnable for new tracks. Now interval fragment listen for a new Track.Id. I've kept the argument in newInstance because we don't know if Runnable finished before fragment is created, right? *I don't know if this is the best approach so I create a Draft PR.*

Finally, unit changed must result in a interval refreshing.

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/406

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
