### PR TITLE
fix #516 post workout export fails silently

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/content/data/Track.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Track.java
@@ -118,6 +118,10 @@ public class Track {
             this.id = id;
         }
 
+        protected Id(Parcel in) {
+            id = in.readLong();
+        }
+
         //TOOD Limit visibility to TrackRecordingService / ContentProvider
         public long getId() {
             return id;

--- a/src/main/java/de/dennisguse/opentracks/settings/SettingsActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/SettingsActivity.java
@@ -1,10 +1,12 @@
 package de.dennisguse.opentracks.settings;
 
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.documentfile.provider.DocumentFile;
@@ -32,8 +34,10 @@ import de.dennisguse.opentracks.util.StringUtils;
 public class SettingsActivity extends AppCompatActivity implements ChooseActivityTypeDialogFragment.ChooseActivityTypeCaller, ResetDialogPreference.ResetCallback {
 
     private static final String TAG = SettingsActivity.class.getSimpleName();
+    public static final String EXTRAS_CHECK_EXPORT_DIRECTORY = "Check Export Directory";
 
     private PrefsFragment prefsFragment;
+    private boolean checkExportDirectory = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -45,7 +49,27 @@ public class SettingsActivity extends AppCompatActivity implements ChooseActivit
         toolbar.setTitle(R.string.menu_settings);
         setSupportActionBar(toolbar);
 
+        Intent intent = getIntent();
+        if (intent != null && intent.hasExtra(EXTRAS_CHECK_EXPORT_DIRECTORY)) {
+            checkExportDirectory = true;
+        }
         onReset();
+    }
+
+    @Override
+    protected void onResume() {
+        if (checkExportDirectory) {
+            checkExportDirectory = false;
+            new AlertDialog.Builder(this)
+                    .setIcon(R.drawable.ic_logo_24dp)
+                    .setTitle(R.string.app_name)
+                    .setMessage(R.string.export_error_post_workout)
+                    .setNeutralButton(R.string.generic_ok, null)
+                    .create()
+                    .show();
+        }
+
+        super.onResume();
     }
 
     @Override

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -212,6 +212,7 @@ limitations under the License.
     <string name="export_with_photos">with photos</string>
     <string name="export_without_photos">without photos</string>
     <string name="export_error">Exported %1$d of %2$s to %3$s</string>
+    <string name="export_error_post_workout">Post-workout export failed, please check the export directory.</string>
     <string name="export_option">as %1$s to %2$s</string>
     <string name="export_progress_message">Exporting to %1$s&#8230;</string>
     <string name="export_success">Exported %1$s to %2$s</string>


### PR DESCRIPTION
Change the post workout export to use the ExportService (JobIntentService) and directing the user to the SettingsActivity in case the export failed to check the export directory.

