### PR TITLE
Remove Track.Id and Marker.Id.isValid()

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
@@ -7,6 +7,8 @@ import android.util.Pair;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 import de.dennisguse.opentracks.util.FileUtils;
@@ -35,19 +37,19 @@ public class TestDataUtil {
      * @param trackId   the trackId of the track
      * @param numPoints the trackPoints number in the track
      */
-    public static Pair<Track, TrackPoint[]> createTrack(Track.Id trackId, int numPoints) {
+    public static Pair<Track, List<TrackPoint>> createTrack(Track.Id trackId, int numPoints) {
         Track track = createTrack(trackId);
 
-        TrackPoint[] trackPoints = new TrackPoint[numPoints];
+        List<TrackPoint> trackPoints = new ArrayList<>(numPoints);
         for (int i = 0; i < numPoints; i++) {
-            trackPoints[i] = createTrackPoint(i);
+            trackPoints.add(createTrackPoint(i));
         }
 
         return new Pair<>(track, trackPoints);
     }
 
     public static Track createTrackAndInsert(ContentProviderUtils contentProviderUtils, Track.Id trackId, int numPoints) {
-        Pair<Track, TrackPoint[]> pair = createTrack(trackId, numPoints);
+        Pair<Track, List<TrackPoint>> pair = createTrack(trackId, numPoints);
 
         insertTrackWithLocations(contentProviderUtils, pair.first, pair.second);
 
@@ -81,7 +83,7 @@ public class TestDataUtil {
      * @param track       track to be inserted
      * @param trackPoints trackPoints to be inserted
      */
-    public static void insertTrackWithLocations(ContentProviderUtils contentProviderUtils, Track track, TrackPoint[] trackPoints) {
+    public static void insertTrackWithLocations(ContentProviderUtils contentProviderUtils, Track track, List<TrackPoint> trackPoints) {
         contentProviderUtils.insertTrack(track);
         contentProviderUtils.bulkInsertTrackPoint(trackPoints, track.getId());
     }

--- a/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
@@ -34,7 +34,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -64,6 +63,7 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class CustomContentProviderUtilsTest {
+
     private static final String NAME_PREFIX = "test name";
     private static final String MOCK_DESC = "Mock Next Marker Desc!";
     private static final String TEST_DESC = "Test Desc!";
@@ -131,14 +131,14 @@ public class CustomContentProviderUtilsTest {
         track = contentProviderUtils.getTrack(id);
         assertNotNull(track);
 
-        TrackPoint[] trackPoints = new TrackPoint[numPoints];
+        List<TrackPoint> trackPoints = new ArrayList<>(numPoints);
         for (int i = 0; i < numPoints; ++i) {
             Location loc = new Location("test");
             loc.setLatitude(37.0 + (double) i / 10000.0);
             loc.setLongitude(57.0 - (double) i / 10000.0);
             loc.setAccuracy((float) i / 100.0f);
             loc.setAltitude(i * 2.5);
-            trackPoints[i] = new TrackPoint(loc);
+            trackPoints.add(new TrackPoint(loc));
         }
         contentProviderUtils.bulkInsertTrackPoint(trackPoints, id);
 
@@ -420,7 +420,7 @@ public class CustomContentProviderUtilsTest {
     @Test
     public void testCreateContentValues_marker() {
         Track.Id trackId = new Track.Id(System.currentTimeMillis());
-        Pair<Track, TrackPoint[]> track = TestDataUtil.createTrack(trackId, 10);
+        Pair<Track, List<TrackPoint>> track = TestDataUtil.createTrack(trackId, 10);
 
         // Bottom
         long startTime = 1000L;
@@ -439,7 +439,7 @@ public class CustomContentProviderUtilsTest {
         track.first.setTrackStatistics(statistics);
         contentProviderUtils.insertTrack(track.first);
 
-        Marker marker = new Marker(trackId, track.second[0]);
+        Marker marker = new Marker(trackId, track.second.get(0));
         marker.setDescription(TEST_DESC);
         contentProviderUtils.insertMarker(marker);
 
@@ -754,19 +754,19 @@ public class CustomContentProviderUtilsTest {
     }
 
     /**
-     * Tests the method {@link ContentProviderUtils#bulkInsertTrackPoint(TrackPoint[], Track.Id)}.
+     * Tests the method {@link ContentProviderUtils#bulkInsertTrackPoint(List, Track.Id)}.
      */
     @Test
     public void testBulkInsertTrackPoint() {
         // given
         Track.Id trackId = new Track.Id(System.currentTimeMillis());
-        Pair<Track, TrackPoint[]> track = TestDataUtil.createTrack(trackId, 10);
+        Pair<Track, List<TrackPoint>> track = TestDataUtil.createTrack(trackId, 10);
         TestDataUtil.insertTrackWithLocations(contentProviderUtils, track.first, track.second);
 
         // when / then
         contentProviderUtils.bulkInsertTrackPoint(track.second, trackId);
         assertEquals(20, contentProviderUtils.getTrackPointCursor(trackId, -1L, 1000).getCount());
-        contentProviderUtils.bulkInsertTrackPoint(Arrays.copyOfRange(track.second, 0, 8), trackId);
+        contentProviderUtils.bulkInsertTrackPoint(track.second.subList(0, 8), trackId);
         assertEquals(28, contentProviderUtils.getTrackPointCursor(trackId, -1L, 1000).getCount());
     }
 
@@ -866,12 +866,12 @@ public class CustomContentProviderUtilsTest {
     public void testGetTrackPointCursor_asc() {
         // given
         Track.Id trackId = new Track.Id(System.currentTimeMillis());
-        Pair<Track, TrackPoint[]> track = TestDataUtil.createTrack(trackId, 10);
+        Pair<Track, List<TrackPoint>> track = TestDataUtil.createTrack(trackId, 10);
         contentProviderUtils.insertTrack(track.first);
 
-        long[] trackpointIds = new long[track.second.length];
+        long[] trackpointIds = new long[track.second.size()];
         for (int i = 0; i < trackpointIds.length; i++) {
-            trackpointIds[i] = ContentUris.parseId(contentProviderUtils.insertTrackPoint(track.second[i], track.first.getId()));
+            trackpointIds[i] = ContentUris.parseId(contentProviderUtils.insertTrackPoint(track.second.get(i), track.first.getId()));
         }
 
         // when
@@ -885,12 +885,12 @@ public class CustomContentProviderUtilsTest {
     public void testGetTrackPointLocationIterator_asc() {
         // given
         Track.Id trackId = new Track.Id(System.currentTimeMillis());
-        Pair<Track, TrackPoint[]> track = TestDataUtil.createTrack(trackId, 10);
+        Pair<Track, List<TrackPoint>> track = TestDataUtil.createTrack(trackId, 10);
         contentProviderUtils.insertTrack(track.first);
 
-        long[] trackpointIds = new long[track.second.length];
+        long[] trackpointIds = new long[track.second.size()];
         for (int i = 0; i < trackpointIds.length; i++) {
-            trackpointIds[i] = ContentUris.parseId(contentProviderUtils.insertTrackPoint(track.second[i], track.first.getId()));
+            trackpointIds[i] = ContentUris.parseId(contentProviderUtils.insertTrackPoint(track.second.get(i), track.first.getId()));
         }
 
         long startTrackPointId = trackpointIds[0];

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -18,7 +18,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import de.dennisguse.opentracks.R;
@@ -62,7 +61,7 @@ public class ExportImportTest {
 
     @Before
     public void setUp() {
-        Pair<Track, TrackPoint[]> track = TestDataUtil.createTrack(trackId, 10);
+        Pair<Track, List<TrackPoint>> track = TestDataUtil.createTrack(trackId, 10);
         track.first.setIcon(TRACK_ICON);
         track.first.setCategory(TRACK_CATEGORY);
         track.first.setDescription(TRACK_DESCRIPTION);
@@ -70,10 +69,10 @@ public class ExportImportTest {
         contentProviderUtils.bulkInsertTrackPoint(track.second, track.first.getId());
 
         trackPoints.clear();
-        trackPoints.addAll(Arrays.asList(track.second));
+        trackPoints.addAll(track.second);
 
         for (int i = 0; i < 3; i++) {
-            Marker marker = new Marker(trackId, track.second[i].getLocation());
+            Marker marker = new Marker(trackId, track.second.get(i).getLocation());
             marker.setName("the marker " + i);
             marker.setDescription("the marker description " + i);
             marker.setCategory("the marker category" + i);

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTest.java
@@ -328,7 +328,7 @@ public class TrackRecordingServiceTest {
     }
 
     private void addTrack(Track track, boolean isRecording) {
-        assertTrue(track.getId().isValid());
+        assertNotNull(track.getId());
         contentProviderUtils.insertTrack(track);
         assertEquals(track.getId(), contentProviderUtils.getTrack(track.getId()).getId());
         PreferencesUtils.setLong(context, R.string.recording_track_id_key, isRecording ? track.getId().getId() : PreferencesUtils.RECORDING_TRACK_ID_DEFAULT);

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLooper.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLooper.java
@@ -203,7 +203,7 @@ public class TrackRecordingServiceTestLooper {
 
         // Start a track.
         Track.Id trackId = service.startNewTrack();
-        assertTrue(trackId.isValid());
+        assertNotNull(trackId);
         assertTrue(service.isRecording());
         Track track = contentProviderUtils.getTrack(trackId);
         assertNotNull(track);

--- a/src/androidTest/java/de/dennisguse/opentracks/util/AnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/AnnouncementUtilsTest.java
@@ -8,7 +8,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Arrays;
 import java.util.List;
 
 import de.dennisguse.opentracks.R;
@@ -50,7 +49,7 @@ public class AnnouncementUtilsTest {
         stats.setMaxSpeed(100);
         stats.setTotalElevationGain(6000);
 
-        List<TrackPoint> trackPoints = Arrays.asList(TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second);
+        List<TrackPoint> trackPoints = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second;
         IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, 1000);
         IntervalStatistics.Interval lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
 

--- a/src/androidTest/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsTest.java
@@ -1,12 +1,9 @@
 package de.dennisguse.opentracks.viewmodels;
 
-import android.util.Pair;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.Arrays;
 import java.util.List;
 
 import de.dennisguse.opentracks.content.data.TestDataUtil;
@@ -24,8 +21,7 @@ public class IntervalStatisticsTest {
 	private static final String TAG = IntervalStatisticsTest.class.getSimpleName();
 
 	private List<TrackPoint> buildTrackPoints(int numberOfTrackPoints) {
-		Pair<Track, TrackPoint[]> pair = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), numberOfTrackPoints);
-		return Arrays.asList(pair.second);
+		return TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), numberOfTrackPoints).second;
 	}
 
 	private TrackStatistics buildTrackStatistics(List<TrackPoint> trackPoints) {

--- a/src/main/java/de/dennisguse/opentracks/TrackEditActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackEditActivity.java
@@ -58,7 +58,7 @@ public class TrackEditActivity extends AbstractActivity implements ChooseActivit
 
         trackRecordingServiceConnection = new TrackRecordingServiceConnection();
         Track.Id trackId = getIntent().getParcelableExtra(EXTRA_TRACK_ID);
-        if (!trackId.isValid()) {
+        if (trackId == null) {
             Log.e(TAG, "invalid trackId");
             finish();
             return;

--- a/src/main/java/de/dennisguse/opentracks/adapters/SensorsAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/adapters/SensorsAdapter.java
@@ -76,10 +76,10 @@ public class SensorsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
     }
 
     private class ViewHolder extends RecyclerView.ViewHolder {
-        TextView label;
-        TextView sensorValue;
-        TextView value;
-        TextView unit;
+        final TextView label;
+        final TextView sensorValue;
+        final TextView value;
+        final TextView unit;
 
         public ViewHolder(@NonNull View itemView) {
             super(itemView);

--- a/src/main/java/de/dennisguse/opentracks/content/TrackDataHub.java
+++ b/src/main/java/de/dennisguse/opentracks/content/TrackDataHub.java
@@ -364,7 +364,7 @@ public class TrackDataHub implements SharedPreferences.OnSharedPreferenceChangeL
         int samplingFrequency = -1;
         boolean includeNextPoint = false;
 
-        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(selectedTrackId, localLastSeenTrackPointIdId + 1, false)) {
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(selectedTrackId, localLastSeenTrackPointIdId + 1)) {
 
             while (trackPointIterator.hasNext()) {
                 TrackPoint trackPoint = trackPointIterator.next();

--- a/src/main/java/de/dennisguse/opentracks/content/data/Marker.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Marker.java
@@ -82,8 +82,8 @@ public final class Marker {
     /**
      * May be null if the it was not loaded from the database.
      */
-    public @Nullable
-    Id getId() {
+    @Nullable
+    public Id getId() {
         return id;
     }
 
@@ -123,8 +123,8 @@ public final class Marker {
         this.icon = icon;
     }
 
-    public @NonNull
-    Track.Id getTrackId() {
+    @NonNull
+    public Track.Id getTrackId() {
         return trackId;
     }
 
@@ -144,8 +144,8 @@ public final class Marker {
         this.duration = duration;
     }
 
-    public @NonNull
-    Location getLocation() {
+    @NonNull
+    public Location getLocation() {
         return location;
     }
 

--- a/src/main/java/de/dennisguse/opentracks/content/data/Marker.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Marker.java
@@ -27,8 +27,6 @@ import androidx.annotation.VisibleForTesting;
 
 import java.util.Objects;
 
-import de.dennisguse.opentracks.util.PreferencesUtils;
-
 /**
  * @author Leif Hendrik Wilden
  * @author Rodrigo Damazio
@@ -178,11 +176,6 @@ public final class Marker {
         //TOOD Limit visibility to TrackRecordingService / ContentProvider
         public long getId() {
             return id;
-        }
-
-        @Deprecated //TODO Use a Id of null instead
-        public boolean isValid() {
-            return id != PreferencesUtils.RECORDING_TRACK_ID_DEFAULT;
         }
 
         @Override

--- a/src/main/java/de/dennisguse/opentracks/content/data/Track.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Track.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 import de.dennisguse.opentracks.stats.TrackStatistics;
-import de.dennisguse.opentracks.util.PreferencesUtils;
 
 /**
  * A track.
@@ -125,11 +124,6 @@ public class Track {
         //TOOD Limit visibility to TrackRecordingService / ContentProvider
         public long getId() {
             return id;
-        }
-
-        @Deprecated //TODO Use a Track.Id of null instead
-        public boolean isValid() {
-            return id != PreferencesUtils.RECORDING_TRACK_ID_DEFAULT;
         }
 
         @Override

--- a/src/main/java/de/dennisguse/opentracks/content/data/Track.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Track.java
@@ -52,8 +52,8 @@ public class Track {
     /**
      * May be null if the track was not loaded from the database.
      */
-    public @Nullable
-    Id getId() {
+    @Nullable
+    public Id getId() {
         return id;
     }
 

--- a/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
@@ -17,15 +17,22 @@ package de.dennisguse.opentracks.content.data;
 
 import android.location.Location;
 import android.location.LocationManager;
+import android.os.Parcel;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Objects;
 
 /**
  * This class extends the standard Android location with extra information.
  *
  * @author Sandor Dornbush
  */
+//TODO Merge constructors by use case; we have too many.
 public class TrackPoint {
+
+    private TrackPoint.Id id;
 
     private final Location location;
 
@@ -92,8 +99,20 @@ public class TrackPoint {
         return new TrackPoint(resume);
     }
 
-    public @NonNull
-    Location getLocation() {
+    /**
+     * May be null if the track was not loaded from the database.
+     */
+    @Nullable
+    public TrackPoint.Id getId() {
+        return id;
+    }
+
+    public void setId(TrackPoint.Id id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public Location getLocation() {
         return location;
     }
 
@@ -250,5 +269,42 @@ public class TrackPoint {
     @Override
     public String toString() {
         return "time=" + getTime() + ": lat=" + getLatitude() + " lng=" + getLongitude() + " acc=" + getAccuracy();
+    }
+
+    public static class Id {
+
+        private final long id;
+
+        public Id(long id) {
+            this.id = id;
+        }
+
+        protected Id(Parcel in) {
+            id = in.readLong();
+        }
+
+        //TOOD Limit visibility to TrackRecordingService / ContentProvider
+        public long getId() {
+            return id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TrackPoint.Id id1 = (TrackPoint.Id) o;
+            return id == id1.id;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return String.valueOf(id);
+        }
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -400,10 +400,7 @@ public class ContentProviderUtils {
         return -1;
     }
 
-    public Marker getMarker(Marker.Id markerId) {
-        if (!markerId.isValid()) {
-            return null;
-        }
+    public Marker getMarker(@NonNull Marker.Id markerId) {
         try (Cursor cursor = getMarkerCursor(null, MarkerColumns._ID + "=?", new String[]{Long.toString(markerId.getId())}, MarkerColumns._ID, 1)) {
             if (cursor != null && cursor.moveToFirst()) {
                 return createMarker(cursor);
@@ -426,7 +423,7 @@ public class ContentProviderUtils {
 
         String selection;
         String[] selectionArgs;
-        if (minMarkerId != null && minMarkerId.isValid()) {
+        if (minMarkerId != null) {
             selection = MarkerColumns.TRACKID + "=? AND " + MarkerColumns._ID + ">=?";
             selectionArgs = new String[]{Long.toString(trackId.getId()), Long.toString(minMarkerId.getId())};
         } else {
@@ -506,7 +503,7 @@ public class ContentProviderUtils {
     ContentValues createContentValues(@NonNull Marker marker) {
         ContentValues values = new ContentValues();
 
-        if (marker.getId() != null && marker.getId().isValid()) {
+        if (marker.getId() != null) {
             values.put(MarkerColumns._ID, marker.getId().getId());
         }
         values.put(MarkerColumns.NAME, marker.getName());

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -588,22 +588,6 @@ public class ContentProviderUtils {
         return trackPoint;
     }
 
-    /**
-     * Inserts multiple trackPoints.
-     *
-     * @param trackPoints an array of trackPoints
-     * @param trackId     the trackPoints id
-     * @return the number of trackPoints inserted
-     */
-    //TODO Only used for testing; might be better to replace it.
-    public int bulkInsertTrackPoint(TrackPoint[] trackPoints, Track.Id trackId) {
-        ContentValues[] values = new ContentValues[trackPoints.length];
-        for (int i = 0; i < values.length; i++) {
-            values[i] = createContentValues(trackPoints[i], trackId);
-        }
-        return contentResolver.bulkInsert(TrackPointsColumns.CONTENT_URI_BY_ID, values);
-    }
-
     //TODO Only used for file import; might be better to replace it.
     public int bulkInsertTrackPoint(List<TrackPoint> trackPoints, Track.Id trackId) {
         ContentValues[] values = new ContentValues[trackPoints.size()];

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -680,27 +680,22 @@ public class ContentProviderUtils {
      * Creates a location cursor. The caller owns the returned cursor and is responsible for closing it.
      *
      * @param trackId           the track id
-     * @param startTrackPointId the starting trackPoint id. -1L to ignore
-     * @param maxLocations      maximum number of locations to return. -1 for no limit
-     * @param descending        true to sort the result in descending order (latest location first)
+     * @param startTrackPointId the starting trackPoint id. `null` to ignore
+     * @param maxLocations      maximum number of locations to return. `null` for no limit
      */
-    public Cursor getTrackPointCursor(Track.Id trackId, long startTrackPointId, int maxLocations, boolean descending) {
+    public Cursor getTrackPointCursor(Track.Id trackId, Long startTrackPointId, Integer maxLocations) {
         String selection;
         String[] selectionArgs;
-        if (startTrackPointId >= 0) {
-            String comparison = descending ? "<=" : ">=";
-            selection = TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns._ID + comparison + "?";
+        if (startTrackPointId != null) {
+            selection = TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns._ID + ">=?";
             selectionArgs = new String[]{Long.toString(trackId.getId()), Long.toString(startTrackPointId)};
         } else {
             selection = TrackPointsColumns.TRACKID + "=?";
             selectionArgs = new String[]{Long.toString(trackId.getId())};
         }
 
-        String sortOrder = TrackPointsColumns._ID;
-        if (descending) {
-            sortOrder += " DESC";
-        }
-        if (maxLocations >= 0) {
+        String sortOrder = TrackPointsColumns.DEFAULT_SORT_ORDER;
+        if (maxLocations != null) {
             sortOrder += " LIMIT " + maxLocations;
         }
         return getTrackPointCursor(null, selection, selectionArgs, sortOrder);
@@ -784,11 +779,10 @@ public class ContentProviderUtils {
      * When done with iteration, {@link TrackPointIterator#close()} must be called.
      *
      * @param trackId           the track id
-     * @param startTrackPointId the starting trackPoint id. -1L to ignore
-     * @param descending        true to sort the result in descending order (latest location first)
+     * @param startTrackPointId the starting trackPoint id. `null` to ignore
      */
-    public TrackPointIterator getTrackPointLocationIterator(final Track.Id trackId, final long startTrackPointId, final boolean descending) {
-        return new TrackPointIterator(this, trackId, startTrackPointId, descending);
+    public TrackPointIterator getTrackPointLocationIterator(final Track.Id trackId, final Long startTrackPointId) {
+        return new TrackPointIterator(this, trackId, startTrackPointId);
     }
 
     private TrackPoint findTrackPointBy(String selection, String[] selectionArgs) {
@@ -816,7 +810,7 @@ public class ContentProviderUtils {
     public List<TrackPoint> getTrackPoints(Track.Id trackId) {
         List<TrackPoint> trackPoints = null;
 
-        try (Cursor trackPointCursor = getTrackPointCursor(trackId, -1L, -1, false)) {
+        try (Cursor trackPointCursor = getTrackPointCursor(trackId, -1L, -1)) {
             if (trackPointCursor != null) {
                 trackPointCursor.moveToFirst();
                 trackPoints = new ArrayList<>(trackPointCursor.getCount());

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -23,7 +23,6 @@ import android.database.Cursor;
 import android.location.Location;
 import android.net.Uri;
 import android.text.TextUtils;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -224,7 +223,7 @@ public class ContentProviderUtils {
      * @param trackId the track id.
      */
     public Track getTrack(Track.Id trackId) {
-        if (trackId == null || !trackId.isValid()) {
+        if (trackId == null) {
             return null;
         }
         try (Cursor cursor = getTrackCursor(TracksColumns._ID + "=?", new String[]{Long.toString(trackId.getId())}, null)) {
@@ -286,7 +285,7 @@ public class ContentProviderUtils {
         TrackStatistics trackStatistics = track.getTrackStatistics();
 
         // Value < 0 indicates no id is available
-        if (track.getId() != null && track.getId().isValid()) {
+        if (track.getId() != null) {
             values.put(TracksColumns._ID, track.getId().getId());
         }
         values.put(TracksColumns.UUID, UUIDUtils.toBytes(track.getUuid()));
@@ -385,10 +384,7 @@ public class ContentProviderUtils {
     /**
      * @return -1 if not able to get the next marker number.
      */
-    public int getNextMarkerNumber(Track.Id trackId) {
-        if (!trackId.isValid()) {
-            return -1;
-        }
+    public int getNextMarkerNumber(@NonNull Track.Id trackId) {
         String[] projection = {MarkerColumns._ID};
         String selection = MarkerColumns.TRACKID + "=?";
         String[] selectionArgs = new String[]{Long.toString(trackId.getId())};
@@ -416,11 +412,7 @@ public class ContentProviderUtils {
      * @param minMarkerId the minimum marker id. null to ignore
      * @param maxCount    the maximum number of markers to return. -1 for no limit
      */
-    public Cursor getMarkerCursor(Track.Id trackId, @Nullable Marker.Id minMarkerId, int maxCount) {
-        if (!trackId.isValid()) {
-            return null;
-        }
-
+    public Cursor getMarkerCursor(@NonNull Track.Id trackId, @Nullable Marker.Id minMarkerId, int maxCount) {
         String selection;
         String[] selectionArgs;
         if (minMarkerId != null) {
@@ -449,10 +441,6 @@ public class ContentProviderUtils {
 
     @Deprecated //TODO TracksColumns.MARKER_COUNT while querying for tracks
     public int getMarkerCount(Track.Id trackId) {
-        if (!trackId.isValid()) {
-            return 0;
-        }
-
         String[] projection = new String[]{"count(*) AS count"};
         String selection = MarkerColumns.TRACKID + "=?";
         String[] selectionArgs = new String[]{Long.toString(trackId.getId())};
@@ -633,9 +621,6 @@ public class ContentProviderUtils {
      */
     @Deprecated
     public Track.Id getFirstTrackPointId(Track.Id trackId) {
-        if (!trackId.isValid()) {
-            return null;
-        }
         String selection = TrackPointsColumns._ID + "=(SELECT MIN(" + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + " WHERE " + TrackPointsColumns.TRACKID + "=?)";
         String[] selectionArgs = new String[]{Long.toString(trackId.getId())};
         try (Cursor cursor = getTrackPointCursor(new String[]{TrackPointsColumns._ID}, selection, selectionArgs, TrackPointsColumns._ID)) {
@@ -653,11 +638,7 @@ public class ContentProviderUtils {
      * @param trackId the track id
      */
     @Deprecated
-    public long getLastTrackPointId(Track.Id trackId) {
-        if (trackId == null || !trackId.isValid()) {
-            Log.w(TAG, "Fix callers who do this.");
-            return -1L;
-        }
+    public long getLastTrackPointId(@NonNull Track.Id trackId) {
         String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") from " + TrackPointsColumns.TABLE_NAME + " WHERE " + TrackPointsColumns.TRACKID + "=?)";
         String[] selectionArgs = new String[]{Long.toString(trackId.getId())};
         try (Cursor cursor = getTrackPointCursor(new String[]{TrackPointsColumns._ID}, selection, selectionArgs, TrackPointsColumns._ID)) {
@@ -676,9 +657,6 @@ public class ContentProviderUtils {
      * @return trackPoint id if the location is in the track. -1L otherwise.
      */
     public long getTrackPointId(Track.Id trackId, Location location) {
-        if (!trackId.isValid()) {
-            return -1L;
-        }
         String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + " WHERE " + TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns.TIME + "=?)";
         String[] selectionArgs = new String[]{Long.toString(trackId.getId()), Long.toString(location.getTime())};
         try (Cursor cursor = getTrackPointCursor(new String[]{TrackPointsColumns._ID}, selection, selectionArgs, TrackPointsColumns._ID)) {
@@ -707,10 +685,6 @@ public class ContentProviderUtils {
      * @param descending        true to sort the result in descending order (latest location first)
      */
     public Cursor getTrackPointCursor(Track.Id trackId, long startTrackPointId, int maxLocations, boolean descending) {
-        if (!trackId.isValid()) {
-            return null;
-        }
-
         String selection;
         String[] selectionArgs;
         if (startTrackPointId >= 0) {
@@ -740,9 +714,6 @@ public class ContentProviderUtils {
      */
     @Deprecated
     public TrackPoint getLastValidTrackPoint(Track.Id trackId) {
-        if (!trackId.isValid()) {
-            return null;
-        }
         String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + " WHERE " + TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns.LATITUDE + "<=" + MAX_LATITUDE + ")";
         String[] selectionArgs = new String[]{Long.toString(trackId.getId())};
         return findTrackPointBy(selection, selectionArgs);

--- a/src/main/java/de/dennisguse/opentracks/content/provider/TrackPointIterator.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/TrackPointIterator.java
@@ -18,16 +18,14 @@ public class TrackPointIterator implements Iterator<TrackPoint>, AutoCloseable {
 
     private final ContentProviderUtils contentProviderUtils;
     private final Track.Id trackId;
-    private final boolean descending;
     private final CachedTrackPointsIndexes indexes;
     private long lastTrackPointId = -1L;
     private Cursor cursor;
 
 
-    public TrackPointIterator(ContentProviderUtils contentProviderUtils, Track.Id trackId, long startTrackPointId, boolean descending) {
+    public TrackPointIterator(ContentProviderUtils contentProviderUtils, Track.Id trackId, Long startTrackPointId) {
         this.contentProviderUtils = contentProviderUtils;
         this.trackId = trackId;
-        this.descending = descending;
 
         cursor = getCursor(startTrackPointId);
         indexes = cursor != null ? new CachedTrackPointsIndexes(cursor)
@@ -40,14 +38,14 @@ public class TrackPointIterator implements Iterator<TrackPoint>, AutoCloseable {
      * @param trackPointId the starting track point id
      */
     private Cursor getCursor(long trackPointId) {
-        return contentProviderUtils.getTrackPointCursor(trackId, trackPointId, contentProviderUtils.getDefaultCursorBatchSize(), descending);
+        return contentProviderUtils.getTrackPointCursor(trackId, trackPointId, contentProviderUtils.getDefaultCursorBatchSize());
     }
 
     /**
      * Advances the cursor to the next batch. Returns true if successful.
      */
     private boolean advanceCursorToNextBatch() {
-        long trackPointId = lastTrackPointId == -1L ? -1L : lastTrackPointId + (descending ? -1 : 1);
+        long trackPointId = lastTrackPointId == -1L ? -1L : lastTrackPointId + 1;
         Log.d(TAG, "Advancing track point id: " + trackPointId);
         cursor.close();
         cursor = getCursor(trackPointId);

--- a/src/main/java/de/dennisguse/opentracks/content/provider/TrackPointIterator.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/TrackPointIterator.java
@@ -19,11 +19,11 @@ public class TrackPointIterator implements Iterator<TrackPoint>, AutoCloseable {
     private final ContentProviderUtils contentProviderUtils;
     private final Track.Id trackId;
     private final CachedTrackPointsIndexes indexes;
-    private long lastTrackPointId = -1L;
+    private TrackPoint.Id lastTrackPointId = null;
     private Cursor cursor;
 
 
-    public TrackPointIterator(ContentProviderUtils contentProviderUtils, Track.Id trackId, Long startTrackPointId) {
+    public TrackPointIterator(ContentProviderUtils contentProviderUtils, Track.Id trackId, TrackPoint.Id startTrackPointId) {
         this.contentProviderUtils = contentProviderUtils;
         this.trackId = trackId;
 
@@ -37,7 +37,7 @@ public class TrackPointIterator implements Iterator<TrackPoint>, AutoCloseable {
      *
      * @param trackPointId the starting track point id
      */
-    private Cursor getCursor(long trackPointId) {
+    private Cursor getCursor(TrackPoint.Id trackPointId) {
         return contentProviderUtils.getTrackPointCursor(trackId, trackPointId, contentProviderUtils.getDefaultCursorBatchSize());
     }
 
@@ -45,15 +45,11 @@ public class TrackPointIterator implements Iterator<TrackPoint>, AutoCloseable {
      * Advances the cursor to the next batch. Returns true if successful.
      */
     private boolean advanceCursorToNextBatch() {
-        long trackPointId = lastTrackPointId == -1L ? -1L : lastTrackPointId + 1;
+        TrackPoint.Id trackPointId = lastTrackPointId == null ? null : new TrackPoint.Id(lastTrackPointId.getId() + 1);
         Log.d(TAG, "Advancing track point id: " + trackPointId);
         cursor.close();
         cursor = getCursor(trackPointId);
         return cursor != null;
-    }
-
-    public long getTrackPointId() {
-        return lastTrackPointId;
     }
 
     @Override
@@ -83,7 +79,7 @@ public class TrackPointIterator implements Iterator<TrackPoint>, AutoCloseable {
                 throw new NoSuchElementException();
             }
         }
-        lastTrackPointId = cursor.getLong(indexes.idIndex);
+        lastTrackPointId = new TrackPoint.Id(cursor.getLong(indexes.idIndex));
         return ContentProviderUtils.fillTrackPoint(cursor, indexes);
     }
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/FileTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/FileTrackExporter.java
@@ -126,7 +126,7 @@ public class FileTrackExporter implements TrackExporter {
         boolean isLastLocationValid = false;
         TrackPoint lastTrackPoint = null;
 
-        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), -1L)) {
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), null)) {
 
             while (trackPointIterator.hasNext()) {
                 if (Thread.interrupted()) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/FileTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/FileTrackExporter.java
@@ -126,7 +126,7 @@ public class FileTrackExporter implements TrackExporter {
         boolean isLastLocationValid = false;
         TrackPoint lastTrackPoint = null;
 
-        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), -1L, false)) {
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), -1L)) {
 
             while (trackPointIterator.hasNext()) {
                 if (Thread.interrupted()) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
@@ -16,7 +16,6 @@
 package de.dennisguse.opentracks.io.file.exporter;
 
 import android.content.Context;
-import android.database.Cursor;
 import android.location.Location;
 
 import java.io.OutputStream;
@@ -403,15 +402,12 @@ public class KmlTrackWriter implements TrackWriter {
         if (trackPointId == -1L) {
             return location.getBearing();
         }
-        TrackPoint viewLocation;
-        try (Cursor cursor = contentProviderUtils.getTrackPointCursor(trackId, trackPointId, 10, true)) {
-            if (cursor == null || cursor.getCount() == 0) {
-                return location.getBearing();
-            }
-            cursor.moveToPosition(cursor.getCount() - 1);
-            viewLocation = contentProviderUtils.createTrackPoint(cursor);
+        TrackPoint viewLocation = contentProviderUtils.getLastValidTrackPoint(trackId);
+        if (viewLocation != null) {
+            return viewLocation.bearingTo(location);
         }
-        return viewLocation.bearingTo(location);
+
+        return location.getBearing();
     }
 
     private String getCoordinates(Location location, String separator) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackWriter.java
@@ -398,8 +398,8 @@ public class KmlTrackWriter implements TrackWriter {
      * @param location the location
      */
     private float getHeading(Track.Id trackId, Location location) {
-        long trackPointId = contentProviderUtils.getTrackPointId(trackId, location);
-        if (trackPointId == -1L) {
+        TrackPoint.Id trackPointId = contentProviderUtils.getTrackPointId(trackId, location);
+        if (trackPointId == null) {
             return location.getBearing();
         }
         TrackPoint viewLocation = contentProviderUtils.getLastValidTrackPoint(trackId);

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -158,7 +158,7 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
         // TODO Should not be necessary anymore?
         TrackStatisticsUpdater markerTrackStatisticsUpdater = new TrackStatisticsUpdater(track.getTrackStatistics().getStartTime_ms());
 
-        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), -1L, false)) {
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), -1L)) {
 
             while (true) {
                 if (marker == null) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -158,7 +158,7 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
         // TODO Should not be necessary anymore?
         TrackStatisticsUpdater markerTrackStatisticsUpdater = new TrackStatisticsUpdater(track.getTrackStatistics().getStartTime_ms());
 
-        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), -1L)) {
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), null)) {
 
             while (true) {
                 if (marker == null) {

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -352,7 +352,7 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
 
         trackStatisticsUpdater = new TrackStatisticsUpdater(track.getTrackStatistics().getStartTime_ms());
 
-        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), -1L)) {
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), null)) {
             trackStatisticsUpdater.addTrackPoint(trackPointIterator, recordingDistanceInterval);
         } catch (RuntimeException e) {
             Log.e(TAG, "RuntimeException", e);

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -352,7 +352,7 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
 
         trackStatisticsUpdater = new TrackStatisticsUpdater(track.getTrackStatistics().getStartTime_ms());
 
-        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), -1L, false)) {
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), -1L)) {
             trackStatisticsUpdater.addTrackPoint(trackPointIterator, recordingDistanceInterval);
         } catch (RuntimeException e) {
             Log.e(TAG, "RuntimeException", e);


### PR DESCRIPTION
isValid() should not be necessary.
We can just use null as Track.Id or Marker.Id if the marker/track was not loaded from the database.