### PR TITLE
Optimize import (pstorch's option 4)

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -488,7 +488,7 @@ public class ContentProviderUtils {
     private void deleteMarkerPhoto(Context context, Marker marker) {
         if (marker != null && marker.hasPhoto()) {
             Uri uri = marker.getPhotoURI();
-            File file = FileUtils.getPhotoFileIfExists(context, marker.getTrackId(), uri);
+            File file = FileUtils.buildInternalPhotoFile(context, marker.getTrackId(), uri);
             if (file.exists()) {
                 File parent = file.getParentFile();
                 file.delete();
@@ -616,11 +616,20 @@ public class ContentProviderUtils {
      * @param trackId     the trackPoints id
      * @return the number of trackPoints inserted
      */
-    //TODO Only used for testing and file import; might be better to replace it.
+    //TODO Only used for testing; might be better to replace it.
     public int bulkInsertTrackPoint(TrackPoint[] trackPoints, Track.Id trackId) {
         ContentValues[] values = new ContentValues[trackPoints.length];
         for (int i = 0; i < values.length; i++) {
             values[i] = createContentValues(trackPoints[i], trackId);
+        }
+        return contentResolver.bulkInsert(TrackPointsColumns.CONTENT_URI_BY_ID, values);
+    }
+
+    //TODO Only used for file import; might be better to replace it.
+    public int bulkInsertTrackPoint(List<TrackPoint> trackPoints, Track.Id trackId) {
+        ContentValues[] values = new ContentValues[trackPoints.size()];
+        for (int i = 0; i < trackPoints.size(); i++) {
+            values[i] = createContentValues(trackPoints.get(i), trackId);
         }
         return contentResolver.bulkInsert(TrackPointsColumns.CONTENT_URI_BY_ID, values);
     }

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
@@ -167,7 +167,7 @@ public class KmlTrackWriter implements TrackWriter {
     @Override
     public void writeMarker(Marker marker) {
         if (printWriter != null && exportTrackDetail) {
-            boolean existsPhoto = FileUtils.getPhotoFileIfExists(context, marker.getTrackId(), marker.getPhotoURI()) != null;
+            boolean existsPhoto = FileUtils.buildInternalPhotoFile(context, marker.getTrackId(), marker.getPhotoURI()) != null;
             if (marker.hasPhoto() && exportPhotos && existsPhoto) {
                 float heading = getHeading(marker.getTrackId(), marker.getLocation());
                 writePhotoOverlay(marker, heading);

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
@@ -108,7 +108,7 @@ public class KmzTrackExporter implements TrackExporter {
                         Marker marker = contentProviderUtils.createMarker(cursor);
                         if (marker.hasPhoto()) {
                             Uri uriPhoto = marker.getPhotoURI();
-                            boolean existsPhoto = FileUtils.getPhotoFileIfExists(context, track.getId(), uriPhoto) != null;
+                            boolean existsPhoto = FileUtils.buildInternalPhotoFile(context, track.getId(), uriPhoto) != null;
                             if (existsPhoto) {
                                 addImage(context, zipOutputStream, uriPhoto, marker);
                             }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -126,11 +126,12 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
             return trackIds.get(0);
         } catch (IOException | SAXException | ParserConfigurationException e) {
             Log.e(TAG, "Unable to import file", e);
-            cleanImport();
+            if (trackIds.size() > 0) {
+                cleanImport();
+            }
             throw new ImportParserException(e);
         } catch (SQLiteConstraintException e) {
             Log.e(TAG, "Unable to import file", e);
-            cleanImport();
             throw new ImportAlreadyExistsException(e);
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportAlreadyExistsException.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportAlreadyExistsException.java
@@ -4,4 +4,8 @@ class ImportAlreadyExistsException extends RuntimeException {
     public ImportAlreadyExistsException(Exception e) {
         super(e);
     }
+
+    public ImportAlreadyExistsException(String msg) {
+        super(msg);
+    }
 }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
@@ -271,6 +271,7 @@ public class KmzTrackImporter implements TrackImporter {
      * Reads an image file (zipInputStream) and save it in a file called fileName inside photo folder.
      *
      * @param zipInputStream the zip input stream
+     * @param trackId        the track's id which image belongs to.
      * @param fileName       the file name
      */
     private void readAndSaveImageFile(ZipInputStream zipInputStream, Track.Id trackId, String fileName) throws IOException {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -294,6 +294,7 @@ limitations under the License.
     <string name="import_error_list_dialog_title">Files not imported</string>
     <string name="import_file_imported">File %1$s imported</string>
     <string name="import_error">Imported %1$d of %2$s from %3$s</string>
+    <string name="import_prevent_reimport">You have set prevent re-import track</string>
     <string name="import_no_directory">%1$s does not exist</string>
     <string name="import_no_file">There were no files to import. Connect your device to your computer and place the files to import in %1$s.</string>
     <string name="import_no_file_title">Import files</string>


### PR DESCRIPTION
I've coded option 1 (import in two steps) and option 4 (import in memory). I like the best option 4 and I think OOM risk is really hard. Why do I think it's difficult or impossible? I have a 900km track (more than 10 hours recording) and it has a size of 8MB in gpx file. I cannot imagine a 10 times longer track, for instance. But, even in that case the file would be 80MB size.

Also, when we'll support several tracks in an only file we have to know that this method load track one by one, so here isn't a problem either.

I also tried to figure out how options 2 and 3 would be, but for me it was difficult (maybe I don't have the needed knowledge), I didn't see it very clearly.

PS/ Don't hesitate to throw this PR away if you think memory import can be problematic ;)

That said. Here you have a analysis of import times with master branch, two steps import branch and this one (memory branch):

| Test | MAIN BRANCH | TWO STEPS IMPORT | IN MEMORY IMPORT |
|---------------|------------- |:-------------:| -----:|
| 126 GPX files (all news) | 1'13" | 1'38" | 1'11"|
| 169 GPX files (43 already exists) | 2'18" | 1'52" | 1'30" |
| 169 GPX files (169 already exists) | 4'59" | 45" | 1'11" |

PS/ All these tests have been run on an very old smartphone I have. Times in Pixel 2 XL are better in all cases.