### PR TITLE
Update list of tested sensors with Polar H10 and Garmin SPD/CAD

### DIFF
--- a/README_TESTED_SENSORS.md
+++ b/README_TESTED_SENSORS.md
@@ -4,6 +4,7 @@
 * Decathlon|Geonaute|Kalenji Dual HRM Belt
 * moofit heart rate monitor
 * Polar H7
+* Polar H10
 * Polar OH1
   Has updatable firmware that requires a user account at polar.com
 * Wahoo Tickr (Model: WFBTHR02)
@@ -13,9 +14,11 @@ Please note that the according to the specification these sensors _may_ provide 
 However, often only one value is provided.
 
 ### Speed
+* Garmin Speed Sensor 2
 * Wahoo Speed (Model: WFRPMSPD)
 
 ### Cadence 
+* Garmin Cadence Sensor 2
 * Wahoo Cadence (Model: WFPODCAD2)
   This sensor reports cadence data as speed.
   A workaround is in place. 

--- a/README_TESTED_SENSORS.md
+++ b/README_TESTED_SENSORS.md
@@ -1,6 +1,7 @@
 # Overview of tested Bluetooth LE sensors
 
 ## HRS: Heartrate Service
+
 * Decathlon|Geonaute|Kalenji Dual HRM Belt
 * moofit heart rate monitor
 * Polar H7
@@ -10,15 +11,18 @@
 * Wahoo Tickr (Model: WFBTHR02)
 
 ## CSCP: Cycling Cadence and Speed Service
+
 Please note that the according to the specification these sensors _may_ provide speed as well as cadence.
 However, often only one value is provided.
 
 ### Speed
+
 * Garmin Speed Sensor 2
 * Wahoo Speed (Model: WFRPMSPD)
 
-### Cadence 
+### Cadence
+
 * Garmin Cadence Sensor 2
 * Wahoo Cadence (Model: WFPODCAD2)
   This sensor reports cadence data as speed.
-  A workaround is in place. 
+  A workaround is in place.


### PR DESCRIPTION
Adds three tested sensors
* "Polar H10" heart rate sensor
* "Garmin Cadence Sensor 2" cadence sensor
* "Garmin Speed Sensor 2" speed sensor

As discussed in https://github.com/OpenTracksApp/OpenTracks/pull/444

I didn't want to change unrelated lines in the file but vscode told me the Markdown should probably have empty lines around the lists
![Bildschirmfoto von 2020-11-07 08-57-38](https://user-images.githubusercontent.com/1374172/98436052-68e82080-20d8-11eb-966d-45f0ae96af88.png)
