### PR TITLE
optimize multiple track deletion

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackDeleteActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackDeleteActivity.java
@@ -52,13 +52,7 @@ public class TrackDeleteActivity extends AbstractActivity {
             ContentProviderUtils contentProviderUtils = new ContentProviderUtils(TrackDeleteActivity.this);
 
             PowerManager.WakeLock wakeLock = SystemUtils.acquireWakeLock(TrackDeleteActivity.this, null);
-
-            for (Track.Id id : trackIds) {
-                if (Thread.interrupted()) {
-                    break;
-                }
-                contentProviderUtils.deleteTrack(TrackDeleteActivity.this, id);
-            }
+            contentProviderUtils.deleteTracks(TrackDeleteActivity.this, trackIds);
 
             wakeLock = SystemUtils.releaseWakeLock(wakeLock);
             if (Thread.interrupted()) {

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -33,6 +33,7 @@ import androidx.loader.content.Loader;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -177,6 +178,17 @@ public class ContentProviderUtils {
 
         File dir = FileUtils.getPhotoDir(context);
         FileUtils.deleteDirectoryRecurse(dir);
+    }
+
+    public void deleteTracks(Context context, @NonNull List<Track.Id> trackIds) {
+        // Delete track folder resources.
+        for (Track.Id trackId : trackIds) {
+            FileUtils.deleteDirectoryRecurse(FileUtils.getPhotoDir(context, trackId));
+        }
+
+        // Delete track last since it triggers a database vacuum call
+        String whereClause = String.format(TracksColumns._ID + " IN (%s)", TextUtils.join(",", Collections.nCopies(trackIds.size(), "?")));
+        contentResolver.delete(TracksColumns.CONTENT_URI, whereClause, trackIds.stream().map(id->Long.toString(id.getId())).toArray(String[]::new));
     }
 
     public void deleteTrack(Context context, @NonNull Track.Id trackId) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -519,9 +519,7 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
      * Cleans up import.
      */
     private void cleanImport() {
-        for (Track.Id trackId : trackIds) {
-            contentProviderUtils.deleteTrack(context, trackId);
-        }
+        contentProviderUtils.deleteTracks(context, trackIds);
     }
 
     /**


### PR DESCRIPTION
After #480 got implemented, we can now delete multiple tracks in one go and only cause DB vacuum once.

