### PR TITLE
Import/Export UI improvement and offer "Open Track" when one track is imported

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportActivity.java
@@ -268,7 +268,14 @@ public class ExportActivity extends FragmentActivity implements ExportServiceRes
         viewBinding.exportProgressTotal.setText("" + trackExportTotalCount);
 
         viewBinding.exportProgressBar.setProgress((int) ((float) done / (float) trackExportTotalCount * 100f));
-        viewBinding.exportProgressSummary.setText(getString(R.string.export_progress_review, getTotalDone(), trackExportSuccessCount, trackExportOverwrittenCount, trackExportSkippedCount, trackExportErrorCount));
+        viewBinding.exportProgressSummaryNew.setText(String.valueOf(trackExportSuccessCount));
+        viewBinding.exportProgressSummaryOverwrite.setText(String.valueOf(trackExportOverwrittenCount));
+        viewBinding.exportProgressSummarySkip.setText(String.valueOf(trackExportSkippedCount));
+        viewBinding.exportProgressSummaryErrors.setText(String.valueOf(trackExportErrorCount));
+        viewBinding.exportProgressSummaryNewGroup.setVisibility(trackExportSuccessCount > 0 ? View.VISIBLE : View.GONE);
+        viewBinding.exportProgressSummaryOverwriteGroup.setVisibility(trackExportOverwrittenCount > 0 ? View.VISIBLE : View.GONE);
+        viewBinding.exportProgressSummarySkipGroup.setVisibility(trackExportSkippedCount > 0 ? View.VISIBLE : View.GONE);
+        viewBinding.exportProgressSummaryErrorsGroup.setVisibility(trackExportErrorCount > 0 ? View.VISIBLE : View.GONE);
     }
 
     private void onExportCompleted(Track.Id trackId) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportActivity.java
@@ -127,7 +127,9 @@ public class ImportActivity extends FragmentActivity {
     private void initViews() {
         viewBinding.importProgressDone.setText("0");
         viewBinding.importProgressTotal.setText("0");
-        viewBinding.importProgressSummary.setText(getString(R.string.import_progress_review, 0, 0, 0, 0));
+        viewBinding.importProgressSummaryOk.setText("0");
+        viewBinding.importProgressSummaryExists.setText("0");
+        viewBinding.importProgressSummaryErrors.setText("0");
     }
 
     private int getTotalDone() {
@@ -141,7 +143,12 @@ public class ImportActivity extends FragmentActivity {
         viewBinding.importProgressTotal.setText("" + summary.getTotalCount());
 
         viewBinding.importProgressBar.setProgress((int) ((float) done / (float) summary.getTotalCount() * 100f));
-        viewBinding.importProgressSummary.setText(getString(R.string.import_progress_review, getTotalDone(), summary.getSuccessCount(), summary.getExistsCount(), summary.getErrorCount()));
+        viewBinding.importProgressSummaryOk.setText(String.valueOf(summary.getSuccessCount()));
+        viewBinding.importProgressSummaryExists.setText(String.valueOf(summary.getExistsCount()));
+        viewBinding.importProgressSummaryErrors.setText(String.valueOf(summary.getErrorCount()));
+        viewBinding.importProgressSummaryOkGroup.setVisibility(summary.getSuccessCount() > 0 ? View.VISIBLE : View.GONE);
+        viewBinding.importProgressSummaryExistsGroup.setVisibility(summary.getExistsCount() > 0 ? View.VISIBLE : View.GONE);
+        viewBinding.importProgressSummaryErrorsGroup.setVisibility(summary.getErrorCount() > 0 ? View.VISIBLE : View.GONE);
 
         if (done == summary.getTotalCount()) {
             onImportEnded();

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportViewModel.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportViewModel.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.util.FileUtils;
 
 public class ImportViewModel extends AndroidViewModel implements ImportServiceResultReceiver.Receiver {
@@ -65,6 +66,7 @@ public class ImportViewModel extends AndroidViewModel implements ImportServiceRe
             throw new RuntimeException(TAG + ": onReceiveResult resultData NULL");
         }
 
+        Track.Id trackId = resultData.getParcelable(ImportServiceResultReceiver.RESULT_EXTRA_TRACK_ID);
         String fileName = resultData.getString(ImportServiceResultReceiver.RESULT_EXTRA_FILENAME);
         String message = resultData.getString(ImportServiceResultReceiver.RESULT_EXTRA_MESSAGE);
 
@@ -74,6 +76,7 @@ public class ImportViewModel extends AndroidViewModel implements ImportServiceRe
                 summary.fileErrors.add(getApplication().getString(R.string.import_error_info, fileName, message));
                 break;
             case ImportServiceResultReceiver.RESULT_CODE_IMPORTED:
+                summary.importedTrackIds.add(trackId);
                 summary.successCount++;
                 break;
             case ImportServiceResultReceiver.RESULT_CODE_ALREADY_EXISTS:
@@ -92,6 +95,7 @@ public class ImportViewModel extends AndroidViewModel implements ImportServiceRe
         private int successCount;
         private int existsCount;
         private int errorCount;
+        private ArrayList<Track.Id> importedTrackIds = new ArrayList<>();
         private final ArrayList<String> fileErrors = new ArrayList<>();
 
         public int getTotalCount() {
@@ -108,6 +112,10 @@ public class ImportViewModel extends AndroidViewModel implements ImportServiceRe
 
         public int getErrorCount() {
             return errorCount;
+        }
+
+        public ArrayList<Track.Id> getImportedTrackIds() {
+            return importedTrackIds;
         }
 
         public ArrayList<String> getFileErrors() {

--- a/src/main/res/layout/export_activity.xml
+++ b/src/main/res/layout/export_activity.xml
@@ -21,9 +21,16 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guideline_vertical_half"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.7" />
+
             <TextView
                 android:id="@+id/export_progress_done"
-                style="@style/TextMedium"
+                style="@style/TextMediumPrimary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="24dp"
@@ -36,7 +43,7 @@
 
             <TextView
                 android:id="@+id/export_progress_slash"
-                style="@style/TextMedium"
+                style="@style/TextMediumPrimary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/generic_separator_done_total"
@@ -47,7 +54,7 @@
 
             <TextView
                 android:id="@+id/export_progress_total"
-                style="@style/TextMedium"
+                style="@style/TextMediumPrimary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="24dp"
@@ -70,16 +77,139 @@
                 app:layout_constraintTop_toBottomOf="@id/export_progress_done"
                 tools:progress="25" />
 
+            <!-- Start Summary -->
+            <!-- Tracks exported (new tracks) -->
             <TextView
-                android:id="@+id/export_progress_summary"
-                style="@style/TextMedium"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_margin="24dp"
-                android:text="@string/export_progress_review"
-                app:layout_constraintEnd_toEndOf="parent"
+                android:id="@+id/export_progress_summary_new_msg"
+                style="@style/TextImportExportSummaryStart"
+                android:text="@string/export_progress_summary_new_msg"
+                app:layout_constraintEnd_toEndOf="@id/guideline_vertical_half"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/export_progress_bar" />
+
+            <TextView
+                android:id="@+id/export_progress_summary_new"
+                style="@style/TextImportExportSummaryEnd"
+                app:layout_constraintBottom_toBottomOf="@id/export_progress_summary_new_msg"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintTop_toTopOf="@id/export_progress_summary_new_msg"
+                tools:text="10" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/export_progress_summary_new_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="export_progress_summary_new_msg,export_progress_summary_new" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/export_progress_summary_new_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible"
+                app:constraint_referenced_ids="export_progress_summary_new_msg,export_progress_summary_new" />
+
+            <!-- Tracks overwritten -->
+            <TextView
+                android:id="@+id/export_progress_summary_overwrite_msg"
+                style="@style/TextImportExportSummaryStart"
+                android:text="@string/export_progress_summary_overwrite_msg"
+                app:layout_constraintEnd_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/export_progress_summary_new_barrier" />
+
+            <TextView
+                android:id="@+id/export_progress_summary_overwrite"
+                style="@style/TextImportExportSummaryEnd"
+                app:layout_constraintBottom_toBottomOf="@id/export_progress_summary_overwrite_msg"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintTop_toTopOf="@id/export_progress_summary_overwrite_msg"
+                tools:text="10" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/export_progress_summary_overwrite_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="export_progress_summary_overwrite_msg,export_progress_summary_overwrite" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/export_progress_summary_overwrite_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible"
+                app:constraint_referenced_ids="export_progress_summary_overwrite_msg,export_progress_summary_overwrite" />
+
+            <!-- Tracks skipped -->
+            <TextView
+                android:id="@+id/export_progress_summary_skip_msg"
+                style="@style/TextImportExportSummaryStart"
+                android:text="@string/export_progress_summary_skip_msg"
+                app:layout_constraintEnd_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/export_progress_summary_overwrite_barrier" />
+
+            <TextView
+                android:id="@+id/export_progress_summary_skip"
+                style="@style/TextImportExportSummaryEnd"
+                app:layout_constraintBottom_toBottomOf="@id/export_progress_summary_skip_msg"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintTop_toTopOf="@id/export_progress_summary_skip_msg"
+                tools:text="10" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/export_progress_summary_skip_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="export_progress_summary_skip_msg,export_progress_summary_skip" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/export_progress_summary_skip_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible"
+                app:constraint_referenced_ids="export_progress_summary_skip_msg,export_progress_summary_skip" />
+
+            <!-- Tracks errors -->
+            <TextView
+                android:id="@+id/export_progress_summary_errors_msg"
+                style="@style/TextImportExportSummaryStart"
+                android:text="@string/export_progress_summary_errors_msg"
+                app:layout_constraintEnd_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/export_progress_summary_skip_barrier" />
+
+            <TextView
+                android:id="@+id/export_progress_summary_errors"
+                style="@style/TextImportExportSummaryEnd"
+                app:layout_constraintBottom_toBottomOf="@id/export_progress_summary_errors_msg"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintTop_toTopOf="@id/export_progress_summary_errors_msg"
+                tools:text="10" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/export_progress_summary_errors_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="export_progress_summary_errors_msg,export_progress_summary_errors" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/export_progress_summary_errors_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible"
+                app:constraint_referenced_ids="export_progress_summary_errors_msg,export_progress_summary_errors" />
+            <!-- End Summary -->
 
             <ImageView
                 android:id="@+id/export_progress_alert_icon"
@@ -96,16 +226,16 @@
 
             <TextView
                 android:id="@+id/export_progress_alert_msg"
-                style="@style/TextMedium"
+                style="@style/TextMediumPrimary"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
+                android:layout_marginTop="48dp"
                 android:layout_marginEnd="24dp"
                 android:layout_marginBottom="24dp"
                 app:layout_constraintBottom_toTopOf="@id/export_progress_apply_to_all"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/export_progress_alert_icon"
-                app:layout_constraintTop_toBottomOf="@id/export_progress_summary"
+                app:layout_constraintTop_toBottomOf="@id/export_progress_summary_errors_barrier"
                 app:layout_constraintVertical_chainStyle="packed"
                 tools:text="The track already exists" />
 

--- a/src/main/res/layout/import_activity.xml
+++ b/src/main/res/layout/import_activity.xml
@@ -19,9 +19,16 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guideline_vertical_half"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.7" />
+
             <TextView
                 android:id="@+id/import_progress_done"
-                style="@style/TextMedium"
+                style="@style/TextMediumPrimary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="24dp"
@@ -34,7 +41,7 @@
 
             <TextView
                 android:id="@+id/import_progress_slash"
-                style="@style/TextMedium"
+                style="@style/TextMediumPrimary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/generic_separator_done_total"
@@ -45,7 +52,7 @@
 
             <TextView
                 android:id="@+id/import_progress_total"
-                style="@style/TextMedium"
+                style="@style/TextMediumPrimary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="24dp"
@@ -68,16 +75,106 @@
                 app:layout_constraintTop_toBottomOf="@id/import_progress_done"
                 tools:progress="25" />
 
+            <!-- Start Summary -->
+            <!-- Files imported correctly -->
             <TextView
-                android:id="@+id/import_progress_summary"
-                style="@style/TextMedium"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_margin="24dp"
-                android:text="@string/import_progress_review"
-                app:layout_constraintEnd_toEndOf="parent"
+                android:id="@+id/import_progress_summary_ok_msg"
+                style="@style/TextImportExportSummaryStart"
+                android:text="@string/import_progress_summary_ok_msg"
+                app:layout_constraintEnd_toEndOf="@id/guideline_vertical_half"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/import_progress_bar" />
+
+            <TextView
+                android:id="@+id/import_progress_summary_ok"
+                style="@style/TextImportExportSummaryEnd"
+                app:layout_constraintBottom_toBottomOf="@id/import_progress_summary_ok_msg"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintTop_toTopOf="@id/import_progress_summary_ok_msg"
+                tools:text="10" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/import_progress_summary_ok_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="import_progress_summary_ok_msg,import_progress_summary_ok" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/import_progress_summary_ok_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible"
+                app:constraint_referenced_ids="import_progress_summary_ok_msg,import_progress_summary_ok" />
+
+            <!-- Already exists files -->
+            <TextView
+                android:id="@+id/import_progress_summary_exists_msg"
+                style="@style/TextImportExportSummaryStart"
+                android:text="@string/import_progress_summary_exists_msg"
+                app:layout_constraintEnd_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/import_progress_summary_ok_barrier" />
+
+            <TextView
+                android:id="@+id/import_progress_summary_exists"
+                style="@style/TextImportExportSummaryEnd"
+                app:layout_constraintBottom_toBottomOf="@id/import_progress_summary_exists_msg"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintTop_toTopOf="@id/import_progress_summary_exists_msg"
+                tools:text="10" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/import_progress_summary_exists_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="import_progress_summary_exists_msg,import_progress_summary_exists" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/import_progress_summary_exists_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible"
+                app:constraint_referenced_ids="import_progress_summary_exists_msg,import_progress_summary_exists" />
+
+            <!-- Importing error files -->
+            <TextView
+                android:id="@+id/import_progress_summary_errors_msg"
+                style="@style/TextImportExportSummaryStart"
+                android:text="@string/import_progress_summary_errors_msg"
+                app:layout_constraintEnd_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/import_progress_summary_exists_barrier" />
+
+            <TextView
+                android:id="@+id/import_progress_summary_errors"
+                style="@style/TextImportExportSummaryEnd"
+                app:layout_constraintBottom_toBottomOf="@id/import_progress_summary_errors_msg"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/guideline_vertical_half"
+                app:layout_constraintTop_toTopOf="@id/import_progress_summary_errors_msg"
+                tools:text="10" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/import_progress_summary_errors_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="import_progress_summary_errors_msg,import_progress_summary_errors" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/import_progress_summary_errors_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible"
+                app:constraint_referenced_ids="import_progress_summary_errors_msg,import_progress_summary_errors" />
+            <!-- End Summary -->
 
             <ImageView
                 android:id="@+id/import_progress_alert_icon"
@@ -94,18 +191,18 @@
 
             <TextView
                 android:id="@+id/import_progress_alert_msg"
-                style="@style/TextMedium"
+                style="@style/TextMediumPrimary"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
+                android:layout_marginTop="48dp"
                 android:layout_marginEnd="24dp"
                 android:layout_marginBottom="24dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/import_progress_alert_icon"
-                app:layout_constraintTop_toBottomOf="@id/import_progress_summary"
+                app:layout_constraintTop_toBottomOf="@id/import_progress_summary_errors_barrier"
                 app:layout_constraintVertical_chainStyle="packed"
-                tools:text="The file already exists" />
+                tools:text="Import progress alert message" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -547,10 +547,6 @@ Pokud zařízení GPS hlásí nepřesná data (např. Polohu, rychlost, nadmořs
     <string name="gps_disabled_msg">GPS vypnuto</string>
     <string name="gps_fixed_and_ready">GPS zaměřeno a připraveno</string>
     <string name="import_no_kml_file_found">Soubor doc.kml nenalezen v KMZ</string>
-    <string name="import_progress_review">Celkem importovaných souborů: %1$d
-\n - Importovaných souborů: %2$d
-\n - Již existuje: %3$d
-\n - Chyb: %4$d</string>
     <string name="settings_default_trackfileformat">Formát souboru pro export/sdílení</string>
     <string name="settings_recording_fullscreen_on_while_recording_title">Na celou obrazovku</string>
     <string name="settings_recording_fullscreen_on_while_recording_summary">Při nahrávání využívat celou obrazovku.</string>
@@ -583,11 +579,6 @@ Pokud zařízení GPS hlásí nepřesná data (např. Polohu, rychlost, nadmořs
     <string name="export_error_post_workout">Export po ukončení aktivity selhal, zkontrolujte prosím adresář pro export.</string>
     <string name="stats_loss">Ztráta</string>
     <string name="export_track_already_exists_msg">Trasa %1$s již existuje v cílovém adresáři.</string>
-    <string name="export_progress_review">Celkem exportovaných tras: %1$d
-\n - Nových exportovaných tras: %2$d
-\n - Přepsaných tras: %3$d
-\n - Přeskočených tras: %4$d
-\n - Chyb: %5$d</string>
     <string name="generic_overwrite">Přepsat</string>
     <string name="generic_show_errors">Zobrazit chyby</string>
     <string name="generic_click_twice_cancel">Opakovaně kliknout zpět pro ukončení</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -586,11 +586,6 @@ g) haz lo que creas que ayude a OpenTracks.</string>
     <string name="settings_default_export_uri_title">Carpeta de pistas exportadas</string>
     <string name="open_track_using_dashboard">Abrir con OpenTracks-Dashboard</string>
     <string name="export_track_already_exists_msg">La pista %1$s ya existe en la carpeta de destino.</string>
-    <string name="export_progress_review">Total de pistas exportadas: %1$d
-\n - Nuevas pistas exportadas: %2$d
-\n - Pistas sobreescritas: %3$d
-\n - Pistas ignoradas: %4$d
-\n - Errores: %5$d</string>
     <string name="generic_overwrite">Sobreescribe</string>
     <string name="generic_click_twice_cancel">Clic otra vez para cancelar</string>
     <string name="gps_disabled_msg">GPS desactivado</string>
@@ -598,10 +593,6 @@ g) haz lo que creas que ayude a OpenTracks.</string>
     <string name="import_unsupported_format">Formato no soportado</string>
     <string name="import_parser_error">Error al analizar: %1$s</string>
     <string name="import_unable_to_import_file">No se ha podido importar el fichero: %1$s</string>
-    <string name="import_progress_review">Total de ficheros importados: %1$d
-\n - Ficheros importados: %2$d
-\n - Ya existen: %3$d
-\n - Errores: %4$d</string>
     <string name="settings_default_trackfileformat">Formato para exportar/compartir</string>
     <string name="settings_recording_fullscreen_on_while_recording_title">Pantalla completa</string>
     <string name="interval_list_empty_message">No hay intervalos todavía</string>

--- a/src/main/res/values-gl/strings.xml
+++ b/src/main/res/values-gl/strings.xml
@@ -580,20 +580,11 @@ Se te detés ou estás en interiores, non se gardarán datos do sensor (mais ser
     <string name="instant_export_enabled_title">Exportación instantánea tras o adestramento</string>
     <string name="settings_default_export_uri_title">Directorio onde exportar as rutas</string>
     <string name="export_track_already_exists_msg">A ruta %1$s xa existe no directorio de destino.</string>
-    <string name="export_progress_review">Total de rutas exportadas: %1$d
-\n- Novas pistas: %2$d
-\n- Pistas sobrescritas: %3$d
-\n- Pistas omitidas: %4$d
-\n- Erros: %5$d</string>
     <string name="generic_overwrite">Sobrescribir</string>
     <plurals name="generic_completed_with_errors">
         <item quantity="one">Completado cun erro</item>
         <item quantity="other">Completado con %1$d erros</item>
     </plurals>
-    <string name="import_progress_review">Total de ficheiros importados: %1$d
-\n- Ficheiros importados: %2$d
-\n- Xa existentes: %3$d
-\n- Erros: %4$d</string>
     <string name="settings_night_mode_title">Decorado IU</string>
     <string name="settings_night_mode_option_system">Sistema</string>
     <string name="stats_intervals">Intervalos</string>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -548,10 +548,6 @@ Infatti, un\'applicazione deve supportare <i>ACTION_VIEW</i> con MIME <i>applica
     </plurals>
     <string name="generic_click_twice_cancel">Premi il tasto indietro di nuovo per annullare</string>
     <string name="gps_fixed_and_ready">GPS pronto e corretto</string>
-    <string name="import_progress_review">File importati: %1$d, di cui
-\n - %2$d nuovi
-\n - %3$d già esistenti
-\n - %4$d errori</string>
     <string name="menu_insert_gallery_img">Inserisci un immagine dalla galleria</string>
     <string name="permission_gps_failed">OpenTracks richiede il permesso di utilizzare il GPS.</string>
     <string name="settings_default_trackfileformat">Formato file nell\' esportazione/condivisione</string>
@@ -559,11 +555,6 @@ Infatti, un\'applicazione deve supportare <i>ACTION_VIEW</i> con MIME <i>applica
     <string name="description_default_speed_or_pace">Per tipo di attività</string>
     <string name="export_all_do_it_for_all">Esegui ciò per tutti i conflitti</string>
     <string name="export_track_errors">Percorsi non esportati</string>
-    <string name="export_progress_review">Totale percorsi esportati: %1$d
-\n - Nuovi percorsi esportati: %2$d
-\n - Percorsi sovrascritti: %3$d
-\n - Percorsi saltati: %4$d
-\n - Errori avvenuti: %5$d</string>
     <string name="generic_overwrite">Sovrascrivere</string>
     <string name="generic_skip">Saltare</string>
     <string name="generic_separator_done_total">/</string>

--- a/src/main/res/values-nb/strings.xml
+++ b/src/main/res/values-nb/strings.xml
@@ -521,16 +521,7 @@ limitations under the License.
     <string name="app_not_installed_show_on_map">Installer en app som støtter presentasjon av kartdata.</string>
     <string name="export_with_photos">med bilder</string>
     <string name="export_track_already_exists_msg">Sporet %1$s finnes allerede i målmappen.</string>
-    <string name="export_progress_review">Totalt eksporterte spor: %1$d
-\n - Nye spor eksportert: %2$d
-\n - Spor overskrevet: %3$d
-\n - Spor hoppet over: %4$d
-\n - Feil: %5$d</string>
     <string name="import_unsupported_format">Filformatet støttes ikke</string>
-    <string name="import_progress_review">Totalt importerte filer: %1$d
-\n - Filer importert: %2$d
-\n - Finnes allerede: %3$d
-\n - Feil: %4$d</string>
     <string name="menu_insert_gallery_img">Sett inn galleribilde</string>
     <string name="permission_gps_failed">OpenTracks krever tillatelse til å bruke GPS.</string>
     <string name="settings_recording_show_on_lockscreen_while_recording_summary">Vis statistikk under opptak uten å låse opp enheten.</string>

--- a/src/main/res/values-pt-rBR/strings.xml
+++ b/src/main/res/values-pt-rBR/strings.xml
@@ -469,21 +469,12 @@
 \n g) faça tudo o que você acha que ajuda a OpenTracks. </string>
     <string name="activity_type_escooter">escooter</string>
     <string name="app_not_installed_show_on_map">Instale um aplicativo que suporte a apresentação de dados de mapas.</string>
-    <string name="export_progress_review">Total de trilhas exportadas: %1$d
-\n - Novas trilhas exportadas: %2$d
-\n - Trilhas substituídas: %3$d
-\n - Trilhas ignoradas: %4$d
-\n - Erros: %5$d</string>
     <plurals name="generic_completed_with_errors">
         <item quantity="one">Concluído com %1$d erro</item>
         <item quantity="other">Concluído com %1$d erros</item>
     </plurals>
     <string name="import_unsupported_format">Formato de arquivo não suportado</string>
     <string name="import_unable_to_import_file">Não foi possível importar o arquivo: %1$s</string>
-    <string name="import_progress_review">Total de arquivos importados: %1$d
-\n - Arquivos importados: %2$d
-\n - Já existe: %3$d
-\n - Erros: %4$d</string>
     <string name="marker_add_photo_canceled">Cancelado, nenhum marcador de foto adicionado</string>
     <string name="menu_insert_gallery_img">Inserir imagem da galeria</string>
     <string name="settings_recording_show_on_lockscreen_while_recording_title">Mostrar estatísticas na tela de bloqueio</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -221,13 +221,10 @@ limitations under the License.
     <string name="export_track_already_exists_msg">The track %1$s already exists at the destination directory.</string>
     <string name="export_all_do_it_for_all">do it for all conflicts</string>
     <string name="export_track_errors">Tracks not exported</string>
-    <string name="export_progress_review">
-        Total exported tracks: %1$d\n
-        - New tracks exported: %2$d\n
-        - Tracks overwritten: %3$d\n
-        - Tracks skipped: %4$d\n
-        - Errors: %5$d
-    </string>
+    <string name="export_progress_summary_new_msg">New tracks exported</string>
+    <string name="export_progress_summary_overwrite_msg">Tracks overwritten</string>
+    <string name="export_progress_summary_skip_msg">Tracks skipped</string>
+    <string name="export_progress_summary_errors_msg">Errors</string>
     <!-- External Storage -->
     <!-- Files -->
     <string name="files_few">%1$d files</string>
@@ -304,12 +301,9 @@ limitations under the License.
     <string name="import_selection_option">All %1$s</string>
     <string name="import_selection_title">Import from external storage</string>
     <string name="import_success">Imported %1$s from %2$s</string>
-    <string name="import_progress_review">
-        Total imported files: %1$d\n
-        - Files imported: %2$d\n
-        - Already exists: %3$d\n
-        - Errors: %4$d
-    </string>
+    <string name="import_progress_summary_ok_msg">Files imported</string>
+    <string name="import_progress_summary_exists_msg">Already exists</string>
+    <string name="import_progress_summary_errors_msg">Errors</string>
     <!-- Marker -->
     <string name="marker_add_error">Unable to insert a marker. No GPS signal. Try again.</string>
     <string name="marker_add_success">A marker was inserted</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -245,6 +245,7 @@ limitations under the License.
     <string name="generic_name_line">Name: %1$s</string>
     <string name="generic_no">No</string>
     <string name="generic_ok">OK</string>
+    <string name="generic_open_track">Open Track</string>
     <string name="generic_paused">Paused</string>
     <string name="generic_progress_title">Please wait&#8230;</string>
     <string name="generic_recording">Recording&#8230;</string>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -241,5 +241,21 @@ limitations under the License.
         <item name="android:layout_width">wrap_content</item>
     </style>
 
+    <style name="TextImportExportSummaryStart" parent="TextMediumPrimary">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginTop">12dp</item>
+        <item name="android:layout_marginEnd">8dp</item>
+        <item name="android:layout_marginStart">24dp</item>
+        <item name="android:gravity">end</item>
+    </style>
+
+    <style name="TextImportExportSummaryEnd" parent="TextMediumPrimary">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginStart">8dp</item>
+        <item name="android:layout_marginEnd">24dp</item>
+    </style>
+
     <style name="ProgressBar" parent="@style/Widget.AppCompat.ProgressBar.Horizontal" />
 </resources>


### PR DESCRIPTION
**Describe the pull request**

*ImportActivity/ExportActivity UI improvements (summary messages)*

Summary messages have been improved offering only useful information. It doesn't make sense these Activity show to the user something like this:
```
- Files imported: 10
- Already exists: 0
- Errors: 0
```

The best option, in this case, should be:
```
Files imported: 10
```

*ImportActivity offers the option to open a track imported*

#558 makes sense. If user import only one file it would interesting to offers to the user to open the track just imported to see the details straight away.

**Screenshots**

![imagen](https://user-images.githubusercontent.com/4819612/104127464-7d5bca00-5362-11eb-9a9a-cae02498a42a.png)

![imagen](https://user-images.githubusercontent.com/4819612/104127471-88165f00-5362-11eb-810e-312da6e68a8c.png)

![imagen](https://user-images.githubusercontent.com/4819612/104127477-91073080-5362-11eb-81dc-aeb05e67154f.png)


**Link to the the issue**
#558 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
