### PR TITLE
ActionBar now provides back functionality

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/AbstractActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/AbstractActivity.java
@@ -19,6 +19,7 @@ package de.dennisguse.opentracks;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
@@ -39,8 +40,22 @@ public abstract class AbstractActivity extends AppCompatActivity {
         setContentView(getRootView());
 
         Toolbar toolbar = findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
+        setupActionBarBack(toolbar);
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        onBackPressed();
+        return true;
     }
 
     protected abstract View getRootView();
+
+    protected void setupActionBarBack(@Nullable Toolbar toolbar) {
+        setSupportActionBar(toolbar);
+        if (toolbar != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setDisplayShowHomeEnabled(true);
+        }
+    }
 }

--- a/src/main/java/de/dennisguse/opentracks/MarkerListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/MarkerListActivity.java
@@ -222,31 +222,35 @@ public class MarkerListActivity extends AbstractActivity implements DeleteMarker
             markerIds[i] = new Marker.Id(longMarkerIds[i]);
         }
 
-        Intent intent;
-        switch (itemId) {
-            case R.id.list_context_menu_show_on_map:
-                if (markerIds.length == 1) {
-                    IntentUtils.showCoordinateOnMap(this, contentProviderUtils.getMarker(markerIds[0]));
-                }
-                return true;
-            case R.id.list_context_menu_edit:
-                if (markerIds.length == 1) {
-                    intent = IntentUtils.newIntent(this, MarkerEditActivity.class)
-                            .putExtra(MarkerEditActivity.EXTRA_MARKER_ID, markerIds[0]);
-                    startActivity(intent);
-                }
-                return true;
-            case R.id.list_context_menu_delete:
-                DeleteMarkerDialogFragment.showDialog(getSupportFragmentManager(), markerIds);
-                return true;
-            case R.id.list_context_menu_select_all:
-                for (int i = 0; i < viewBinding.markerList.getCount(); i++) {
-                    viewBinding.markerList.setItemChecked(i, true);
-                }
-                return false;
-            default:
-                return false;
+        if (itemId == R.id.list_context_menu_show_on_map) {
+            if (markerIds.length == 1) {
+                IntentUtils.showCoordinateOnMap(this, contentProviderUtils.getMarker(markerIds[0]));
+            }
+            return true;
         }
+
+        if (itemId == R.id.list_context_menu_edit) {
+            if (markerIds.length == 1) {
+                Intent intent = IntentUtils.newIntent(this, MarkerEditActivity.class)
+                        .putExtra(MarkerEditActivity.EXTRA_MARKER_ID, markerIds[0]);
+                startActivity(intent);
+            }
+            return true;
+        }
+
+        if (itemId == R.id.list_context_menu_delete) {
+            DeleteMarkerDialogFragment.showDialog(getSupportFragmentManager(), markerIds);
+            return true;
+        }
+
+        if (itemId == R.id.list_context_menu_select_all) {
+            for (int i = 0; i < viewBinding.markerList.getCount(); i++) {
+                viewBinding.markerList.setItemChecked(i, true);
+            }
+            return false;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -37,6 +37,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
+import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
 import androidx.cursoradapter.widget.ResourceCursorAdapter;
 import androidx.loader.app.LoaderManager;
@@ -241,6 +242,12 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
         loadData(getIntent());
 
         requestGPSPermissions();
+    }
+
+    @Override
+    protected void setupActionBarBack(Toolbar toolbar) {
+        setSupportActionBar(toolbar);
+        toolbar.setNavigationIcon(R.drawable.ic_logo_color_24dp);
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -469,31 +469,37 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
             trackIds[i] = new Track.Id(longTrackIds[i]);
         }
 
-        Intent intent;
-        switch (itemId) {
-            case R.id.list_context_menu_show_on_map:
-                IntentDashboardUtils.startDashboard(this, false, trackIds);
-                return true;
-            case R.id.list_context_menu_share:
-                intent = IntentUtils.newShareFileIntent(this, trackIds);
-                intent = Intent.createChooser(intent, null);
-                startActivity(intent);
-                return true;
-            case R.id.list_context_menu_edit:
-                intent = IntentUtils.newIntent(this, TrackEditActivity.class)
-                        .putExtra(TrackEditActivity.EXTRA_TRACK_ID, trackIds[0]);
-                startActivity(intent);
-                return true;
-            case R.id.list_context_menu_delete:
-                deleteTracks(trackIds);
-                return true;
-            case R.id.list_context_menu_select_all:
-                int size = viewBinding.trackList.getCount();
-                for (int i = 0; i < size; i++) {
-                    viewBinding.trackList.setItemChecked(i, true);
-                }
-                return false;
+        if (itemId == R.id.list_context_menu_show_on_map) {
+            IntentDashboardUtils.startDashboard(this, false, trackIds);
+            return true;
         }
+
+        if (itemId == R.id.list_context_menu_share) {
+            Intent intent = IntentUtils.newShareFileIntent(this, trackIds);
+            intent = Intent.createChooser(intent, null);
+            startActivity(intent);
+            return true;
+        }
+
+
+        if (itemId == R.id.list_context_menu_edit) {
+            Intent intent = IntentUtils.newIntent(this, TrackEditActivity.class)
+                    .putExtra(TrackEditActivity.EXTRA_TRACK_ID, trackIds[0]);
+            startActivity(intent);
+            return true;
+        }
+
+        if (itemId == R.id.list_context_menu_delete) {
+            deleteTracks(trackIds);
+            return true;
+        }
+        if (itemId == R.id.list_context_menu_select_all) {
+            for (int i = 0; i < viewBinding.trackList.getCount(); i++) {
+                viewBinding.trackList.setItemChecked(i, true);
+            }
+            return false;
+        }
+
         return false;
     }
 

--- a/src/main/java/de/dennisguse/opentracks/settings/SettingsActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/SettingsActivity.java
@@ -4,10 +4,10 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.View;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.DialogFragment;
@@ -18,6 +18,7 @@ import androidx.preference.PreferenceFragmentCompat;
 
 import java.util.Locale;
 
+import de.dennisguse.opentracks.AbstractActivity;
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.fragments.ChooseActivityTypeDialogFragment;
 import de.dennisguse.opentracks.io.file.TrackFileFormat;
@@ -31,7 +32,7 @@ import de.dennisguse.opentracks.util.HackUtils;
 import de.dennisguse.opentracks.util.PreferencesUtils;
 import de.dennisguse.opentracks.util.StringUtils;
 
-public class SettingsActivity extends AppCompatActivity implements ChooseActivityTypeDialogFragment.ChooseActivityTypeCaller, ResetDialogPreference.ResetCallback {
+public class SettingsActivity extends AbstractActivity implements ChooseActivityTypeDialogFragment.ChooseActivityTypeCaller, ResetDialogPreference.ResetCallback {
 
     private static final String TAG = SettingsActivity.class.getSimpleName();
     public static final String EXTRAS_CHECK_EXPORT_DIRECTORY = "Check Export Directory";
@@ -43,17 +44,22 @@ public class SettingsActivity extends AppCompatActivity implements ChooseActivit
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        setContentView(R.layout.settings);
-
-        Toolbar toolbar = findViewById(R.id.toolbar);
-        toolbar.setTitle(R.string.menu_settings);
-        setSupportActionBar(toolbar);
-
         Intent intent = getIntent();
         if (intent != null && intent.hasExtra(EXTRAS_CHECK_EXPORT_DIRECTORY)) {
             checkExportDirectory = true;
         }
         onReset();
+    }
+
+    @Override
+    protected View getRootView() {
+        return getLayoutInflater().inflate(R.layout.settings, null);
+    }
+
+    @Override
+    protected void setupActionBarBack(Toolbar toolbar) {
+        super.setupActionBarBack(toolbar);
+        toolbar.setTitle(R.string.menu_settings);
     }
 
     @Override

--- a/src/main/res/layout/toolbar.xml
+++ b/src/main/res/layout/toolbar.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:minHeight="?attr/actionBarSize"
-        app:navigationIcon="@drawable/ic_logo_color_24dp" />
+        android:minHeight="?attr/actionBarSize" />
 </merge>


### PR DESCRIPTION
The app icon is now only shown in the TrackListActivity.
In all other activities the actionBar icon now triggers the back action (same as Android navigation bar).

This feature was actually in place quite a while ago, but implemented differently.
Back then the actual target for the back action of each activity was defined in the manifest.
The new solution just uses android's activity stack to go back.
