### PR TITLE
Track recorded stats shows sensor data from trackpoints table

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/sensor/SensorDataCyclingTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/sensor/SensorDataCyclingTest.java
@@ -24,7 +24,7 @@ public class SensorDataCyclingTest {
         current.compute(previous);
 
         // then
-        assertEquals(60, current.getCadence_rpm(), 0.01);
+        assertEquals(60, current.getValue(), 0.01);
     }
 
     @Test
@@ -37,7 +37,7 @@ public class SensorDataCyclingTest {
         current.compute(previous);
 
         // then
-        assertEquals(33.53, current.getCadence_rpm(), 0.01);
+        assertEquals(33.53, current.getValue(), 0.01);
     }
 
     @Test
@@ -50,7 +50,7 @@ public class SensorDataCyclingTest {
         current.compute(previous);
 
         // then
-        assertEquals(0, current.getCadence_rpm(), 0.01);
+        assertEquals(0, current.getValue(), 0.01);
     }
 
 
@@ -64,7 +64,7 @@ public class SensorDataCyclingTest {
         current.compute(previous);
 
         // then
-        assertFalse(current.hasCadence_rpm());
+        assertFalse(current.hasValue());
     }
 
     @Test
@@ -77,7 +77,7 @@ public class SensorDataCyclingTest {
         current.compute(previous);
 
         // then
-        assertEquals(60, current.getCadence_rpm(), 0.01);
+        assertEquals(60, current.getValue(), 0.01);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class SensorDataCyclingTest {
         current.compute(previous);
 
         // then
-        assertEquals(60, current.getCadence_rpm(), 0.01);
+        assertEquals(60, current.getValue(), 0.01);
     }
 
     @Test
@@ -103,7 +103,7 @@ public class SensorDataCyclingTest {
         current.compute(previous, 2150);
 
         // then
-        assertEquals(1.20, current.getSpeed_mps(), 0.01);
+        assertEquals(1.20, current.getValue(), 0.01);
     }
 
     @Test
@@ -116,7 +116,7 @@ public class SensorDataCyclingTest {
         current.compute(previous, 2000);
 
         // then
-        assertEquals(2, current.getSpeed_mps(), 0.01);
+        assertEquals(2, current.getValue(), 0.01);
     }
 
     @Test

--- a/src/main/java/de/dennisguse/opentracks/adapters/SensorsAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/adapters/SensorsAdapter.java
@@ -1,7 +1,6 @@
 package de.dennisguse.opentracks.adapters;
 
 import android.content.Context;
-import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,19 +12,11 @@ import androidx.recyclerview.widget.RecyclerView;
 import java.util.List;
 
 import de.dennisguse.opentracks.R;
-import de.dennisguse.opentracks.content.sensor.SensorData;
-import de.dennisguse.opentracks.content.sensor.SensorDataCycling;
-import de.dennisguse.opentracks.content.sensor.SensorDataCyclingPower;
-import de.dennisguse.opentracks.content.sensor.SensorDataHeartRate;
-import de.dennisguse.opentracks.util.StringUtils;
+import de.dennisguse.opentracks.viewmodels.SensorDataModel;
 
 public class SensorsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
-    public static final int HEART_RATE_TYPE = 0;
-    public static final int CADENCE_TYPE = 1;
-    public static final int POWER_TYPE = 2;
-
-    private List<Pair<Integer, SensorData>> sensorDataList;
+    private List<SensorDataModel> sensorDataList;
     private final Context context;
 
     public SensorsAdapter(Context context) {
@@ -42,9 +33,8 @@ public class SensorsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
     @Override
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         SensorsAdapter.ViewHolder viewHolder = (SensorsAdapter.ViewHolder) holder;
-        int type = sensorDataList.get(position).first;
-        SensorData sensorData = sensorDataList.get(position).second;
-        viewHolder.setData(sensorData, type);
+        SensorDataModel sensorDataModel = sensorDataList.get(position);
+        viewHolder.setData(sensorDataModel);
     }
 
     @Override
@@ -56,12 +46,7 @@ public class SensorsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         }
     }
 
-    @Override
-    public int getItemViewType(int position) {
-        return sensorDataList.get(position).first;
-    }
-
-    public List<Pair<Integer, SensorData>> swapData(List<Pair<Integer, SensorData>> data) {
+    public List<SensorDataModel> swapData(List<SensorDataModel> data) {
         if (sensorDataList == data) {
             return null;
         }
@@ -89,70 +74,18 @@ public class SensorsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             unit = itemView.findViewById(R.id.stats_sensor_unit);
         }
 
-        public void setData(SensorData sensorData, int type) {
-            switch (type) {
-                case HEART_RATE_TYPE:
-                    setHeartRateSensorData((SensorDataHeartRate) sensorData);
-                    break;
-                case CADENCE_TYPE:
-                    setCadenceSensorData((SensorDataCycling.Cadence) sensorData);
-                    break;
-                case POWER_TYPE:
-                    setPowerSensorData((SensorDataCyclingPower) sensorData);
-                    break;
-                default:
-                    throw new RuntimeException("Unknown sensor type");
-            }
-        }
+        public void setData(SensorDataModel sensorDataModel) {
+            String sensorName = sensorDataModel.getSensorName();
+            String sensorValue = sensorDataModel.hasValue() ? sensorDataModel.getSensorValue() : context.getString(R.string.value_unknown);
 
-        private void setHeartRateSensorData(SensorDataHeartRate data) {
-            String sensorValue = context.getString(R.string.value_unknown);
-            String sensorName = context.getString(R.string.value_unknown);
-            if (data != null) {
-                sensorName = data.getSensorNameOrAddress();
-                if (data.hasHeartRate_bpm() && data.isRecent()) {
-                    sensorValue = StringUtils.formatDecimal(data.getHeartRate_bpm(), 0);
-                }
+            this.label.setText(context.getString(sensorDataModel.getLabelId()));
+            if (sensorName == null) {
+                this.sensorValue.setVisibility(View.GONE);
+            } else {
+                this.sensorValue.setText(sensorName);
             }
-
-            this.label.setText(context.getString(R.string.sensor_state_heart_rate));
-            this.sensorValue.setText(sensorName);
             this.value.setText(sensorValue);
-            this.unit.setText(R.string.sensor_unit_beats_per_minute);
-        }
-
-        private void setCadenceSensorData(SensorDataCycling.Cadence data) {
-            String sensorValue = context.getString(R.string.value_unknown);
-            String sensorName = context.getString(R.string.value_unknown);
-            if (data != null) {
-                sensorName = data.getSensorNameOrAddress();
-
-                if (data.hasCadence_rpm() && data.isRecent()) {
-                    sensorValue = StringUtils.formatDecimal(data.getCadence_rpm(), 0);
-                }
-            }
-
-            this.label.setText(context.getString(R.string.sensor_state_cadence));
-            this.sensorValue.setText(sensorName);
-            this.value.setText(sensorValue);
-            this.unit.setText(R.string.sensor_unit_rounds_per_minute);
-        }
-
-        private void setPowerSensorData(SensorDataCyclingPower data) {
-            String sensorValue = context.getString(R.string.value_unknown);
-            String sensorName = context.getString(R.string.value_unknown);
-            if (data != null) {
-                sensorName = data.getSensorNameOrAddress();
-
-                if (data.hasPower_w() && data.isRecent()) {
-                    sensorValue = StringUtils.formatDecimal(data.getPower_w(), 0);
-                }
-            }
-
-            this.label.setText(context.getString(R.string.sensor_state_power));
-            this.sensorValue.setText(sensorName);
-            this.value.setText(sensorValue);
-            this.unit.setText(R.string.sensor_unit_power);
+            this.unit.setText(context.getString(sensorDataModel.getUnitId()));
         }
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/content/sensor/SensorData.java
+++ b/src/main/java/de/dennisguse/opentracks/content/sensor/SensorData.java
@@ -8,7 +8,9 @@ import java.time.Instant;
 
 import de.dennisguse.opentracks.services.sensors.BluetoothRemoteSensorManager;
 
-public class SensorData {
+public class SensorData<T> {
+
+    protected T value;
 
     private final String sensorAddress;
     private final String sensorName;
@@ -44,6 +46,17 @@ public class SensorData {
         return sensorName != null ? sensorName : sensorAddress;
     }
 
+    public boolean hasValue() {
+        return value != null;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    /**
+     * Is the data recent considering the current time.
+     */
     public boolean isRecent() {
         return Instant.now().isBefore(timestamp_ms.plus(BluetoothRemoteSensorManager.MAX_SENSOR_DATE_SET_AGE_MS));
     }

--- a/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataCyclingPower.java
+++ b/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataCyclingPower.java
@@ -2,31 +2,20 @@ package de.dennisguse.opentracks.content.sensor;
 
 import androidx.annotation.NonNull;
 
-public class SensorDataCyclingPower extends SensorData {
-
-    private final Float power_w;
+public class SensorDataCyclingPower extends SensorData<Float> {
 
     public SensorDataCyclingPower(String address) {
         super(address);
-        this.power_w = null;
     }
 
     public SensorDataCyclingPower(String name, String address, float power_w) {
         super(name, address);
-        this.power_w = power_w;
-    }
-
-    public boolean hasPower_w() {
-        return power_w != null;
-    }
-
-    public float getPower_w() {
-        return power_w;
+        this.value = power_w;
     }
 
     @NonNull
     @Override
     public String toString() {
-        return "power=" + power_w;
+        return "power=" + value;
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataHeartRate.java
+++ b/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataHeartRate.java
@@ -2,31 +2,20 @@ package de.dennisguse.opentracks.content.sensor;
 
 import androidx.annotation.NonNull;
 
-public class SensorDataHeartRate extends SensorData {
-
-    private final Float heartRate_bpm;
+public class SensorDataHeartRate extends SensorData<Float> {
 
     public SensorDataHeartRate(String address) {
         super(address);
-        heartRate_bpm = null;
     }
 
     public SensorDataHeartRate(String name, String address, float heartRate_bpm) {
         super(name, address);
-        this.heartRate_bpm = heartRate_bpm;
-    }
-
-    public boolean hasHeartRate_bpm() {
-        return heartRate_bpm != null;
-    }
-
-    public Float getHeartRate_bpm() {
-        return heartRate_bpm;
+        this.value = heartRate_bpm;
     }
 
     @NonNull
     @Override
     public String toString() {
-        return "heart=" + heartRate_bpm;
+        return "heart=" + value;
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataSet.java
+++ b/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataSet.java
@@ -50,19 +50,19 @@ public final class SensorDataSet {
 
     public void fillTrackPoint(TrackPoint trackPoint) {
         if (heartRate != null) {
-            trackPoint.setHeartRate_bpm(heartRate.getHeartRate_bpm());
+            trackPoint.setHeartRate_bpm(heartRate.getValue());
         }
 
-        if (cyclingCadence != null && cyclingCadence.hasCadence_rpm()) {
-            trackPoint.setCyclingCadence_rpm(cyclingCadence.getCadence_rpm());
+        if (cyclingCadence != null && cyclingCadence.hasValue()) {
+            trackPoint.setCyclingCadence_rpm(cyclingCadence.getValue());
         }
 
-        if (cyclingSpeed != null && cyclingSpeed.hasSpeed_mps()) {
-            trackPoint.setSpeed(cyclingSpeed.getSpeed_mps());
+        if (cyclingSpeed != null && cyclingSpeed.hasValue()) {
+            trackPoint.setSpeed(cyclingSpeed.getValue());
         }
 
-        if (cyclingPower != null && cyclingPower.hasPower_w()) {
-            trackPoint.setPower(cyclingPower.getPower_w());
+        if (cyclingPower != null && cyclingPower.hasValue()) {
+            trackPoint.setPower(cyclingPower.getValue());
         }
     }
 

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
@@ -38,6 +38,7 @@ import de.dennisguse.opentracks.util.PreferencesUtils;
 import de.dennisguse.opentracks.util.StringUtils;
 import de.dennisguse.opentracks.util.TrackIconUtils;
 import de.dennisguse.opentracks.util.UnitConversions;
+import de.dennisguse.opentracks.viewmodels.SensorDataModel;
 
 /**
  * A fragment to display track statistics to the user for a currently recording {@link Track}.
@@ -272,15 +273,15 @@ public class StatisticsRecordingFragment extends Fragment implements TrackDataLi
         } else {
             SensorDataSet sensorDataSet = trackRecordingService.getSensorData();
             if (sensorDataSet != null) {
-                List<Pair<Integer, SensorData>> sensorDataList = new ArrayList<>();
+                List<SensorDataModel> sensorDataList = new ArrayList<>();
                 if (sensorDataSet.getHeartRate() != null) {
-                    sensorDataList.add(new Pair<>(SensorsAdapter.HEART_RATE_TYPE, sensorDataSet.getHeartRate()));
+                    sensorDataList.add(new SensorDataModel(sensorDataSet.getHeartRate()));
                 }
                 if (sensorDataSet.getCyclingCadence() != null) {
-                    sensorDataList.add(new Pair<>(SensorsAdapter.CADENCE_TYPE, sensorDataSet.getCyclingCadence()));
+                    sensorDataList.add(new SensorDataModel(sensorDataSet.getCyclingCadence()));
                 }
                 if(sensorDataSet.getCyclingPower() != null) {
-                    sensorDataList.add(new Pair<>(SensorsAdapter.POWER_TYPE, sensorDataSet.getCyclingPower()));
+                    sensorDataList.add(new SensorDataModel(sensorDataSet.getCyclingPower()));
                 }
                 sensorsAdapter.swapData(sensorDataList);
                 setSpeedSensorData(sensorDataSet);
@@ -333,8 +334,8 @@ public class StatisticsRecordingFragment extends Fragment implements TrackDataLi
         if (sensorDataSet != null && sensorDataSet.getCyclingSpeed() != null) {
             SensorDataCycling.Speed data = sensorDataSet.getCyclingSpeed();
 
-            if (data.hasSpeed_mps() && data.isRecent()) {
-                setSpeed(data.getSpeed_mps());
+            if (data.hasValue() && data.isRecent()) {
+                setSpeed(data.getValue());
             }
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/stats/SensorStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/SensorStatistics.java
@@ -1,0 +1,49 @@
+package de.dennisguse.opentracks.stats;
+
+public class SensorStatistics {
+    private Float maxHr;
+    private Float avgHr;
+    private Float maxCadence;
+    private Float avgCadence;
+    private Float avgPower;
+
+    public SensorStatistics(Float maxHr, Float avgHr, Float maxCadence, Float avgCadence, Float avgPower) {
+        this.maxHr = maxHr;
+        this.avgHr = avgHr;
+        this.maxCadence = maxCadence;
+        this.avgCadence = avgCadence;
+        this.avgPower = avgPower;
+    }
+
+    public boolean hasHeartRate() {
+        return maxHr != null;
+    }
+
+    public float getMaxHeartRate() {
+        return maxHr;
+    }
+
+    public float getAvgHeartRate() {
+        return avgHr;
+    }
+
+    public boolean hasCadence() {
+        return maxCadence != null;
+    }
+
+    public float getMaxCadence() {
+        return maxCadence;
+    }
+
+    public float getAvgCadence() {
+        return avgCadence;
+    }
+
+    public boolean hasPower() {
+        return avgPower != null;
+    }
+
+    public float getAvgPower() {
+        return avgPower;
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/viewmodels/SensorDataModel.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/SensorDataModel.java
@@ -1,0 +1,56 @@
+package de.dennisguse.opentracks.viewmodels;
+
+import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.content.sensor.SensorData;
+import de.dennisguse.opentracks.content.sensor.SensorDataCycling;
+import de.dennisguse.opentracks.content.sensor.SensorDataCyclingPower;
+import de.dennisguse.opentracks.content.sensor.SensorDataHeartRate;
+import de.dennisguse.opentracks.util.StringUtils;
+
+public class SensorDataModel {
+    private int labelId;
+    private String sensorValue;
+    private String sensorName;
+    private int unitId;
+
+    public SensorDataModel(int labelId, int unitId, float sensorValue) {
+        this.labelId = labelId;
+        this.unitId = unitId;
+        this.sensorValue = StringUtils.formatDecimal(sensorValue, 0);
+    }
+
+    public SensorDataModel(SensorData sensorData) {
+        this.sensorName = sensorData.getSensorNameOrAddress();
+        this.sensorValue = sensorData.hasValue() && sensorData.isRecent() ? StringUtils.formatDecimal((float) sensorData.getValue(), 0) : null;
+        if (sensorData instanceof SensorDataHeartRate) {
+            this.labelId = R.string.sensor_state_heart_rate;
+            this.unitId = R.string.sensor_unit_beats_per_minute;
+        } else if (sensorData instanceof SensorDataCycling.Cadence) {
+            this.labelId = R.string.sensor_state_cadence;
+            this.unitId = R.string.sensor_unit_rounds_per_minute;
+        } else if (sensorData instanceof SensorDataCyclingPower) {
+            this.labelId = R.string.sensor_state_power;
+            this.unitId = R.string.sensor_unit_power;
+        }
+    }
+
+    public int getLabelId() {
+        return labelId;
+    }
+
+    public int getUnitId() {
+        return unitId;
+    }
+
+    public String getSensorName() {
+        return sensorName;
+    }
+
+    public String getSensorValue() {
+        return sensorValue;
+    }
+
+    public boolean hasValue() {
+        return sensorValue != null;
+    }
+}

--- a/src/main/res/layout/statistics_recorded.xml
+++ b/src/main/res/layout/statistics_recorded.xml
@@ -313,5 +313,14 @@
             app:layout_constraintEnd_toStartOf="@+id/guideline3"
             app:layout_constraintTop_toBottomOf="@+id/stats_elevation_barrier" />
 
+        <!-- Sensors data -->
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/stats_sensors_recycler_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintTop_toBottomOf="@id/stats_end_horizontal_line" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -360,11 +360,16 @@ limitations under the License.
     <!-- Sensor State -->
     <string name="sensor_state_battery">Battery level</string>
     <string name="sensor_state_cadence">Cadence</string>
+    <string name="sensor_state_cadence_avg">Avg Cadence</string>
+    <string name="sensor_state_cadence_max">Max Cadence</string>
     <string name="sensor_state_cadence_value">%1$d rpm</string>
     <string name="sensor_state_disconnected">Disconnected</string>
     <string name="sensor_state_heart_rate">Heart rate</string>
+    <string name="sensor_state_heart_rate_avg">Avg Heart rate</string>
+    <string name="sensor_state_heart_rate_max">Max Heart rate</string>
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Power</string>
+    <string name="sensor_state_power_avg">Avg Power</string>
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_not_known">Sensor %1$s is unknown. Please check the settings.</string>
     <string name="sensor_could_not_scan">Could not scan for Bluetooth devices (error %1$i).</string>


### PR DESCRIPTION
**Context**
OT saves on trackpoints table sensor information: heart rate, cadence and power. But users cannot see sensor stats after recording an activity, they were hidden.

**Description**
Track recorded stats now shows sensor data stats from trackpoints table:
- Heart rate: maximum and average.
- Cadence: maximum and average.
- Power: average.

**Changes impact on other parts**
I've generalized SensorsAdapter so it can be used from track recorded and track recording activities. This adapter can be used from sensors classes and from new SensorStats class whose data comes from trackpoints table.

For that, I've created a model for SensorsAdapter.

**Some screenshots**
![imagen](https://user-images.githubusercontent.com/4819612/107882210-4ee48800-6ee8-11eb-8991-1de2e4e8e86a.png)

![imagen](https://user-images.githubusercontent.com/4819612/107882234-776c8200-6ee8-11eb-9c73-998333bb8e7c.png)


**Issues related**
#525 and #502 and #214


**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
