### PR TITLE
Added workaround for allowing Android 11 install with only apk v1 sig…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ android {
 
 
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 29
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Confirmed that changing targetSdkVersion to 29 from 30 allows install on Android 11 with only apk v1 signature