### PR TITLE
Intervals rate and gain

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
@@ -16,6 +16,7 @@ public class TestDataUtil {
     public static final double INITIAL_LATITUDE = 37.0;
     public static final double INITIAL_LONGITUDE = -57.0;
     public static final double ALTITUDE_INTERVAL = 2.5;
+    public static final float ELEVATION_GAIN = 3;
 
     /**
      * Create a track without any trackPoints.
@@ -70,7 +71,7 @@ public class TestDataUtil {
         trackPoint.setHeartRate_bpm(100f + i);
         trackPoint.setCyclingCadence_rpm(300f + i);
         trackPoint.setPower(400f + i);
-        trackPoint.setElevationGain(500f + i);
+        trackPoint.setElevationGain(ELEVATION_GAIN);
         return trackPoint;
     }
 

--- a/src/androidTest/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsTest.java
@@ -80,7 +80,7 @@ public class IntervalStatisticsTest {
 		// given
 		List<TrackPoint> trackPoints = buildTrackPoints(200);
 		TrackStatistics trackStatistics = buildTrackStatistics(trackPoints);
-		float distanceInterval = 3000;
+		float distanceInterval = 3000f;
 		IntervalStatistics intervalStatistics = new IntervalStatistics();
 
 		// when and then
@@ -97,7 +97,7 @@ public class IntervalStatisticsTest {
 		// given
 		List<TrackPoint> trackPoints = buildTrackPoints(1000);
 		TrackStatistics trackStatistics = buildTrackStatistics(trackPoints);
-		float distanceInterval = 3000;
+		float distanceInterval = 3000f;
 		IntervalStatistics intervalStatistics = new IntervalStatistics();
 
 		// when and then
@@ -114,7 +114,7 @@ public class IntervalStatisticsTest {
 		// given
 		List<TrackPoint> trackPoints = buildTrackPoints(10000);
 		TrackStatistics trackStatistics = buildTrackStatistics(trackPoints);
-		float distanceInterval = 1000;
+		float distanceInterval = 1000f;
 		IntervalStatistics intervalStatistics = new IntervalStatistics();
 
 		// when and then
@@ -126,15 +126,18 @@ public class IntervalStatisticsTest {
 		List<IntervalStatistics.Interval> intervalList = intervalStatistics.getIntervalList();
 		double totalDistance = 0d;
 		long totalTime = 0L;
+		float totalGain = 0f;
 		for (IntervalStatistics.Interval i : intervalList) {
 			totalDistance += i.getDistance_m();
 			totalTime += ((i.getDistance_m() / i.getSpeed_ms()) * UnitConversions.S_TO_MS);
+			totalGain += i.getGain_m();
 		}
 
 		// then
 		assertEquals(trackStatistics.getTotalDistance(), totalDistance, 0.01);
 		assertEquals(trackStatistics.getTotalTime() * UnitConversions.MS_TO_S, totalTime * UnitConversions.MS_TO_S, 0.1);
 		assertEquals(intervalList.size(), (int) Math.ceil(trackStatistics.getTotalDistance() / distanceInterval));
+		assertEquals(totalGain, trackPoints.size() * TestDataUtil.ELEVATION_GAIN, 0.1);
 		for (int i = 0; i < intervalList.size() - 1; i++) {
 			assertEquals(intervalList.get(i).getDistance_m(), distanceInterval, 0.001);
 			totalDistance -= intervalList.get(i).getDistance_m();

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -253,7 +253,7 @@ public class TrackRecordedActivity extends AbstractListActivity implements Choos
                 case 0:
                     return StatisticsRecordedFragment.newInstance(trackId);
                 case 1:
-                    return IntervalsFragment.newInstance(trackId);
+                    return IntervalsFragment.newInstance();
                 case 2:
                     return ChartFragment.newInstance(false);
                 case 3:

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -66,8 +66,8 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
     // Preferences
     private boolean recordingTrackPaused;
 
-    // Intervals recording fragment needs Track.Id when the activity creates it.
-    private OnTrackIdListener intervalsListener;
+    // Intervals recording fragment needs Track.Id when the activity creates it and knowing when category change.
+    private OnTrackRecordingListener intervalsListener;
 
     private final Runnable bindChangedCallback = new Runnable() {
         @Override
@@ -370,6 +370,7 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
         Track track = contentProviderUtils.getTrack(trackId);
         String category = getString(TrackIconUtils.getIconActivityType(iconValue));
         TrackUtils.updateTrack(this, track, null, category, null, contentProviderUtils);
+        intervalsListener.onCategoryChanged(category);
     }
 
     private class CustomFragmentPagerAdapter extends FragmentPagerAdapter {
@@ -417,11 +418,12 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
         }
     }
 
-    public interface OnTrackIdListener {
+    public interface OnTrackRecordingListener {
         void onTrackId(Track.Id trackId);
+        void onCategoryChanged(String category);
     }
 
-    public void setTrackIdListener(OnTrackIdListener listener) {
+    public void setTrackIdListener(OnTrackRecordingListener listener) {
         this.intervalsListener = listener;
         if (trackId != null) {
             listener.onTrackId(trackId);

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -66,9 +66,6 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
     // Preferences
     private boolean recordingTrackPaused;
 
-    // Intervals recording fragment needs Track.Id when the activity creates it and knowing when category change.
-    private OnTrackRecordingListener intervalsListener;
-
     private final Runnable bindChangedCallback = new Runnable() {
         @Override
         public void run() {
@@ -85,9 +82,6 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
                 if (trackId == null) {
                     // trackId isn't initialized -> leads a new recording.
                     trackId = service.startNewTrack();
-                    if (intervalsListener != null) {
-                        intervalsListener.onTrackId(trackId);
-                    }
                 } else {
                     // trackId is initialized -> resumes the track.
                     service.resumeTrack(trackId);
@@ -370,7 +364,6 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
         Track track = contentProviderUtils.getTrack(trackId);
         String category = getString(TrackIconUtils.getIconActivityType(iconValue));
         TrackUtils.updateTrack(this, track, null, category, null, contentProviderUtils);
-        intervalsListener.onCategoryChanged(category);
     }
 
     private class CustomFragmentPagerAdapter extends FragmentPagerAdapter {
@@ -391,7 +384,7 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
                 case 0:
                     return StatisticsRecordingFragment.newInstance();
                 case 1:
-                    return IntervalsFragment.IntervalsRecordingFragment.newInstance(trackId);
+                    return IntervalsFragment.IntervalsRecordingFragment.newInstance();
                 case 2:
                     return ChartFragment.newInstance(false);
                 case 3:
@@ -415,18 +408,6 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
                 default:
                     throw new RuntimeException("There isn't Fragment associated with the position: " + position);
             }
-        }
-    }
-
-    public interface OnTrackRecordingListener {
-        void onTrackId(Track.Id trackId);
-        void onCategoryChanged(String category);
-    }
-
-    public void setTrackIdListener(OnTrackRecordingListener listener) {
-        this.intervalsListener = listener;
-        if (trackId != null) {
-            listener.onTrackId(trackId);
         }
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/adapters/IntervalStatisticsAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/adapters/IntervalStatisticsAdapter.java
@@ -23,10 +23,12 @@ public class IntervalStatisticsAdapter extends ArrayAdapter<IntervalStatistics.I
     private StackMode stackMode;
     private boolean metricUnits;
     private float sumDistance_m;
+    private String category;
 
-    public IntervalStatisticsAdapter(Context context, List<IntervalStatistics.Interval> intervalList, StackMode stackMode) {
+    public IntervalStatisticsAdapter(Context context, List<IntervalStatistics.Interval> intervalList, String category, StackMode stackMode) {
         super(context, R.layout.interval_stats_list_item, intervalList);
         metricUnits = PreferencesUtils.isMetricUnits(context);
+        this.category = category;
         this.stackMode = stackMode;
     }
 
@@ -43,8 +45,8 @@ public class IntervalStatisticsAdapter extends ArrayAdapter<IntervalStatistics.I
             intervalView = LayoutInflater.from(getContext()).inflate(R.layout.interval_stats_list_item, parent, false);
 
             viewHolder.distance = intervalView.findViewById(R.id.interval_item_distance);
-            viewHolder.speed = intervalView.findViewById(R.id.interval_item_speed);
-            viewHolder.pace = intervalView.findViewById(R.id.interval_item_pace);
+            viewHolder.rate = intervalView.findViewById(R.id.interval_item_rate);
+            viewHolder.gain = intervalView.findViewById(R.id.interval_item_gain);
 
             intervalView.setTag(viewHolder);
         } else {
@@ -58,11 +60,16 @@ public class IntervalStatisticsAdapter extends ArrayAdapter<IntervalStatistics.I
         }
         viewHolder.distance.setText(StringUtils.formatDistance(getContext(), sumDistance_m, metricUnits));
 
-        Pair<String, String> speedParts = StringUtils.getSpeedParts(getContext(), interval.getSpeed_ms(), metricUnits, true);
-        viewHolder.speed.setText(speedParts.first + " " + speedParts.second);
+        if (PreferencesUtils.isReportSpeed(getContext(), category)) {
+            Pair<String, String> speedParts = StringUtils.getSpeedParts(getContext(), interval.getSpeed_ms(), metricUnits, true);
+            viewHolder.rate.setText(speedParts.first + " " + speedParts.second);
+        } else {
+            Pair<String, String> paceParts = StringUtils.getSpeedParts(getContext(), interval.getSpeed_ms(), metricUnits, false);
+            viewHolder.rate.setText(paceParts.first + " " + paceParts.second);
+        }
 
-        Pair<String, String> paceParts = StringUtils.getSpeedParts(getContext(), interval.getSpeed_ms(), metricUnits, false);
-        viewHolder.pace.setText(paceParts.first + " " + paceParts.second);
+        Pair<String, String> gainParts = StringUtils.formatElevation(getContext(), interval.getGain_m(), metricUnits);
+        viewHolder.gain.setText(gainParts.first + " " + gainParts.second);
 
         return intervalView;
     }
@@ -77,7 +84,7 @@ public class IntervalStatisticsAdapter extends ArrayAdapter<IntervalStatistics.I
 
     private static class ViewHolder {
         private TextView distance;
-        private TextView speed;
-        private TextView pace;
+        private TextView rate;
+        private TextView gain;
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/content/TrackDataHub.java
+++ b/src/main/java/de/dennisguse/opentracks/content/TrackDataHub.java
@@ -54,17 +54,15 @@ import de.dennisguse.opentracks.util.PreferencesUtils;
 public class TrackDataHub implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     /**
-     * Target number of track points displayed by the map overlay.
+     * Target number of track points displayed by the diagrams (recommended).
      * We may display more than this number of points.
      */
-    @Deprecated
     private static final int TARGET_DISPLAYED_TRACKPOINTS = 5000;
 
     /**
-     * Maximum number of markers to displayed.
+     * Maximum number of markers to displayed in the diagrams.
      */
     @VisibleForTesting
-    @Deprecated
     private static final int MAX_DISPLAYED_MARKERS = 128;
 
     private static final String TAG = TrackDataHub.class.getSimpleName();

--- a/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatistics.java
@@ -24,6 +24,7 @@ public class IntervalStatistics {
         }
 
         Interval interval = new Interval();
+        interval.gain_m += trackPointList.get(0).hasElevationGain() ? trackPointList.get(0).getElevationGain() : 0;
         for (int i = 1; i < trackPointList.size(); i++) {
             TrackPoint prevTrackPoint = trackPointList.get(i - 1);
             TrackPoint trackPoint = trackPointList.get(i);
@@ -31,6 +32,7 @@ public class IntervalStatistics {
             if (LocationUtils.isValidLocation(trackPoint.getLocation()) && LocationUtils.isValidLocation(prevTrackPoint.getLocation())) {
                 interval.distance_m += prevTrackPoint.distanceTo(trackPoint);
                 interval.time_ms += trackPoint.getTime() - prevTrackPoint.getTime();
+                interval.gain_m += trackPoint.hasElevationGain() ? trackPoint.getElevationGain() : 0;
 
                 if (interval.distance_m >= distanceInterval_m) {
                     float adjustFactor = distanceInterval_m / interval.distance_m;
@@ -80,17 +82,20 @@ public class IntervalStatistics {
     public static class Interval {
         private float distance_m = 0f;
         private float time_ms = 0f;
+        private float gain_m = 0f;
 
         public Interval() {}
 
         public Interval(float distance_m, float time_ms) {
             this.distance_m = distance_m;
             this.time_ms = time_ms;
+            this.gain_m = 0f;
         }
 
         public Interval(Interval i) {
             distance_m = i.distance_m;
             time_ms = i.time_ms;
+            gain_m = i.gain_m;
         }
 
         public float getDistance_m() {
@@ -110,6 +115,10 @@ public class IntervalStatistics {
                 return 0f;
             }
             return distance_m / (float) (time_ms * UnitConversions.MS_TO_S);
+        }
+
+        public float getGain_m() {
+            return gain_m;
         }
     }
 }

--- a/src/main/res/drawable/ic_arrow_drop_up_24.xml
+++ b/src/main/res/drawable/ic_arrow_drop_up_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M7,14l5,-5 5,5z"/>
+</vector>

--- a/src/main/res/layout/interval_list_view.xml
+++ b/src/main/res/layout/interval_list_view.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 
     <LinearLayout
@@ -42,7 +43,7 @@
             android:text="@string/stats_distance" />
 
         <TextView
-            android:id="@+id/interval_speed"
+            android:id="@+id/interval_rate"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
@@ -50,10 +51,10 @@
             android:layout_margin="1dp"
             android:textAlignment="center"
             android:layout_gravity="center"
-            android:text="@string/stats_speed" />
+            tools:text="Speed"/>
 
         <TextView
-            android:id="@+id/interval_pace"
+            android:id="@+id/interval_elevation"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
@@ -61,7 +62,7 @@
             android:layout_margin="1dp"
             android:textAlignment="center"
             android:layout_gravity="center"
-            android:text="@string/stats_pace" />
+            android:text="@string/stats_elevation" />
 
     </LinearLayout>
 

--- a/src/main/res/layout/interval_stats_list_item.xml
+++ b/src/main/res/layout/interval_stats_list_item.xml
@@ -5,28 +5,43 @@
     android:layout_marginBottom="8dp"
     android:orientation="horizontal">
 
-    <TextView
-        android:id="@+id/interval_item_distance"
-        style="@style/TextMedium"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        tools:text="1 km" />
+        <TextView
+            android:id="@+id/interval_item_distance"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_gravity="center_vertical"
+            style="@style/TextMedium"
+            tools:text="1 km" />
 
-    <TextView
-        android:id="@+id/interval_item_speed"
-        style="@style/TextMedium"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        tools:text="15 km/h" />
+        <TextView
+            android:id="@+id/interval_item_rate"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_gravity="center_vertical"
+            style="@style/TextMedium"
+            tools:text="15 km/h" />
 
-    <TextView
-        android:id="@+id/interval_item_pace"
-        style="@style/TextMedium"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        tools:text="4:00" />
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_arrow_drop_up_24" />
+
+            <TextView
+                android:id="@+id/interval_item_gain"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                style="@style/TextMedium"
+                tools:text="100 m" />
+
+        </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
**Describe the pull request**
Intervals show distance, speed/pace (depending on user's settings) and gain.

I would like to test it in real activities (I hope next week) to move this Draft to PR.

**Motivation**
Speed or pace doesn't mean too much without gain. For example, an average speed of 10km/h by bike in an interval of 1km can seem too little but if you has a gain of 80m then 10km/h is so good.

That's why I think is necessary the gain in intervals.

PS/ When we add elevation loss to the logic of OpenTracks then we'll been able to add the elevation lost too.

**Link to the the issue**
(If available): The link to the issue that this pull request solves.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
