### PR TITLE
Edit texts: select all on focus and capitalize by words/sentences.

### DIFF
--- a/src/main/res/layout/marker_edit.xml
+++ b/src/main/res/layout/marker_edit.xml
@@ -39,7 +39,9 @@ limitations under the License.
                     android:drawableStart="@drawable/ic_marker_orange_pushpin_with_shadow"
                     android:id="@+id/marker_edit_name"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+                    android:layout_height="wrap_content"
+                    android:inputType="textCapWords"
+                    android:selectAllOnFocus="true" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
@@ -53,7 +55,8 @@ limitations under the License.
                     style="@style/EditCategory"
                     android:layout_width="match_parent"
                     android:hint="@string/marker_edit_marker_type"
-                    android:imeOptions="actionNext" />
+                    android:imeOptions="actionNext"
+                    android:selectAllOnFocus="true" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
@@ -66,7 +69,9 @@ limitations under the License.
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/marker_edit_description"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+                    android:layout_height="wrap_content"
+                    android:inputType="textCapSentences"
+                    android:selectAllOnFocus="true" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <RelativeLayout

--- a/src/main/res/layout/track_edit.xml
+++ b/src/main/res/layout/track_edit.xml
@@ -38,7 +38,9 @@ limitations under the License.
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/track_edit_name"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+                    android:layout_height="wrap_content"
+                    android:inputType="textCapWords"
+                    android:selectAllOnFocus="true" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <LinearLayout
@@ -57,7 +59,8 @@ limitations under the License.
                         android:id="@+id/track_edit_activity_type"
                         style="@style/EditCategory"
                         android:hint="@string/track_edit_activity_type_hint"
-                        android:imeOptions="actionNext" />
+                        android:imeOptions="actionNext"
+                        android:selectAllOnFocus="true" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <Spinner
@@ -77,7 +80,9 @@ limitations under the License.
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/track_edit_description"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+                    android:layout_height="wrap_content"
+                    android:inputType="textCapSentences"
+                    android:selectAllOnFocus="true" />
             </com.google.android.material.textfield.TextInputLayout>
 
         </LinearLayout>


### PR DESCRIPTION
**Describe the pull request**
Some releases ago, every time you clicked on an EditText the text was selected (selectAllOnFocus) and text were capitalized by word or by sentence.

After this PR:
- For titles: added attributes textCapWords and selectAllOnFocus.
- For descriptions: added attributes textCapSentences and selectAllOnFocus.

I think this should be the default behaviour.

**Link to the the issue**
#461 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
