### PR TITLE
Bugfix: NPE in import. Fixes #506.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportActivity.java
@@ -110,7 +110,7 @@ public class ImportActivity extends FragmentActivity {
 
     @Override
     public void onBackPressed() {
-        if (doubleBackToCancel || getTotalDone() == summary.getTotalCount()) {
+        if (doubleBackToCancel || (summary != null && getTotalDone() == summary.getTotalCount())) {
             super.onBackPressed();
             viewModel.cancel();
             getViewModelStore().clear();
@@ -130,7 +130,7 @@ public class ImportActivity extends FragmentActivity {
     }
 
     private int getTotalDone() {
-        return summary.getSuccessCount() + summary.getExistsCount() + summary.getErrorCount();
+        return summary != null ? summary.getSuccessCount() + summary.getExistsCount() + summary.getErrorCount() : 0;
     }
 
     private void setProgress() {


### PR DESCRIPTION
I cannot reproduce the #506 issue but it's clear that `summary` can be NULL if user press back button before view model load import data.