### PR TITLE
Share markers from list

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/MarkerListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/MarkerListActivity.java
@@ -93,14 +93,11 @@ public class MarkerListActivity extends AbstractActivity implements DeleteMarker
         public void onPrepare(Menu menu, int[] positions, long[] ids, boolean showSelectAll) {
             boolean isSingleSelection = ids.length == 1;
 
-            menu.findItem(R.id.list_context_menu_share).setVisible(false);
             menu.findItem(R.id.list_context_menu_show_on_map).setVisible(isSingleSelection);
             menu.findItem(R.id.list_context_menu_edit).setVisible(isSingleSelection);
             menu.findItem(R.id.list_context_menu_delete).setVisible(true);
-            /*
-             * Set select all to the same visibility as delete since delete is the
-             * only action that can be applied to multiple markers.
-             */
+
+            // Set select all to the same visibility as delete since delete is the only action that can be applied to multiple markers.
             menu.findItem(R.id.list_context_menu_select_all).setVisible(showSelectAll);
         }
 
@@ -225,6 +222,15 @@ public class MarkerListActivity extends AbstractActivity implements DeleteMarker
         if (itemId == R.id.list_context_menu_show_on_map) {
             if (markerIds.length == 1) {
                 IntentUtils.showCoordinateOnMap(this, contentProviderUtils.getMarker(markerIds[0]));
+            }
+            return true;
+        }
+
+        if (itemId == R.id.list_context_menu_share) {
+            Intent intent = IntentUtils.newShareFileIntent(this, markerIds);
+            if (intent != null) {
+                intent = Intent.createChooser(intent, null);
+                startActivity(intent);
             }
             return true;
         }

--- a/src/main/java/de/dennisguse/opentracks/fragments/MarkerDetailFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/MarkerDetailFragment.java
@@ -207,7 +207,7 @@ public class MarkerDetailFragment extends Fragment {
 
         if (item.getItemId() == R.id.marker_detail_share) {
             if (marker.hasPhoto()) {
-                Intent intent = IntentUtils.newShareImageIntent(getContext(), marker.getPhotoURI());
+                Intent intent = IntentUtils.newShareFileIntent(getContext(), marker.getId());
                 intent = Intent.createChooser(intent, null);
                 startActivity(intent);
             }


### PR DESCRIPTION
Marker images can now be shared from the list directly via the contet menu (like tracks).

Fixes #495.