### PR TITLE
Shrinking all APK builds without obfuscation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ android {
         buildConfigField "String", "VERSION_NAME_FULL", "\"${getVersionName()}\""
 
 
-
         minSdkVersion 21
         targetSdkVersion 30
 
@@ -68,15 +67,25 @@ android {
         debug {
             applicationIdSuffix ".debug"
             versionNameSuffix "-debug"
+
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
         }
 
         release {
-            minifyEnabled false
+            shrinkResources true
+            minifyEnabled true
+
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
         }
 
         releasePlayStore {
             applicationIdSuffix ".playstore"
             versionNameSuffix "-PlayStore"
+
+            shrinkResources true
+            minifyEnabled true
+
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
         }
     }
 

--- a/proguard-rules.txt
+++ b/proguard-rules.txt
@@ -1,0 +1,2 @@
+-dontobfuscate
+-optimizations !code/simplification/arithmetic,!field/*,!class/merging/*,!code/allocation/variable


### PR DESCRIPTION
We can save quite some space by using shrinking the APK (removing unused things; I guess mainly support library stuff) without obfuscation.

![Screenshot from 2020-11-01 09-12-42](https://user-images.githubusercontent.com/2820825/97798014-7dcd3b80-1c22-11eb-93d8-391aa249fbd8.png)

Merge after next release.
Needs some serious testing...

Fixes #433.