### PR TITLE
Database enforces foreign key constraints incl. cascading deletes.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
@@ -212,7 +212,7 @@ public class CustomContentProviderUtilsTest {
         Track.Id trackId = new Track.Id(System.currentTimeMillis());
         TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
 
-        Marker waypoint = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId));
+        Marker waypoint = new Marker(trackId, contentProviderUtils.getLastValidTrackPoint(trackId));
         contentProviderUtils.insertMarker(waypoint);
 
         ContentResolver contentResolver = context.getContentResolver();
@@ -287,8 +287,7 @@ public class CustomContentProviderUtilsTest {
         TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId2, 10);
         TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId3, 10);
 
-        Marker waypoint = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId2));
-        waypoint.setTrackId(trackId1);
+        Marker waypoint = new Marker(trackId1, contentProviderUtils.getLastValidTrackPoint(trackId2));
         contentProviderUtils.insertMarker(waypoint);
 
         ContentResolver contentResolver = context.getContentResolver();
@@ -463,7 +462,7 @@ public class CustomContentProviderUtilsTest {
         track.first.setTrackStatistics(statistics);
         contentProviderUtils.insertTrack(track.first);
 
-        Marker waypoint = new Marker(track.second[0]);
+        Marker waypoint = new Marker(trackId, track.second[0]);
         waypoint.setDescription(TEST_DESC);
         contentProviderUtils.insertMarker(waypoint);
 
@@ -522,9 +521,8 @@ public class CustomContentProviderUtilsTest {
         TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
 
         // Insert at first.
-        Marker waypoint1 = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId));
+        Marker waypoint1 = new Marker(trackId, contentProviderUtils.getLastValidTrackPoint(trackId));
         waypoint1.setDescription(TEST_DESC);
-        waypoint1.setTrackId(trackId);
         contentProviderUtils.insertMarker(waypoint1);
 
         // Check insert was done.
@@ -600,14 +598,12 @@ public class CustomContentProviderUtilsTest {
 //        TestDataUtil.insertTrackWithLocations(contentProviderUtils, track);
 
         // Insert at first.
-        Marker waypoint1 = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId));
+        Marker waypoint1 = new Marker(trackId, contentProviderUtils.getLastValidTrackPoint(trackId));
         waypoint1.setDescription(MOCK_DESC);
-        waypoint1.setTrackId(trackId);
         Marker.Id waypoint1Id = new Marker.Id(ContentUris.parseId(contentProviderUtils.insertMarker(waypoint1)));
 
-        Marker waypoint2 = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId));
+        Marker waypoint2 = new Marker(trackId, contentProviderUtils.getLastValidTrackPoint(trackId));
         waypoint2.setDescription(MOCK_DESC);
-        waypoint2.setTrackId(trackId);
         Marker.Id waypoint2Id = new Marker.Id(ContentUris.parseId(contentProviderUtils.insertMarker(waypoint2)));
 
         // Delete
@@ -626,14 +622,10 @@ public class CustomContentProviderUtilsTest {
         Track.Id trackId = new Track.Id(System.currentTimeMillis());
         TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
 
-        Marker waypoint1 = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId));
-        waypoint1.setTrackId(trackId);
-        Marker waypoint2 = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId));
-        waypoint2.setTrackId(trackId);
-        Marker waypoint3 = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId));
-        waypoint3.setTrackId(trackId);
-        Marker waypoint4 = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId));
-        waypoint4.setTrackId(trackId);
+        Marker waypoint1 = new Marker(trackId, contentProviderUtils.getLastValidTrackPoint(trackId));
+        Marker waypoint2 = new Marker(trackId, contentProviderUtils.getLastValidTrackPoint(trackId));
+        Marker waypoint3 = new Marker(trackId, contentProviderUtils.getLastValidTrackPoint(trackId));
+        Marker waypoint4 = new Marker(trackId, contentProviderUtils.getLastValidTrackPoint(trackId));
         contentProviderUtils.insertMarker(waypoint1);
         contentProviderUtils.insertMarker(waypoint2);
         contentProviderUtils.insertMarker(waypoint3);
@@ -651,9 +643,8 @@ public class CustomContentProviderUtilsTest {
         Track.Id trackId = new Track.Id(System.currentTimeMillis());
         TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
 
-        Marker waypoint = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId));
+        Marker waypoint = new Marker(trackId, contentProviderUtils.getLastValidTrackPoint(trackId));
         waypoint.setDescription(TEST_DESC);
-        waypoint.setTrackId(trackId);
         Marker.Id waypointId = new Marker.Id(ContentUris.parseId(contentProviderUtils.insertMarker(waypoint)));
 
         assertEquals(TEST_DESC, contentProviderUtils.getMarker(waypointId).getDescription());
@@ -668,9 +659,8 @@ public class CustomContentProviderUtilsTest {
         TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
 
         // Insert at first.
-        Marker waypoint = new Marker(contentProviderUtils.getLastValidTrackPoint(trackId));
+        Marker waypoint = new Marker(trackId, contentProviderUtils.getLastValidTrackPoint(trackId));
         waypoint.setDescription(TEST_DESC);
-        waypoint.setTrackId(trackId);
         Marker.Id waypointId = new Marker.Id(ContentUris.parseId(contentProviderUtils.insertMarker(waypoint)));
 
         // Update
@@ -695,7 +685,6 @@ public class CustomContentProviderUtilsTest {
         TrackPoint trackPoint = contentProviderUtils.getLastValidTrackPoint(trackId);
         Marker waypoint = TestDataUtil.createWaypointWithPhoto(context, trackId, trackPoint.getLocation());
         waypoint.setDescription(TEST_DESC);
-        waypoint.setTrackId(trackId);
         Marker.Id waypointId = new Marker.Id(ContentUris.parseId(contentProviderUtils.insertMarker(waypoint)));
 
         File dir = new File(FileUtils.getPhotoDir(context), "" + trackId.getId());
@@ -731,7 +720,6 @@ public class CustomContentProviderUtilsTest {
         TrackPoint trackPoint = contentProviderUtils.getLastValidTrackPoint(trackId);
         Marker waypoint = TestDataUtil.createWaypointWithPhoto(context, trackId, trackPoint.getLocation());
         waypoint.setDescription(TEST_DESC);
-        waypoint.setTrackId(trackId);
         Marker.Id waypointId = new Marker.Id(ContentUris.parseId(contentProviderUtils.insertMarker(waypoint)));
 
         File dir = new File(FileUtils.getPhotoDir(context), "" + trackId.getId());
@@ -766,10 +754,8 @@ public class CustomContentProviderUtilsTest {
         TrackPoint trackPoint = contentProviderUtils.getLastValidTrackPoint(trackId);
         Marker waypoint = TestDataUtil.createWaypointWithPhoto(context, trackId, trackPoint.getLocation());
         waypoint.setDescription(TEST_DESC);
-        waypoint.setTrackId(trackId);
         Marker otherWaypoint = TestDataUtil.createWaypointWithPhoto(context, trackId, trackPoint.getLocation());
         otherWaypoint.setDescription(TEST_DESC);
-        otherWaypoint.setTrackId(trackId);
         Marker.Id waypointId = new Marker.Id(ContentUris.parseId(contentProviderUtils.insertMarker(waypoint)));
         contentProviderUtils.insertMarker(otherWaypoint);
 

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -72,13 +72,12 @@ public class ExportImportTest {
         trackPoints.addAll(Arrays.asList(track.second));
 
         for (int i = 0; i < 3; i++) {
-            Marker marker = new Marker(track.second[i].getLocation());
+            Marker marker = new Marker(trackId, track.second[i].getLocation());
             marker.setName("the marker " + i);
             marker.setDescription("the marker description " + i);
             marker.setCategory("the marker category" + i);
             marker.setIcon("the marker icon" + i);
             marker.setPhotoUrl("the photo url" + i);
-            marker.setTrackId(trackId);
             contentProviderUtils.insertMarker(marker);
 
             markers.add(marker);
@@ -90,7 +89,9 @@ public class ExportImportTest {
     @After
     public void tearDown() {
         contentProviderUtils.deleteTrack(context, trackId);
-        contentProviderUtils.deleteTrack(context, importTrackId);
+        if (importTrackId != null) {
+            contentProviderUtils.deleteTrack(context, importTrackId);
+        }
     }
 
     @LargeTest

--- a/src/main/java/de/dennisguse/opentracks/content/data/Marker.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Marker.java
@@ -40,20 +40,28 @@ public final class Marker {
     private String description = "";
     private String category = "";
     private String icon = "";
-    private Track.Id trackId;
+    private final Track.Id trackId;
+    //TODO It is the distance from the track starting point; rename to something more meaningful
     private double length = 0.0;
     private long duration = 0;
-    private Location location;
+    private final Location location;
     @Deprecated //TODO Make an URI instead of String
     private String photoUrl = "";
 
     @VisibleForTesting
-    public Marker(@NonNull TrackPoint trackPoint) {
-        this.location = trackPoint.getLocation();
+    public Marker(@NonNull Track.Id trackId, @NonNull TrackPoint trackPoint) {
+        this(trackId, trackPoint.getLocation());
     }
 
+    @Deprecated
+    //TODO Used by AbstractFileImporter to create an intermediate marker before saving a new one into the database.
     public Marker(@NonNull Location location) {
+        this(null, location);
+    }
+
+    public Marker(@NonNull Track.Id trackId, @NonNull Location location) {
         this.location = location;
+        this.trackId = trackId;
     }
 
     public Marker(String name, String description, String category, String icon, @NonNull Track.Id trackId, double length, long duration, @NonNull Location location, String photoUrl) {
@@ -112,12 +120,9 @@ public final class Marker {
         this.icon = icon;
     }
 
-    public Track.Id getTrackId() {
+    public @NonNull
+    Track.Id getTrackId() {
         return trackId;
-    }
-
-    public void setTrackId(Track.Id trackId) {
-        this.trackId = trackId;
     }
 
     public double getLength() {

--- a/src/main/java/de/dennisguse/opentracks/content/data/MarkerColumns.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/MarkerColumns.java
@@ -28,7 +28,7 @@ import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
  */
 public interface MarkerColumns extends BaseColumns {
 
-    String TABLE_NAME = "waypoints";
+    String TABLE_NAME = "markers";
     Uri CONTENT_URI = Uri.parse(ContentProviderUtils.CONTENT_BASE_URI + "/" + TABLE_NAME);
     Uri CONTENT_URI_BY_TRACKID = Uri.parse(ContentProviderUtils.CONTENT_BASE_URI + "/" + TABLE_NAME + "/trackid");
     String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.de.dennisguse.waypoint";
@@ -60,7 +60,7 @@ public interface MarkerColumns extends BaseColumns {
             + DESCRIPTION + " TEXT, "
             + CATEGORY + " TEXT, "
             + ICON + " TEXT, "
-            + TRACKID + " INTEGER, "
+            + TRACKID + " INTEGER NOT NULL, "
             + LENGTH + " FLOAT, "
             + DURATION + " INTEGER, "
             + LONGITUDE + " INTEGER, "
@@ -69,7 +69,8 @@ public interface MarkerColumns extends BaseColumns {
             + ALTITUDE + " FLOAT, "
             + ACCURACY + " FLOAT, "
             + BEARING + " FLOAT, "
-            + PHOTOURL + " TEXT"
+            + PHOTOURL + " TEXT, "
+            + "FOREIGN KEY (" + TRACKID + ") REFERENCES " + TracksColumns.TABLE_NAME + "(" + TracksColumns._ID + ") ON UPDATE CASCADE ON DELETE CASCADE"
             + ")";
 
     String CREATE_TABLE_INDEX = "CREATE INDEX " + TABLE_NAME + "_" + TRACKID + "_index ON " + TABLE_NAME + "(" + TRACKID + ")";

--- a/src/main/java/de/dennisguse/opentracks/content/data/TrackPointsColumns.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TrackPointsColumns.java
@@ -40,7 +40,9 @@ public interface TrackPointsColumns extends BaseColumns {
 
     String LONGITUDE = "longitude";
     String LATITUDE = "latitude";
+    @Deprecated
     double PAUSE_LATITUDE = 100.0;
+    @Deprecated
     double RESUME_LATITUDE = 200.0;
 
     String TIME = "time";
@@ -55,7 +57,7 @@ public interface TrackPointsColumns extends BaseColumns {
 
     String CREATE_TABLE = "CREATE TABLE " + TABLE_NAME + " ("
             + _ID + " INTEGER PRIMARY KEY AUTOINCREMENT, "
-            + TRACKID + " INTEGER, "
+            + TRACKID + " INTEGER NOT NULL, "
             + LONGITUDE + " INTEGER, "
             + LATITUDE + " INTEGER, "
             + TIME + " INTEGER, "
@@ -66,7 +68,9 @@ public interface TrackPointsColumns extends BaseColumns {
             + SENSOR_HEARTRATE + " FLOAT, "
             + SENSOR_CADENCE + " FLOAT, "
             + SENSOR_POWER + " FLOAT, "
-            + ELEVATION_GAIN + " FLOAT)";
+            + ELEVATION_GAIN + " FLOAT, "
+            + "FOREIGN KEY (" + TRACKID + ") REFERENCES " + TracksColumns.TABLE_NAME + "(" + TracksColumns._ID + ") ON UPDATE CASCADE ON DELETE CASCADE"
+            + ")";
 
     String CREATE_TABLE_INDEX = "CREATE INDEX " + TABLE_NAME + "_" + TRACKID + "_index ON " + TABLE_NAME + "(" + TRACKID + ")";
 }

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -184,17 +184,7 @@ public class ContentProviderUtils {
         FileUtils.deleteDirectoryRecurse(dir);
     }
 
-    /**
-     * Deletes a track.
-     *
-     * @param trackId the track id
-     */
-    public void deleteTrack(Context context, Track.Id trackId) {
-        if (trackId == null) {
-            return;
-        }
-        deleteTrackPointsAndMarkers(trackId);
-
+    public void deleteTrack(Context context, @NonNull Track.Id trackId) {
         // Delete track folder resources.
         FileUtils.deleteDirectoryRecurse(FileUtils.getPhotoDir(context, trackId));
 
@@ -368,7 +358,8 @@ public class ContentProviderUtils {
             location.setBearing(cursor.getFloat(bearingIndex));
         }
 
-        Marker marker = new Marker(location);
+        Track.Id trackId = new Track.Id(cursor.getLong(trackIdIndex));
+        Marker marker = new Marker(trackId, location);
 
         if (!cursor.isNull(idIndex)) {
             marker.setId(new Marker.Id(cursor.getLong(idIndex)));
@@ -384,9 +375,6 @@ public class ContentProviderUtils {
         }
         if (!cursor.isNull(iconIndex)) {
             marker.setIcon(cursor.getString(iconIndex));
-        }
-        if (!cursor.isNull(trackIdIndex)) {
-            marker.setTrackId(new Track.Id(cursor.getLong(trackIdIndex)));
         }
         if (!cursor.isNull(lengthIndex)) {
             marker.setLength(cursor.getFloat(lengthIndex));
@@ -566,9 +554,7 @@ public class ContentProviderUtils {
         values.put(MarkerColumns.DESCRIPTION, marker.getDescription());
         values.put(MarkerColumns.CATEGORY, marker.getCategory());
         values.put(MarkerColumns.ICON, marker.getIcon());
-        if (marker.getTrackId() != null) {
-            values.put(MarkerColumns.TRACKID, marker.getTrackId().getId());
-        }
+        values.put(MarkerColumns.TRACKID, marker.getTrackId().getId());
         values.put(MarkerColumns.LENGTH, marker.getLength());
         values.put(MarkerColumns.DURATION, marker.getDuration());
 

--- a/src/main/java/de/dennisguse/opentracks/content/provider/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/CustomContentProvider.java
@@ -39,6 +39,8 @@ import de.dennisguse.opentracks.content.data.TracksColumns;
 
 /**
  * A {@link ContentProvider} that handles access to track points, tracks, and markers tables.
+ * <p>
+ * Data consistency is enforced using Foreign Key Constraints within the database incl. cascading deletes.
  *
  * @author Leif Hendrik Wilden
  */
@@ -82,6 +84,8 @@ public class CustomContentProvider extends ContentProvider {
         CustomSQLiteOpenHelper databaseHelper = new CustomSQLiteOpenHelper(context);
         try {
             db = databaseHelper.getWritableDatabase();
+            // Necessary to enable cascade deletion from Track to TrackPoints and Markers
+            db.setForeignKeyConstraintsEnabled(true);
         } catch (SQLiteException e) {
             Log.e(TAG, "Unable to open database for writing.", e);
         }

--- a/src/main/java/de/dennisguse/opentracks/content/provider/CustomSQLiteOpenHelper.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/CustomSQLiteOpenHelper.java
@@ -25,7 +25,7 @@ public class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
 
     private static final String TAG = CustomSQLiteOpenHelper.class.getSimpleName();
 
-    private static final int DATABASE_VERSION = 27;
+    private static final int DATABASE_VERSION = 28;
 
     @VisibleForTesting
     public static final String DATABASE_NAME = "database.db";
@@ -73,7 +73,9 @@ public class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
                 case 27:
                     upgradeFrom26to27(db);
                     break;
-
+                case 28:
+                    upgradeFrom27to28(db);
+                    break;
 
                 default:
                     throw new RuntimeException("Not implemented: upgrade to " + toVersion);
@@ -97,6 +99,9 @@ public class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
                     break;
                 case 26:
                     downgradeFrom27to26(db);
+                    break;
+                case 27:
+                    downgradeFrom28to27(db);
                     break;
 
                 default:
@@ -142,6 +147,9 @@ public class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
         db.endTransaction();
     }
 
+    /**
+     * Add indeces for foreign key trackId
+     */
     private void upgradeFrom24to25(SQLiteDatabase db) {
         db.beginTransaction();
 
@@ -162,6 +170,9 @@ public class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
         db.endTransaction();
     }
 
+    /**
+     * Add track UUID to prevent re-import of existing tracks
+     */
     private void upgradeFrom25to26(SQLiteDatabase db) {
         db.beginTransaction();
 
@@ -198,6 +209,9 @@ public class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
         db.endTransaction();
     }
 
+    /**
+     * Add elevation gain
+     */
     private void upgradeFrom26to27(SQLiteDatabase db) {
         db.beginTransaction();
 
@@ -216,6 +230,56 @@ public class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
         db.execSQL("DROP TABLE trackpoints_old");
 
         db.execSQL("CREATE INDEX trackpoints_trackid_index ON trackpoints(trackid)");
+
+        db.setTransactionSuccessful();
+        db.endTransaction();
+    }
+
+    /**
+     * Add foreign key constraints on trackId
+     */
+    private void upgradeFrom27to28(SQLiteDatabase db) {
+        db.beginTransaction();
+
+        // TrackPoints
+        db.execSQL("ALTER TABLE trackpoints RENAME TO trackpoints_old");
+        db.execSQL("CREATE TABLE trackpoints (_id INTEGER PRIMARY KEY AUTOINCREMENT, trackid INTEGER NOT NULL, longitude INTEGER, latitude INTEGER, time INTEGER, elevation FLOAT, accuracy FLOAT, speed FLOAT, bearing FLOAT, sensor_heartrate FLOAT, sensor_cadence FLOAT, sensor_power FLOAT, elevation_gain FLOAT, FOREIGN KEY (trackid) REFERENCES tracks(_id) ON UPDATE CASCADE ON DELETE CASCADE)");
+        db.execSQL("INSERT INTO trackpoints SELECT _id, trackid, longitude, latitude, time, elevation, accuracy, speed, bearing, sensor_heartrate, sensor_cadence, sensor_power, elevation_gain FROM trackpoints_old");
+        db.execSQL("DROP TABLE trackpoints_old");
+
+        db.execSQL("CREATE INDEX trackpoints_trackid_index ON trackpoints(trackid)");
+
+        // Markers
+        db.execSQL("ALTER TABLE waypoints RENAME TO markers_old");
+        db.execSQL("CREATE TABLE markers (_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, category TEXT, icon TEXT, trackid INTEGER NOT NULL, length FLOAT, duration INTEGER, longitude INTEGER, latitude INTEGER, time INTEGER, elevation FLOAT, accuracy FLOAT, bearing FLOAT, photoUrl TEXT, FOREIGN KEY (trackid) REFERENCES tracks(_id) ON UPDATE CASCADE ON DELETE CASCADE)");
+
+        db.execSQL("INSERT INTO markers SELECT _id, name, description, category, icon, trackid, length, duration, longitude, latitude, time, elevation, accuracy, bearing, photoUrl FROM markers_old");
+        db.execSQL("DROP TABLE markers_old");
+
+        db.execSQL("CREATE INDEX markers_trackid_index ON markers(trackid)");
+
+        db.setTransactionSuccessful();
+        db.endTransaction();
+    }
+
+    private void downgradeFrom28to27(SQLiteDatabase db) {
+        db.beginTransaction();
+
+        // TrackPoints
+        db.execSQL("ALTER TABLE trackpoints RENAME TO trackpoints_old");
+        db.execSQL("CREATE TABLE trackpoints (_id INTEGER PRIMARY KEY AUTOINCREMENT, trackid INTEGER NOT NULL, longitude INTEGER, latitude INTEGER, time INTEGER, elevation FLOAT, accuracy FLOAT, speed FLOAT, bearing FLOAT, sensor_heartrate FLOAT, sensor_cadence FLOAT, sensor_power FLOAT, elevation_gain FLOAT, FOREIGN KEY (trackid) REFERENCES tracks(_id) ON UPDATE CASCADE ON DELETE CASCADE)");
+        db.execSQL("INSERT INTO trackpoints SELECT _id, trackid, longitude, latitude, time, elevation, accuracy, speed, bearing, sensor_heartrate, sensor_cadence, sensor_power, elevation_gain FROM trackpoints_old");
+        db.execSQL("DROP TABLE trackpoints_old");
+
+        db.execSQL("CREATE INDEX trackpoints_trackid_index ON trackpoints(trackid)");
+
+        // Markers
+        db.execSQL("CREATE TABLE waypoints (_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, category TEXT, icon TEXT, trackid INTEGER, length FLOAT, duration INTEGER, longitude INTEGER, latitude INTEGER, time INTEGER, elevation FLOAT, accuracy FLOAT, bearing FLOAT, photoUrl TEXT)");
+
+        db.execSQL("INSERT INTO waypoints SELECT _id, name, description, category, icon, trackid, length, duration, longitude, latitude, time, elevation, accuracy, bearing, photoUrl FROM markers");
+        db.execSQL("DROP TABLE markers");
+
+        db.execSQL("CREATE INDEX waypoints_trackid_index ON waypoints(trackid)");
 
         db.setTransactionSuccessful();
         db.endTransaction();

--- a/src/main/java/de/dennisguse/opentracks/content/provider/CustomSQLiteOpenHelper.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/CustomSQLiteOpenHelper.java
@@ -267,7 +267,7 @@ public class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
 
         // TrackPoints
         db.execSQL("ALTER TABLE trackpoints RENAME TO trackpoints_old");
-        db.execSQL("CREATE TABLE trackpoints (_id INTEGER PRIMARY KEY AUTOINCREMENT, trackid INTEGER NOT NULL, longitude INTEGER, latitude INTEGER, time INTEGER, elevation FLOAT, accuracy FLOAT, speed FLOAT, bearing FLOAT, sensor_heartrate FLOAT, sensor_cadence FLOAT, sensor_power FLOAT, elevation_gain FLOAT, FOREIGN KEY (trackid) REFERENCES tracks(_id) ON UPDATE CASCADE ON DELETE CASCADE)");
+        db.execSQL("CREATE TABLE trackpoints (_id INTEGER PRIMARY KEY AUTOINCREMENT, trackid INTEGER NOT NULL, longitude INTEGER, latitude INTEGER, time INTEGER, elevation FLOAT, accuracy FLOAT, speed FLOAT, bearing FLOAT, sensor_heartrate FLOAT, sensor_cadence FLOAT, sensor_power FLOAT, elevation_gain FLOAT)");
         db.execSQL("INSERT INTO trackpoints SELECT _id, trackid, longitude, latitude, time, elevation, accuracy, speed, bearing, sensor_heartrate, sensor_cadence, sensor_power, elevation_gain FROM trackpoints_old");
         db.execSQL("DROP TABLE trackpoints_old");
 


### PR DESCRIPTION
So far the three tables were independent of each other (from a database perspective).
I added now foreign key constraints incl. cascading deletes for trackId.
Thus, if a track get's deleted the database automatically deletes all referencing trackpoints and marker automatically.

However, this has a drawback: There is only _one_ notification for consent observer (i.e., the track got deleted). So far, we sent one for each trackpoint and marker as well.

Also the trackId column is now NOT NULL.