### PR TITLE
Added opentracks:gain and opentracks:loss information in GPX files

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
@@ -17,6 +17,7 @@ public class TestDataUtil {
     public static final double INITIAL_LONGITUDE = -57.0;
     public static final double ALTITUDE_INTERVAL = 2.5;
     public static final float ELEVATION_GAIN = 3;
+    public static final float ELEVATION_LOSS = 3;
 
     /**
      * Create a track without any trackPoints.
@@ -72,6 +73,7 @@ public class TestDataUtil {
         trackPoint.setCyclingCadence_rpm(300f + i);
         trackPoint.setPower(400f + i);
         trackPoint.setElevationGain(ELEVATION_GAIN);
+        trackPoint.setElevationLoss(ELEVATION_LOSS);
         return trackPoint;
     }
 

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -135,7 +135,7 @@ public class ExportImportTest {
         assertMarkers();
 
         // 3. trackpoints
-        assertTrackpoints(false, false, false, false);
+        assertTrackpoints(false, false, false, false, false);
     }
 
     @LargeTest
@@ -170,7 +170,7 @@ public class ExportImportTest {
         assertMarkers();
 
         // 3. trackpoints
-        assertTrackpoints(true, true, true, true);
+        assertTrackpoints(true, true, true, true, true);
     }
 
     @LargeTest
@@ -263,7 +263,7 @@ public class ExportImportTest {
         assertMarkers();
 
         // 3. trackpoints
-        assertTrackpoints(false, true, true, false);
+        assertTrackpoints(false, true, true, true, true);
     }
 
     @LargeTest
@@ -310,7 +310,7 @@ public class ExportImportTest {
         }
     }
 
-    private void assertTrackpoints(boolean verifyPower, boolean verifyHeartrate, boolean verifyCadence, boolean verifyElevationGain) {
+    private void assertTrackpoints(boolean verifyPower, boolean verifyHeartrate, boolean verifyCadence, boolean verifyElevationGain, boolean verifyElevationLoss) {
         List<TrackPoint> importedTrackPoints = contentProviderUtils.getTrackPoints(importTrackId);
         assertEquals(trackPoints.size(), importedTrackPoints.size());
 
@@ -338,6 +338,9 @@ public class ExportImportTest {
             }
             if (verifyElevationGain) {
                 assertEquals(trackPoint.getElevationGain(), importedTrackPoint.getElevationGain(), 0.01);
+            }
+            if (verifyElevationLoss) {
+                assertEquals(trackPoint.getElevationLoss(), importedTrackPoint.getElevationLoss(), 0.01);
             }
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GpxTrackWriter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GpxTrackWriter.java
@@ -197,9 +197,8 @@ public class GpxTrackWriter implements TrackWriter {
 
             printWriter.println("<time>" + StringUtils.formatDateTimeIso8601(trackPoint.getTime()) + "</time>");
 
-            if (trackPoint.hasSpeed() || trackPoint.hasHeartRate() || trackPoint.hasCyclingCadence()) {
+            if (trackPoint.hasSpeed() || trackPoint.hasHeartRate() || trackPoint.hasCyclingCadence() || trackPoint.hasElevationGain() || trackPoint.hasElevationLoss()) {
                 printWriter.println("<extensions><gpxtpx:TrackPointExtension>");
-
 
                 if (trackPoint.hasSpeed()) {
                     printWriter.println("<gpxtpx:speed>" + SPEED_FORMAT.format(trackPoint.getSpeed()) + "</gpxtpx:speed>");
@@ -211,6 +210,14 @@ public class GpxTrackWriter implements TrackWriter {
 
                 if (trackPoint.hasCyclingCadence()) {
                     printWriter.println("<gpxtpx:cad>" + HEARTRATE_FORMAT.format(trackPoint.getCyclingCadence_rpm()) + "</gpxtpx:cad>");
+                }
+
+                if (trackPoint.hasElevationGain()) {
+                    printWriter.println("<opentracks:gain>" + ELEVATION_FORMAT.format(trackPoint.getElevationGain()) + "</opentracks:gain>");
+                }
+
+                if (trackPoint.hasElevationLoss()) {
+                    printWriter.println("<opentracks:loss>" + ELEVATION_FORMAT.format(trackPoint.getElevationLoss()) + "</opentracks:loss>");
                 }
 
                 printWriter.println("</gpxtpx:TrackPointExtension></extensions>");

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -86,6 +86,8 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
     protected String markerType;
     protected String photoUrl;
     protected String uuid;
+    protected String gain;
+    protected String loss;
 
     // The current track data
     private TrackData trackData;
@@ -464,6 +466,21 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
                 trackPoint.setCyclingCadence_rpm(Float.parseFloat(cadence));
             } catch (Exception e) {
                 throw new SAXException(createErrorMessage(String.format(Locale.US, "Unable to parse cadence: %s", cadence)), e);
+            }
+        }
+
+        if (gain != null) {
+            try {
+                trackPoint.setElevationGain(Float.parseFloat(gain));
+            } catch (Exception e) {
+                throw new SAXException(createErrorMessage(String.format(Locale.US, "Unable to parse elevation gain: %s", gain)), e);
+            }
+        }
+        if (loss != null) {
+            try {
+                trackPoint.setElevationLoss(Float.parseFloat(loss));
+            } catch (Exception e) {
+                throw new SAXException(createErrorMessage(String.format(Locale.US, "Unable to parse elevation loss: %s", loss)), e);
             }
         }
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
@@ -54,6 +54,9 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
     private static final String TAG_EXTENSION_HEARTRATE = "gpxtpx:hr";
     private static final String TAG_EXTENSION_CADENCE = "gpxtpx:cad";
 
+    private static final String TAG_EXTENSION_GAIN = "opentracks:gain";
+    private static final String TAG_EXTENSION_LOSS = "opentracks:loss";
+
     /**
      * Constructor.
      *
@@ -151,6 +154,16 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
                     uuid = content.trim();
                 }
                 break;
+            case TAG_EXTENSION_GAIN:
+                if (content != null) {
+                    gain = content.trim();
+                }
+                break;
+            case TAG_EXTENSION_LOSS:
+                if (content != null) {
+                    loss = content.trim();
+                }
+                break;
         }
 
         // Reset element content
@@ -176,6 +189,8 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
         altitude = null;
         time = null;
         speed = null;
+        gain = null;
+        loss = null;
     }
 
     /**


### PR DESCRIPTION
**Describe the pull request**
OT lost elevation gain/loss after export and import process. Fixed.

I've added `<opentracks:gain>` and `<opentracks:loss>` tags from  to GPX files.

**Link to the the issue**
#555 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).