### PR TITLE
Use distance from cycling speed sensors.

### DIFF
--- a/README_TESTED_SENSORS.md
+++ b/README_TESTED_SENSORS.md
@@ -19,6 +19,9 @@ However, often only one value is provided.
 ### Speed
 
 * Garmin Speed Sensor 2
+  This sensor reports speed data as cadence.
+  A workaround is in place.
+
 * Wahoo Speed (Model: WFRPMSPD)
 
 ### Cadence

--- a/README_TESTED_SENSORS.md
+++ b/README_TESTED_SENSORS.md
@@ -19,8 +19,11 @@ However, often only one value is provided.
 ### Speed
 
 * Garmin Speed Sensor 2
-  This sensor reports speed data as cadence.
-  A workaround is in place.
+  * Has updatable firmware that requires an account for garmin.com
+  * This sensor reports speed data as cadence.
+    A workaround is in place.
+  * This sensor sometimes counts backwards (unknown software version).
+    A workaround is in place.
 
 * Wahoo Speed (Model: WFRPMSPD)
 

--- a/doc/opentracks-schema-1.0.xsd
+++ b/doc/opentracks-schema-1.0.xsd
@@ -1,8 +1,32 @@
 <?xml version="1.0"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     targetNamespace="http://opentracksapp.com/xmlschemas/v1">
 
-    <xs:element name="trackuuid"
-        type="xs:string" />
+    <xsd:element name="trackuuid"
+        type="xsd:string">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+                A unique track identifier stored as UUID.
+            </xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
 
-</xs:schema>
+    <xsd:element name="loss"
+        type="xsd:float">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+                The lost elevation in meters from the previous to the current TrackPoint.
+                Only used in GPX.
+            </xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:element name="gain"
+        type="xsd:string">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+                The gained elevation in meters from the previous to the current TrackPoint.
+                Only used in GPX.
+            </xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+</xsd:schema>

--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
+import de.dennisguse.opentracks.content.provider.TrackPointIterator;
 import de.dennisguse.opentracks.util.FileUtils;
 
 public class TestDataUtil {
@@ -149,5 +150,14 @@ public class TestDataUtil {
         String photoUrl = photoUri.toString();
 
         return new Marker("Marker name", "Marker description", "Marker category", "", trackId, 0.0, 0, trackPoint, photoUrl);
+    }
+
+    public static List<TrackPoint> getTrackPoints(ContentProviderUtils contentProviderUtils, Track.Id trackId) {
+        TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(trackId, null);
+        ArrayList<TrackPoint> trackPoints = new ArrayList<>();
+        while (trackPointIterator.hasNext()) {
+            trackPoints.add(trackPointIterator.next());
+        }
+        return trackPoints;
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
@@ -822,7 +822,7 @@ public class CustomContentProviderUtilsTest {
         Track track = TestDataUtil.createTrackAndInsert(contentProviderUtils, trackId, 10);
 
         contentProviderUtils.insertTrackPoint(TestDataUtil.createTrackPoint(22), trackId);
-        assertEquals(11, contentProviderUtils.getTrackPoints(trackId).size());
+        assertEquals(11, contentProviderUtils.getTrackPointCursor(trackId, null).getCount());
     }
 
     @Test
@@ -840,7 +840,7 @@ public class CustomContentProviderUtilsTest {
         contentProviderUtils.insertTrackPoint(trackPoint, trackId);
 
         // then
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         assertTrue(trackPoints.get(10).hasHeartRate());
         assertEquals(trackPoint.getHeartRate_bpm(), trackPoints.get(10).getHeartRate_bpm(), 0.01);
         assertEquals(trackPoint.getCyclingCadence_rpm(), trackPoints.get(10).getCyclingCadence_rpm(), 0.01);

--- a/src/androidTest/java/de/dennisguse/opentracks/content/sensor/SensorDataCyclingTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/sensor/SensorDataCyclingTest.java
@@ -96,34 +96,36 @@ public class SensorDataCyclingTest {
     @Test
     public void compute_speed() {
         // given
-        SensorDataCycling.Speed previous = new SensorDataCycling.Speed("sensorAddress", "sensorName", 1, 6184);
-        SensorDataCycling.Speed current = new SensorDataCycling.Speed("sensorAddress", "sensorName", 2, 8016);
+        SensorDataCycling.DistanceSpeed previous = new SensorDataCycling.DistanceSpeed("sensorAddress", "sensorName", 1, 6184);
+        SensorDataCycling.DistanceSpeed current = new SensorDataCycling.DistanceSpeed("sensorAddress", "sensorName", 2, 8016);
 
         // when
         current.compute(previous, 2150);
 
         // then
-        assertEquals(1.20, current.getValue(), 0.01);
+        assertEquals(1.20, current.getValue().distance_m, 2150);
+        assertEquals(1.20, current.getValue().speed_mps, 0.01);
     }
 
     @Test
     public void compute_speed_rollOverCount() {
         // given
-        SensorDataCycling.Speed previous = new SensorDataCycling.Speed("sensorAddress", "sensorName", UintUtils.UINT16_MAX - 1, 1024);
-        SensorDataCycling.Speed current = new SensorDataCycling.Speed("sensorAddress", "sensorName", 0, 2048);
+        SensorDataCycling.DistanceSpeed previous = new SensorDataCycling.DistanceSpeed("sensorAddress", "sensorName", UintUtils.UINT16_MAX - 1, 1024);
+        SensorDataCycling.DistanceSpeed current = new SensorDataCycling.DistanceSpeed("sensorAddress", "sensorName", 0, 2048);
 
         // when
         current.compute(previous, 2000);
 
         // then
-        assertEquals(2, current.getValue(), 0.01);
+        assertEquals(1.20, current.getValue().distance_m, 2000);
+        assertEquals(2, current.getValue().speed_mps, 0.01);
     }
 
     @Test
     public void equals_speed_with_no_data() {
         // given
-        SensorDataCycling.Speed previous = new SensorDataCycling.Speed("sensorAddress");
-        SensorDataCycling.Speed current = new SensorDataCycling.Speed("sensorAddress", "sensorName", 0, 2048);
+        SensorDataCycling.DistanceSpeed previous = new SensorDataCycling.DistanceSpeed("sensorAddress");
+        SensorDataCycling.DistanceSpeed current = new SensorDataCycling.DistanceSpeed("sensorAddress", "sensorName", 0, 2048);
 
         // when
         previous.toString();

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.content.data.Marker;
+import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
@@ -111,7 +112,7 @@ public class ExportImportTest {
         contentProviderUtils.updateTrack(track);
 
         track = contentProviderUtils.getTrack(trackId);
-        trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         markers = contentProviderUtils.getMarkers(trackId);
         assertEquals(10, trackPoints.size());
         assertEquals(2, markers.size());
@@ -325,8 +326,7 @@ public class ExportImportTest {
     }
 
     private void assertTrackpoints(List<TrackPoint> trackPoints, boolean verifyPower, boolean verifyHeartrate, boolean verifyCadence, boolean verifyElevationGain, boolean verifyElevationLoss, boolean verifyDistance) {
-        List<TrackPoint> importedTrackPoints = contentProviderUtils.getTrackPoints(importTrackId);
-
+        List<TrackPoint> importedTrackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, importTrackId);
         assertEquals(trackPoints.size(), importedTrackPoints.size());
 
         for (int i = 0; i < trackPoints.size(); i++) {

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -3,7 +3,6 @@ package de.dennisguse.opentracks.io.file.importer;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.location.Location;
 import android.os.Looper;
 import android.util.Log;
 
@@ -24,6 +23,7 @@ import org.junit.runners.JUnit4;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -91,17 +91,17 @@ public class ExportImportTest {
 
         trackId = service.startNewTrack();
 
-        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 14, 10, 15, 10, 0, 66, 3, 50), 0);
+        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 14, 10, 15, 10, 0, 66, 3, 50, 5), 0);
         service.insertMarker("Marker 1", "Marker 1 category", "Marker 1 desc", null);
-        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 14.001, 10, 15, 10, 0, 66, 3, 50), 0);
-        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 14.002, 10, 15, 10, 0, 66, 3, 50), 0);
+        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 14.001, 10, 15, 10, 0, 66, 3, 50, 5), 0);
+        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 14.002, 10, 15, 10, 0, 66, 3, 50, 5), 0);
         service.insertMarker("Marker 2", "Marker 2 category", "Marker 2 desc", null);
         service.pauseCurrentTrack();
 
         service.resumeCurrentTrack();
-        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 14.003, 10, 15, 10, 0, 66, 3, 50), 0);
-        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 16, 10, 15, 10, 0, 66, 3, 50), 0);
-        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 16.001, 10, 15, 10, 0, 66, 3, 50), 0);
+        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 14.003, 10, 15, 10, 0, 66, 3, 50, 5), 0);
+        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 16, 10, 15, 10, 0, 66, 3, 50, 5), 0);
+        service.newTrackPoint(createTrackPoint(System.currentTimeMillis(), 3, 16.001, 10, 15, 10, 0, 66, 3, 50, 5), 0);
         service.endCurrentTrack();
 
         track = contentProviderUtils.getTrack(trackId);
@@ -163,10 +163,10 @@ public class ExportImportTest {
         assertEquals(track.getUuid(), importedTrack.getUuid());
 
         // 2. trackpoints
-        assertTrackpoints(trackPoints, false, false, false, false, false);
+        assertTrackpoints(trackPoints, false, false, false, false, false, false);
 
         // 3. trackstatistics
-        assertTrackStatistics(false, false);
+        assertTrackStatistics(false, false, false);
 
         // 4. markers
         assertMarkers();
@@ -201,10 +201,10 @@ public class ExportImportTest {
         assertEquals(track.getIcon(), importedTrack.getIcon());
 
         // 2. trackpoints
-        assertTrackpoints(trackPoints, true, true, true, true, true);
+        assertTrackpoints(trackPoints, true, true, true, true, true, true);
 
         // 2. trackstatistics
-        assertTrackStatistics(false, true);
+        assertTrackStatistics(false, true, true);
 
         // 4. markers
         assertMarkers();
@@ -232,38 +232,6 @@ public class ExportImportTest {
         // then
         Track importedTrack = contentProviderUtils.getTrack(importTrackId);
         assertNull(importedTrack);
-    }
-
-    @Ignore
-    @LargeTest
-    @Test
-    public void kmz_only_track() {
-        // TODO
-        Log.e(TAG, "Test not implemented.");
-    }
-
-    @Ignore
-    @LargeTest
-    @Test
-    public void kmz_with_trackdetail() {
-        // TODO
-        Log.e(TAG, "Test not implemented.");
-    }
-
-    @Ignore
-    @LargeTest
-    @Test
-    public void kmz_with_trackdetail_and_sensordata() {
-        // TODO
-        Log.e(TAG, "Test not implemented.");
-    }
-
-    @Ignore
-    @LargeTest
-    @Test
-    public void kmz_with_trackdetail_and_sensordata_and_pictures() {
-        // TODO
-        Log.e(TAG, "Test not implemented.");
     }
 
     @LargeTest
@@ -303,10 +271,10 @@ public class ExportImportTest {
         trackPointsWithCoordinates.get(0).setType(TrackPoint.Type.SEGMENT_START_AUTOMATIC);
         trackPointsWithCoordinates.get(3).setType(TrackPoint.Type.SEGMENT_START_AUTOMATIC);
 
-        assertTrackpoints(trackPointsWithCoordinates, true, true, true, true, true);
+        assertTrackpoints(trackPointsWithCoordinates, true, true, true, true, true, false);
 
         // 3. trackstatistics
-        assertTrackStatistics(true, true);
+        assertTrackStatistics(true, true, false);
 
         // 4. markers
         assertMarkers();
@@ -356,7 +324,7 @@ public class ExportImportTest {
         }
     }
 
-    private void assertTrackpoints(List<TrackPoint> trackPoints, boolean verifyPower, boolean verifyHeartrate, boolean verifyCadence, boolean verifyElevationGain, boolean verifyElevationLoss) {
+    private void assertTrackpoints(List<TrackPoint> trackPoints, boolean verifyPower, boolean verifyHeartrate, boolean verifyCadence, boolean verifyElevationGain, boolean verifyElevationLoss, boolean verifyDistance) {
         List<TrackPoint> importedTrackPoints = contentProviderUtils.getTrackPoints(importTrackId);
 
         assertEquals(trackPoints.size(), importedTrackPoints.size());
@@ -407,10 +375,13 @@ public class ExportImportTest {
             if (verifyElevationLoss) {
                 assertEquals(trackPoint.getElevationLoss(), importedTrackPoint.getElevationLoss(), 0.01);
             }
+            if (verifyDistance) {
+                assertEquals(trackPoint.getSensorDistance(), importedTrackPoint.getSensorDistance(), 0.01);
+            }
         }
     }
 
-    private void assertTrackStatistics(boolean isGpx, boolean verifyElevationGainAndLoss) {
+    private void assertTrackStatistics(boolean isGpx, boolean verifyElevationGainAndLoss, boolean verifyDistance) {
         Track importedTrack = contentProviderUtils.getTrack(importTrackId);
 
         assertNotNull(importedTrack.getTrackStatistics());
@@ -428,7 +399,9 @@ public class ExportImportTest {
             assertEquals(trackStatistics.getMovingTime(), importedTrackStatistics.getMovingTime());
 
             // Distance
-            assertEquals(trackStatistics.getTotalDistance(), importedTrackStatistics.getTotalDistance(), 0.01);
+            if (verifyDistance) {
+                assertEquals(trackStatistics.getTotalDistance(), importedTrackStatistics.getTotalDistance(), 0.01);
+            }
 
             // Speed
             assertEquals(trackStatistics.getMaxSpeed(), importedTrackStatistics.getMaxSpeed(), 0.01);
@@ -448,20 +421,15 @@ public class ExportImportTest {
         }
     }
 
-    private static TrackPoint createTrackPoint(long time, double latitude, double longitude, float accuracy, long speed, long altitude, float elevationGain, float heartRate, float cyclingCadence, float power) {
-        Location location = new Location("");
-        location.setTime(time);
-        location.setLongitude(longitude);
-        location.setLatitude(latitude);
-        location.setAccuracy(accuracy);
-        location.setAltitude(altitude);
-        location.setSpeed(speed);
-
-        TrackPoint tp = new TrackPoint(location);
+    private static TrackPoint createTrackPoint(long time, double latitude, double longitude, float accuracy, float speed, float altitude, float elevationGain, float heartRate, float cyclingCadence, float power, float distance) {
+        TrackPoint tp = new TrackPoint(latitude, longitude, (double) altitude, Instant.ofEpochMilli(time));
+        tp.setAccuracy(accuracy);
+        tp.setSpeed(speed);
         tp.setHeartRate_bpm(heartRate);
         tp.setCyclingCadence_rpm(cyclingCadence);
         tp.setPower(power);
         tp.setElevationGain(elevationGain);
+        tp.setSensorDistance(distance);
         return tp;
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/LegacyImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/LegacyImportTest.java
@@ -14,6 +14,7 @@ import org.junit.runners.JUnit4;
 import java.io.InputStream;
 import java.util.List;
 
+import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
@@ -69,7 +70,7 @@ public class LegacyImportTest {
         assertEquals(0, contentProviderUtils.getMarkerCount(importTrackId));
 
         // 3. trackpoints
-        List<TrackPoint> importedTrackPoints = contentProviderUtils.getTrackPoints(importTrackId);
+        List<TrackPoint> importedTrackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, importTrackId);
         assertEquals(6, importedTrackPoints.size());
 
         // first 3 trackpoints
@@ -122,7 +123,7 @@ public class LegacyImportTest {
         assertEquals("UNKNOWN", importedTrack.getIcon());
 
         // 3. trackpoints
-        List<TrackPoint> importedTrackPoints = contentProviderUtils.getTrackPoints(importTrackId);
+        List<TrackPoint> importedTrackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, importTrackId);
         assertEquals(6, importedTrackPoints.size());
 
         // first segment

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeoutException;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.content.data.Marker;
+import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
@@ -191,7 +192,7 @@ public class TrackRecordingServiceTest {
         Track.Id trackId = service.startNewTrack();
 
         // then
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
 
         assertEquals(1, trackPoints.size());
         assertEquals(TrackPoint.Type.SEGMENT_START_MANUAL, trackPoints.get(0).getType());
@@ -208,7 +209,7 @@ public class TrackRecordingServiceTest {
         service.endCurrentTrack();
 
         // then
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
 
         assertEquals(2, trackPoints.size());
         assertEquals(TrackPoint.Type.SEGMENT_START_MANUAL, trackPoints.get(0).getType());
@@ -226,7 +227,7 @@ public class TrackRecordingServiceTest {
         service.pauseCurrentTrack();
 
         // then
-        assertEquals(2, contentProviderUtils.getTrackPoints(trackId).size());
+        assertEquals(2, contentProviderUtils.getTrackPointCursor(trackId, null).getCount());
 
         //when
         service.resumeTrack(trackId);
@@ -235,7 +236,7 @@ public class TrackRecordingServiceTest {
         assertTrue(service.isRecording());
         assertEquals(trackId, service.getRecordingTrackId());
 
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         assertEquals(3, trackPoints.size());
         assertEquals(TrackPoint.Type.SEGMENT_START_MANUAL, trackPoints.get(0).getType());
         assertEquals(TrackPoint.Type.SEGMENT_END_MANUAL, trackPoints.get(1).getType());
@@ -251,7 +252,7 @@ public class TrackRecordingServiceTest {
         assertTrue(service.isRecording());
         service.endCurrentTrack();
 
-        assertEquals(2, contentProviderUtils.getTrackPoints(trackId).size());
+        assertEquals(2, contentProviderUtils.getTrackPointCursor(trackId, null).getCount());
 
         // when
         service.resumeTrack(trackId);
@@ -261,7 +262,7 @@ public class TrackRecordingServiceTest {
         assertTrue(service.isRecording());
         assertEquals(trackId, service.getRecordingTrackId());
 
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         assertEquals(4, trackPoints.size());
         assertEquals(TrackPoint.Type.SEGMENT_START_MANUAL, trackPoints.get(0).getType());
         assertEquals(TrackPoint.Type.SEGMENT_END_MANUAL, trackPoints.get(1).getType());
@@ -278,7 +279,7 @@ public class TrackRecordingServiceTest {
         assertTrue(service.isRecording());
         service.pauseCurrentTrack();
 
-        assertEquals(2, contentProviderUtils.getTrackPoints(trackId).size());
+        assertEquals(2, contentProviderUtils.getTrackPointCursor(trackId, null).getCount());
 
         // when
         service.endCurrentTrack();
@@ -287,7 +288,7 @@ public class TrackRecordingServiceTest {
         assertFalse(service.isRecording());
         assertNull(service.getRecordingTrackId());
 
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         assertEquals(2, trackPoints.size());
         assertEquals(TrackPoint.Type.SEGMENT_START_MANUAL, trackPoints.get(0).getType());
         assertEquals(TrackPoint.Type.SEGMENT_END_MANUAL, trackPoints.get(1).getType());

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLocation.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLocation.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
@@ -104,7 +105,7 @@ public class TrackRecordingServiceTestLocation {
         // then
         assertFalse(service.isRecording());
 
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         assertEquals(8, trackPoints.size());
         assertTrackPoints(List.of(
                 new Pair<>(TrackPoint.Type.SEGMENT_START_MANUAL, null),
@@ -138,7 +139,7 @@ public class TrackRecordingServiceTestLocation {
         // then
         assertFalse(service.isRecording());
 
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         assertEquals(4, trackPoints.size());
         assertTrackPoints(List.of(
                 new Pair<>(TrackPoint.Type.SEGMENT_START_MANUAL, null),
@@ -185,7 +186,7 @@ public class TrackRecordingServiceTestLocation {
         // then
         assertFalse(service.isRecording());
 
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         assertTrackPoints(List.of(
                 new Pair<>(TrackPoint.Type.SEGMENT_START_MANUAL, null),
                 new Pair<>(TrackPoint.Type.TRACKPOINT, 1),
@@ -214,7 +215,7 @@ public class TrackRecordingServiceTestLocation {
         // then
         assertFalse(service.isRecording());
 
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         assertEquals(6, trackPoints.size());
         assertTrackPoints(List.of(
                 new Pair<>(TrackPoint.Type.SEGMENT_START_MANUAL, null),
@@ -260,7 +261,7 @@ public class TrackRecordingServiceTestLocation {
         // then
         assertFalse(service.isRecording());
 
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         assertEquals(8, trackPoints.size());
         assertTrackPoints(List.of(
                 new Pair<>(TrackPoint.Type.SEGMENT_START_MANUAL, null),
@@ -292,7 +293,7 @@ public class TrackRecordingServiceTestLocation {
         // then
         assertFalse(service.isRecording());
 
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId);
+        List<TrackPoint> trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         assertEquals(7, trackPoints.size());
         assertTrackPoints(List.of(
                 new Pair<>(TrackPoint.Type.SEGMENT_START_MANUAL, null),

--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
@@ -1,27 +1,36 @@
 package de.dennisguse.opentracks.stats;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.time.Duration;
+import java.time.Instant;
 
 import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.content.data.Track;
+import de.dennisguse.opentracks.content.data.TrackPoint;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(AndroidJUnit4.class)
 public class TrackStatisticsUpdaterTest {
 
+    private static final int GPS_DISTANCE = 50;
+
     @Test
-    public void addTrackPoint() {
+    public void addTrackPoint_TestingTrack() {
         // given
         TestDataUtil.TrackData data = TestDataUtil.createTestingTrack(new Track.Id(1));
 
         // when
-        TrackStatisticsUpdater updater = new TrackStatisticsUpdater();
-        data.trackPoints.forEach(it -> updater.addTrackPoint(it, 50));
+        TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
+        data.trackPoints.forEach(it -> subject.addTrackPoint(it, GPS_DISTANCE));
 
         // then
-        TrackStatistics statistics = updater.getTrackStatistics();
+        TrackStatistics statistics = subject.getTrackStatistics();
         assertEquals(85.35, statistics.getTotalDistance(), 0.01);
         assertEquals(Duration.ofMillis(13999), statistics.getTotalTime());
         assertEquals(Duration.ofSeconds(6), statistics.getMovingTime());
@@ -34,5 +43,123 @@ public class TrackStatisticsUpdaterTest {
         assertEquals(14.226, statistics.getMaxSpeed(), 0.01);
         assertEquals(14.226, statistics.getAverageMovingSpeed(), 0.01);
         assertEquals(6.566, statistics.getAverageSpeed(), 0.01);
+    }
+
+    @Test
+    public void addTrackPoint_distance_from_GPS_not_moving() {
+        // given
+        TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
+
+        TrackPoint tp1 = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochMilli(1000));
+        TrackPoint tp2 = new TrackPoint(0, 0, 5.0, Instant.ofEpochMilli(2000));
+        TrackPoint tp3 = new TrackPoint(0.00001, 0, 5.0, Instant.ofEpochMilli(3000));
+
+        // when
+        subject.addTrackPoint(tp1, GPS_DISTANCE);
+        subject.addTrackPoint(tp2, GPS_DISTANCE);
+        subject.addTrackPoint(tp3, GPS_DISTANCE);
+
+        // then
+        assertEquals(0, subject.getTrackStatistics().getTotalDistance(), 0.01);
+    }
+
+    @Test
+    public void addTrackPoint_distance_from_GPS_moving() {
+        // given
+        TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
+
+        TrackPoint tp1 = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochMilli(1000));
+        TrackPoint tp2 = new TrackPoint(0, 0, 5.0, Instant.ofEpochMilli(2000));
+        TrackPoint tp3 = new TrackPoint(0.00001, 0, 5.0, Instant.ofEpochMilli(3000));
+        tp3.setSpeed(5f);
+
+        // when
+        subject.addTrackPoint(tp1, GPS_DISTANCE);
+        subject.addTrackPoint(tp2, GPS_DISTANCE);
+        subject.addTrackPoint(tp3, GPS_DISTANCE);
+
+        // then
+        assertEquals(1.10, subject.getTrackStatistics().getTotalDistance(), 0.01);
+    }
+
+    @Test
+    public void addTrackPoint_distance_from_GPS_moving_and_sensor_moving() {
+        // given
+        TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
+
+        TrackPoint tp1 = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochMilli(1000));
+        TrackPoint tp2 = new TrackPoint(0, 0, 5.0, Instant.ofEpochMilli(2000));
+        tp2.setSpeed(5f);
+        TrackPoint tp3 = new TrackPoint(0.001, 0, 5.0, Instant.ofEpochMilli(3000));
+        tp2.setSpeed(5f);
+        TrackPoint tp4 = new TrackPoint(0.001, 0, 5.0, Instant.ofEpochMilli(4000));
+        tp2.setSpeed(5f);
+        tp4.setSensorDistance(5f);
+        TrackPoint tp5 = new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.ofEpochMilli(5000));
+        tp5.setSensorDistance(10f);
+
+        // when
+        subject.addTrackPoint(tp1, GPS_DISTANCE);
+        subject.addTrackPoint(tp2, GPS_DISTANCE);
+        subject.addTrackPoint(tp3, GPS_DISTANCE);
+
+        // then
+        assertEquals(110.57, subject.getTrackStatistics().getTotalDistance(), 0.01);
+
+        // when
+        subject.addTrackPoint(tp4, GPS_DISTANCE);
+        subject.addTrackPoint(tp5, GPS_DISTANCE);
+
+        // then
+        assertEquals(125.57, subject.getTrackStatistics().getTotalDistance(), 0.01);
+    }
+
+    @Test
+    public void addTrackPoint_distance_from_GPS_not_moving_and_sensor_moving() {
+        // given
+        TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
+
+        TrackPoint tp1 = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochMilli(1000));
+        TrackPoint tp2 = new TrackPoint(0, 0, 5.0, Instant.ofEpochMilli(2000));
+        TrackPoint tp3 = new TrackPoint(0.00001, 0, 5.0, Instant.ofEpochMilli(3000));
+        TrackPoint tp4 = new TrackPoint(0.00001, 0, 5.0, Instant.ofEpochMilli(4000));
+        tp4.setSensorDistance(5f);
+        TrackPoint tp5 = new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.ofEpochMilli(5000));
+        tp5.setSensorDistance(10f);
+
+        // when
+        subject.addTrackPoint(tp1, GPS_DISTANCE);
+        subject.addTrackPoint(tp2, GPS_DISTANCE);
+        subject.addTrackPoint(tp3, GPS_DISTANCE);
+
+        // then
+        assertEquals(0, subject.getTrackStatistics().getTotalDistance(), 0.01);
+
+        // when
+        subject.addTrackPoint(tp4, GPS_DISTANCE);
+        subject.addTrackPoint(tp5, GPS_DISTANCE);
+
+        // then
+        assertEquals(15, subject.getTrackStatistics().getTotalDistance(), 0.01);
+    }
+
+    @Ignore("TODO: create a concept ont to compute speed from GPS and sensor")
+    @Test
+    public void addTrackPoint_speed_from_GPS_not_moving() {
+    }
+
+    @Ignore("TODO: create a concept ont to compute speed from GPS and sensor")
+    @Test
+    public void addTrackPoint_speed_from_GPS_moving() {
+    }
+
+    @Ignore("TODO: create a concept ont to compute speed from GPS and sensor")
+    @Test
+    public void addTrackPoint_speed_from_GPS_not_moving_and_sensor_speed() {
+    }
+
+    @Ignore("TODO: create a concept ont to compute speed from GPS and sensor")
+    @Test
+    public void addTrackPoint_speed_from_GPS_moving_and_sensor_speed() {
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/util/BluetoothUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/BluetoothUtilsTest.java
@@ -47,7 +47,7 @@ public class BluetoothUtilsTest {
 
         // then
         assertEquals(200, sensor.getCadence().getCrankRevolutionsCount());
-        assertNull(sensor.getSpeed());
+        assertNull(sensor.getDistanceSpeed());
     }
 
     @Test
@@ -60,7 +60,7 @@ public class BluetoothUtilsTest {
 
         // then
         assertNull(sensor.getCadence());
-        assertEquals(225, sensor.getSpeed().getWheelRevolutionsCount());
+        assertEquals(225, sensor.getDistanceSpeed().getWheelRevolutionsCount());
     }
 
     @Test
@@ -73,7 +73,7 @@ public class BluetoothUtilsTest {
 
         // then
         assertEquals(200, sensor.getCadence().getCrankRevolutionsCount());
-        assertEquals(225, sensor.getSpeed().getWheelRevolutionsCount());
+        assertEquals(225, sensor.getDistanceSpeed().getWheelRevolutionsCount());
     }
 
     @Test

--- a/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
@@ -57,6 +57,7 @@ public class TrackPoint {
     private Double altitude_m;
     private Float speed_mps;
     private Float bearing;
+    private Float sensorDistance_m;
 
     public enum Type {
         SEGMENT_START_MANUAL(-2), //Start of a segment due to user interaction (start, resume)
@@ -224,7 +225,7 @@ public class TrackPoint {
         return elevationGain != null;
     }
 
-    public Float getElevationGain() {
+    public float getElevationGain() {
         return elevationGain;
     }
 
@@ -310,8 +311,12 @@ public class TrackPoint {
         this.accuracy = horizontalAccuracy;
     }
 
-    public float distanceTo(@NonNull TrackPoint dest) {
-        return getLocation().distanceTo(dest.getLocation());
+    public float distanceToPrevious(@NonNull TrackPoint previous) {
+        if (hasSensorDistance()) {
+            return getSensorDistance();
+        }
+
+        return getLocation().distanceTo(previous.getLocation());
     }
 
     public boolean fulfillsAccuracy(int poorAccuracy) {
@@ -327,6 +332,18 @@ public class TrackPoint {
     }
 
     // Sensor data
+    public boolean hasSensorDistance() {
+        return sensorDistance_m != null;
+    }
+
+    public Float getSensorDistance() {
+        return sensorDistance_m;
+    }
+
+    public void setSensorDistance(Float distance_m) {
+        this.sensorDistance_m = distance_m;
+    }
+
     public boolean hasSensorData() {
         return hasHeartRate() || hasCyclingCadence() || hasPower();
     }
@@ -347,7 +364,7 @@ public class TrackPoint {
         return cyclingCadence_rpm != null;
     }
 
-    public Float getCyclingCadence_rpm() {
+    public float getCyclingCadence_rpm() {
         return cyclingCadence_rpm;
     }
 
@@ -359,7 +376,7 @@ public class TrackPoint {
         return power != null;
     }
 
-    public Float getPower() {
+    public float getPower() {
         return power;
     }
 

--- a/src/main/java/de/dennisguse/opentracks/content/data/TrackPointsColumns.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TrackPointsColumns.java
@@ -50,6 +50,7 @@ public interface TrackPointsColumns extends BaseColumns {
     String BEARING = "bearing";
     String SENSOR_HEARTRATE = "sensor_heartrate";
     String SENSOR_CADENCE = "sensor_cadence";
+    String SENSOR_DISTANCE = "sensor_distance"; //DISTANCE from previous TrackPoint
     String SENSOR_POWER = "sensor_power";
     String ELEVATION_GAIN = "elevation_gain";
     String ELEVATION_LOSS = "elevation_loss";
@@ -77,6 +78,7 @@ public interface TrackPointsColumns extends BaseColumns {
             + ELEVATION_GAIN + " FLOAT, "
             + ELEVATION_LOSS + " FLOAT, "
             + TYPE + " TEXT CHECK(type IN (-2, -1, 0, 1)), "
+            + SENSOR_DISTANCE + " FLOAT, "
             + "FOREIGN KEY (" + TRACKID + ") REFERENCES " + TracksColumns.TABLE_NAME + "(" + TracksColumns._ID + ") ON UPDATE CASCADE ON DELETE CASCADE"
             + ")";
 

--- a/src/main/java/de/dennisguse/opentracks/content/provider/CachedTrackPointsIndexes.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/CachedTrackPointsIndexes.java
@@ -19,6 +19,7 @@ class CachedTrackPointsIndexes {
     final int bearingIndex;
     final int sensorHeartRateIndex;
     final int sensorCadenceIndex;
+    final int sensorDistanceIndex;
     final int sensorPowerIndex;
     final int elevationGainIndex;
     final int elevationLossIndex;
@@ -35,6 +36,7 @@ class CachedTrackPointsIndexes {
         bearingIndex = cursor.getColumnIndexOrThrow(TrackPointsColumns.BEARING);
         sensorHeartRateIndex = cursor.getColumnIndexOrThrow(TrackPointsColumns.SENSOR_HEARTRATE);
         sensorCadenceIndex = cursor.getColumnIndexOrThrow(TrackPointsColumns.SENSOR_CADENCE);
+        sensorDistanceIndex = cursor.getColumnIndexOrThrow(TrackPointsColumns.SENSOR_DISTANCE);
         sensorPowerIndex = cursor.getColumnIndexOrThrow(TrackPointsColumns.SENSOR_POWER);
         elevationGainIndex = cursor.getColumnIndexOrThrow(TrackPointsColumns.ELEVATION_GAIN);
         elevationLossIndex = cursor.getColumnIndexOrThrow(TrackPointsColumns.ELEVATION_LOSS);

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -758,23 +758,6 @@ public class ContentProviderUtils {
         return contentResolver.query(TrackPointsColumns.CONTENT_URI_BY_ID, projection, selection, selectionArgs, sortOrder);
     }
 
-    @Deprecated //Use TrackPointIterator instead
-    @VisibleForTesting
-    public List<TrackPoint> getTrackPoints(Track.Id trackId) {
-        List<TrackPoint> trackPoints;
-
-        try (Cursor trackPointCursor = getTrackPointCursor(trackId, null)) {
-            trackPointCursor.moveToFirst();
-            trackPoints = new ArrayList<>(trackPointCursor.getCount());
-            for (int i = 0; i < trackPointCursor.getCount(); i++) {
-                trackPoints.add(createTrackPoint(trackPointCursor));
-                trackPointCursor.moveToNext();
-            }
-        }
-
-        return trackPoints;
-    }
-
     public static String formatIdListForUri(Track.Id... trackIds) {
         long[] ids = new long[trackIds.length];
         for (int i = 0; i < trackIds.length; i++) {

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -556,6 +556,9 @@ public class ContentProviderUtils {
         if (!cursor.isNull(indexes.sensorCadenceIndex)) {
             trackPoint.setCyclingCadence_rpm(cursor.getFloat(indexes.sensorCadenceIndex));
         }
+        if (!cursor.isNull(indexes.sensorDistanceIndex)) {
+            trackPoint.setSensorDistance(cursor.getFloat(indexes.sensorDistanceIndex));
+        }
         if (!cursor.isNull(indexes.sensorPowerIndex)) {
             trackPoint.setPower(cursor.getFloat(indexes.sensorPowerIndex));
         }
@@ -707,6 +710,9 @@ public class ContentProviderUtils {
         }
         if (trackPoint.hasCyclingCadence()) {
             values.put(TrackPointsColumns.SENSOR_CADENCE, trackPoint.getCyclingCadence_rpm());
+        }
+        if (trackPoint.hasSensorDistance()) {
+            values.put(TrackPointsColumns.SENSOR_DISTANCE, trackPoint.getSensorDistance());
         }
         if (trackPoint.hasPower()) {
             values.put(TrackPointsColumns.SENSOR_POWER, trackPoint.getPower());

--- a/src/main/java/de/dennisguse/opentracks/content/provider/TrackPointIterator.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/TrackPointIterator.java
@@ -3,6 +3,7 @@ package de.dennisguse.opentracks.content.provider;
 import android.database.Cursor;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -49,6 +50,11 @@ public class TrackPointIterator implements Iterator<TrackPoint>, AutoCloseable {
             throw new NoSuchElementException();
         }
         return ContentProviderUtils.fillTrackPoint(cursor, indexes);
+    }
+
+    @VisibleForTesting
+    public int getCount() {
+        return cursor.getCount();
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/content/sensor/SensorData.java
+++ b/src/main/java/de/dennisguse/opentracks/content/sensor/SensorData.java
@@ -55,10 +55,22 @@ public abstract class SensorData<T> {
     }
 
     /**
+     * Reset long term aggregated values (more than derived from previous SensorData). e.g. overall distance.
+     */
+    public void reset() {
+    }
+
+    /**
      * Is the data recent considering the current time.
      */
     public boolean isRecent() {
         return Instant.now()
                 .isBefore(time.plus(BluetoothRemoteSensorManager.MAX_SENSOR_DATE_SET_AGE_MS));
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "sensorAddress='" + sensorAddress;
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataCycling.java
+++ b/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataCycling.java
@@ -127,6 +127,8 @@ public final class SensorDataCycling {
                     value = null;
                 } else {
                     long wheelDiff = UintUtils.diff(wheelRevolutionsCount, previous.wheelRevolutionsCount, UintUtils.UINT16_MAX);
+                    wheelDiff = Math.abs(wheelDiff); //HACK for Garmin Speed 2 as it some of those seem to count backwards
+
                     double timeDiff_s = timeDiff_ms * UnitConversions.MS_TO_S;
                     float distance_m = (float) (wheelDiff * wheel_circumference_mm * UnitConversions.MM_TO_M);
                     float distance_overall_m = distance_m;

--- a/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataCyclingPower.java
+++ b/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataCyclingPower.java
@@ -16,6 +16,6 @@ public class SensorDataCyclingPower extends SensorData<Float> {
     @NonNull
     @Override
     public String toString() {
-        return "power=" + value;
+        return super.toString() + " power=" + value;
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataHeartRate.java
+++ b/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataHeartRate.java
@@ -16,6 +16,6 @@ public class SensorDataHeartRate extends SensorData<Float> {
     @NonNull
     @Override
     public String toString() {
-        return "heart=" + value;
+        return super.toString() + " heart=" + value;
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataSet.java
+++ b/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataSet.java
@@ -10,7 +10,7 @@ public final class SensorDataSet {
 
     private SensorDataCycling.Cadence cyclingCadence;
 
-    private SensorDataCycling.Speed cyclingSpeed;
+    private SensorDataCycling.DistanceSpeed cyclingDistanceSpeed;
 
     private SensorDataCyclingPower cyclingPower;
 
@@ -25,8 +25,8 @@ public final class SensorDataSet {
         return cyclingCadence;
     }
 
-    public SensorDataCycling.Speed getCyclingSpeed() {
-        return cyclingSpeed;
+    public SensorDataCycling.DistanceSpeed getCyclingDistanceSpeed() {
+        return cyclingDistanceSpeed;
     }
 
     public SensorDataCyclingPower getCyclingPower() {
@@ -44,7 +44,7 @@ public final class SensorDataSet {
     public void clear() {
         this.heartRate = null;
         this.cyclingCadence = null;
-        this.cyclingSpeed = null;
+        this.cyclingDistanceSpeed = null;
         this.cyclingPower = null;
     }
 
@@ -57,8 +57,9 @@ public final class SensorDataSet {
             trackPoint.setCyclingCadence_rpm(cyclingCadence.getValue());
         }
 
-        if (cyclingSpeed != null && cyclingSpeed.hasValue()) {
-            trackPoint.setSpeed(cyclingSpeed.getValue());
+        if (cyclingDistanceSpeed != null && cyclingDistanceSpeed.hasValue()) {
+            trackPoint.setSensorDistance(cyclingDistanceSpeed.getValue().distance_overall_m);
+            trackPoint.setSpeed(cyclingDistanceSpeed.getValue().speed_mps);
         }
 
         if (cyclingPower != null && cyclingPower.hasValue()) {
@@ -66,12 +67,19 @@ public final class SensorDataSet {
         }
     }
 
+    public void reset() {
+        if (heartRate != null) heartRate.reset();
+        if (cyclingCadence != null) cyclingCadence.reset();
+        if (cyclingDistanceSpeed != null) cyclingDistanceSpeed.reset();
+        if (cyclingPower != null) cyclingPower.reset();
+    }
+
     @NonNull
     @Override
     public String toString() {
         return (getHeartRate() != null ? "" + getHeartRate() : "")
                 + (getCyclingCadence() != null ? " " + getCyclingCadence() : "")
-                + (getCyclingSpeed() != null ? " " + getCyclingSpeed() : "")
+                + (getCyclingDistanceSpeed() != null ? " " + getCyclingDistanceSpeed() : "")
                 + (getCyclingPower() != null ? " " + getCyclingPower() : "");
     }
 
@@ -85,8 +93,8 @@ public final class SensorDataSet {
             this.cyclingCadence = (SensorDataCycling.Cadence) data;
             return;
         }
-        if (type instanceof SensorDataCycling.Speed) {
-            this.cyclingSpeed = (SensorDataCycling.Speed) data;
+        if (type instanceof SensorDataCycling.DistanceSpeed) {
+            this.cyclingDistanceSpeed = (SensorDataCycling.DistanceSpeed) data;
             return;
         }
 

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
@@ -62,6 +62,7 @@ public class StatisticsRecordingFragment extends Fragment implements TrackDataLi
     private TrackRecordingServiceConnection trackRecordingServiceConnection = new TrackRecordingServiceConnection();
     private TrackPoint lastTrackPoint;
 
+    //TODO Should not be nullable
     private TrackStatistics lastTrackStatistics;
 
     private String category = "";
@@ -366,29 +367,26 @@ public class StatisticsRecordingFragment extends Fragment implements TrackDataLi
     }
 
     private void setSpeedSensorData(SensorDataSet sensorDataSet) {
-        if (sensorDataSet != null && sensorDataSet.getCyclingSpeed() != null) {
-            SensorDataCycling.Speed data = sensorDataSet.getCyclingSpeed();
+        if (sensorDataSet != null && sensorDataSet.getCyclingDistanceSpeed() != null) {
+            SensorDataCycling.DistanceSpeed data = sensorDataSet.getCyclingDistanceSpeed();
 
             if (data.hasValue() && data.isRecent()) {
-                setSpeed(data.getValue());
+                setTotalDistance(data.getValue().distance_overall_m);
+                setSpeed(data.getValue().speed_mps);
+            }
+            if (data.hasValue() && data.isRecent()) {
+                setSpeed(data.getValue().speed_mps);
             }
         }
     }
 
     private void updateStats() {
-        String trackIconValue = TrackIconUtils.getIconValue(getContext(), category);
 
-        // Set total distance
-        {
-            double totalDistance = lastTrackStatistics == null ? Double.NaN : lastTrackStatistics.getTotalDistance();
-            Pair<String, String> parts = StringUtils.getDistanceParts(getContext(), totalDistance, preferenceMetricUnits);
-
-            viewBinding.statsDistanceValue.setText(parts.first);
-            viewBinding.statsDistanceUnit.setText(parts.second);
-        }
+        setTotalDistance(0);
 
         // Set activity type
         {
+            String trackIconValue = TrackIconUtils.getIconValue(getContext(), category);
             viewBinding.statsActivityTypeIcon.setEnabled(isSelectedTrackRecording());
             viewBinding.statsActivityTypeIcon.setImageResource(TrackIconUtils.getIconDrawable(trackIconValue));
         }
@@ -477,6 +475,14 @@ public class StatisticsRecordingFragment extends Fragment implements TrackDataLi
             viewBinding.statsLatitudeValue.setText(latitudeText);
             viewBinding.statsLongitudeValue.setText(longitudeText);
         }
+    }
+
+    private void setTotalDistance(double sensorDistanceSinceLastTrackpoint) {
+        double totalDistance = lastTrackStatistics != null ? (lastTrackStatistics.getTotalDistance() + sensorDistanceSinceLastTrackpoint) : Double.NaN;
+        Pair<String, String> parts = StringUtils.getDistanceParts(getContext(), totalDistance, preferenceMetricUnits);
+
+        viewBinding.statsDistanceValue.setText(parts.first);
+        viewBinding.statsDistanceUnit.setText(parts.second);
     }
 
     private void setSpeed(double speed) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
@@ -49,6 +49,7 @@ public class GPXTrackExporter implements TrackExporter {
     private static final NumberFormat ELEVATION_FORMAT = NumberFormat.getInstance(Locale.US);
     private static final NumberFormat COORDINATE_FORMAT = NumberFormat.getInstance(Locale.US);
     private static final NumberFormat SPEED_FORMAT = NumberFormat.getInstance(Locale.US);
+    private static final NumberFormat DISTANCE_FORMAT = NumberFormat.getInstance(Locale.US);
     private static final NumberFormat HEARTRATE_FORMAT = NumberFormat.getInstance(Locale.US);
     private static final NumberFormat CADENCE_FORMAT = NumberFormat.getInstance(Locale.US);
     private static final NumberFormat POWER_FORMAT = NumberFormat.getInstance(Locale.US);
@@ -310,6 +311,10 @@ public class GPXTrackExporter implements TrackExporter {
 
                 if (trackPoint.hasElevationLoss()) {
                     printWriter.println("<opentracks:loss>" + ELEVATION_FORMAT.format(trackPoint.getElevationLoss()) + "</opentracks:loss>");
+                }
+
+                if (trackPoint.hasSensorDistance()) {
+                    printWriter.println("<opentracks:distance>" + DISTANCE_FORMAT.format(trackPoint.getElevationLoss()) + "</opentracks:distance>");
                 }
 
                 printWriter.println("</gpxtpx:TrackPointExtension></extensions>");

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
@@ -57,6 +57,7 @@ public class KMLTrackExporter implements TrackExporter {
     private static final String SCHEMA_ID = "schema";
 
     public static final String EXTENDED_DATA_TYPE_SPEED = "speed";
+    public static final String EXTENDED_DATA_TYPE_DISTANCE = "distance";
     public static final String EXTENDED_DATA_TYPE_CADENCE = "cadence";
     public static final String EXTENDED_DATA_TYPE_HEART_RATE = "heart_rate";
     public static final String EXTENDED_DATA_TYPE_POWER = "power";
@@ -74,6 +75,7 @@ public class KMLTrackExporter implements TrackExporter {
 
     private PrintWriter printWriter;
     private final List<Float> speedList = new ArrayList<>();
+    private final List<Float> distanceList = new ArrayList<>();
     private final List<Float> powerList = new ArrayList<>();
     private final List<Float> cadenceList = new ArrayList<>();
     private final List<Float> heartRateList = new ArrayList<>();
@@ -338,6 +340,7 @@ public class KMLTrackExporter implements TrackExporter {
         if (printWriter != null) {
             printWriter.println("<gx:Track>");
             speedList.clear();
+            distanceList.clear();
             powerList.clear();
             cadenceList.clear();
             heartRateList.clear();
@@ -355,6 +358,9 @@ public class KMLTrackExporter implements TrackExporter {
                 writeSimpleArrayData(speedList, EXTENDED_DATA_TYPE_SPEED);
             }
             if (exportSensorData) {
+                if (distanceList.stream().anyMatch(Objects::nonNull)) {
+                    writeSimpleArrayData(distanceList, EXTENDED_DATA_TYPE_DISTANCE);
+                }
                 if (powerList.stream().anyMatch(Objects::nonNull)) {
                     writeSimpleArrayData(powerList, EXTENDED_DATA_TYPE_POWER);
                 }
@@ -392,6 +398,7 @@ public class KMLTrackExporter implements TrackExporter {
             speedList.add(trackPoint.hasSpeed() ? trackPoint.getSpeed() : null);
 
             if (exportSensorData) {
+                distanceList.add(trackPoint.hasSensorDistance() ? trackPoint.getSensorDistance() : null);
                 heartRateList.add(trackPoint.hasHeartRate() ? trackPoint.getHeartRate_bpm() : null);
                 cadenceList.add(trackPoint.hasCyclingCadence() ? trackPoint.getCyclingCadence_rpm() : null);
                 powerList.add(trackPoint.hasPower() ? trackPoint.getPower() : null);

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
@@ -63,6 +63,7 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
 
     private static final String TAG_EXTENSION_GAIN = "opentracks:gain";
     private static final String TAG_EXTENSION_LOSS = "opentracks:loss";
+    private static final String TAG_EXTENSION_DISTANCE = "opentracks:distance";
 
     /**
      * Constructor.
@@ -177,6 +178,11 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
             case TAG_EXTENSION_LOSS:
                 if (content != null) {
                     loss = content.trim();
+                }
+                break;
+            case TAG_EXTENSION_DISTANCE:
+                if (content != null) {
+                    distance = content.trim();
                 }
                 break;
         }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
@@ -66,6 +66,7 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
     private String extendedDataType;
     private final ArrayList<TrackPoint> trackPoints = new ArrayList<>();
     private final ArrayList<Float> speedList = new ArrayList<>();
+    private final ArrayList<Float> distanceList = new ArrayList<>();
     private final ArrayList<Float> cadenceList = new ArrayList<>();
     private final ArrayList<Float> heartRateList = new ArrayList<>();
     private final ArrayList<Float> powerList = new ArrayList<>();
@@ -216,6 +217,7 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
         super.onTrackSegmentStart();
         trackPoints.clear();
         speedList.clear();
+        distanceList.clear();
         heartRateList.clear();
         cadenceList.clear();
         powerList.clear();
@@ -231,6 +233,9 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
 
             if (i < speedList.size()) {
                 trackPoint.setSpeed(speedList.get(i));
+            }
+            if (i < distanceList.size()) {
+                trackPoint.setSensorDistance(distanceList.get(i));
             }
             if (i < heartRateList.size()) {
                 trackPoint.setHeartRate_bpm(heartRateList.get(i));
@@ -309,6 +314,9 @@ public class KmlFileTrackImporter extends AbstractFileTrackImporter {
         switch (extendedDataType) {
             case KMLTrackExporter.EXTENDED_DATA_TYPE_SPEED:
                 speedList.add(value);
+                break;
+            case KMLTrackExporter.EXTENDED_DATA_TYPE_DISTANCE:
+                distanceList.add(value);
                 break;
             case KMLTrackExporter.EXTENDED_DATA_TYPE_POWER:
                 powerList.add(value);

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -571,7 +571,7 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
             return;
         }
 
-        double distanceToLastTrackLocation = trackPoint.distanceTo(lastValidTrackPoint);
+        double distanceToLastTrackLocation = trackPoint.distanceToPrevious(lastValidTrackPoint);
         if (distanceToLastTrackLocation > maxRecordingDistance) {
             insertTrackPointIfNewer(track, lastTrackPoint);
 
@@ -663,6 +663,10 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
                 trackPoint.setElevationGain(elevationSumManager.getElevationGain_m());
                 trackPoint.setElevationLoss(elevationSumManager.getElevationLoss_m());
                 elevationSumManager.reset();
+            }
+            if (remoteSensorManager != null) {
+                fillWithSensorDataSet(trackPoint);
+                remoteSensorManager.reset();
             }
             contentProviderUtils.insertTrackPoint(trackPoint, track.getId());
             trackStatisticsUpdater.addTrackPoint(trackPoint, recordingDistanceInterval);

--- a/src/main/java/de/dennisguse/opentracks/services/sensors/BluetoothConnectionManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/sensors/BluetoothConnectionManager.java
@@ -220,7 +220,13 @@ public abstract class BluetoothConnectionManager {
         protected SensorDataCycling.DistanceSpeed parsePayload(String sensorName, String address, BluetoothGattCharacteristic characteristic) {
             SensorDataCycling.CadenceAndSpeed cadenceAndSpeed = BluetoothUtils.parseCyclingCrankAndWheel(address, sensorName, characteristic);
             if (cadenceAndSpeed != null) {
-                return cadenceAndSpeed.getDistanceSpeed();
+                // Workaround for Garmin Speed Sensor 2: provides cadence instead of speed
+                SensorDataCycling.DistanceSpeed result = cadenceAndSpeed.getDistanceSpeed();
+                if (result == null && cadenceAndSpeed.getCadence() != null) {
+                    result = new SensorDataCycling.DistanceSpeed(cadenceAndSpeed.getSensorAddress(), cadenceAndSpeed.getSensorName(), (int) cadenceAndSpeed.getCadence().getCrankRevolutionsCount(), cadenceAndSpeed.getCadence().getCrankRevolutionsTime());
+                }
+
+                return result;
             }
             return null;
         }

--- a/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
+++ b/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
@@ -23,12 +23,13 @@ import android.speech.tts.TextToSpeech;
 import android.speech.tts.UtteranceProgressListener;
 import android.util.Log;
 
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Locale;
 
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
+import de.dennisguse.opentracks.content.provider.TrackPointIterator;
 import de.dennisguse.opentracks.services.TrackRecordingService;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.util.AnnouncementUtils;
@@ -172,8 +173,13 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
         Track track = contentProviderUtils.getTrack(PreferencesUtils.getRecordingTrackId(sharedPreferences, context));
         String category = track != null ? track.getCategory() : "";
 
-        //TODO Querying all TrackPoints all the time is inefficient; use TrackDataHub
-        List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(track.getId());
+        //TODO Querying all TrackPoints all the time is inefficient; use TrackDataHub or something else.
+        TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), null);
+        ArrayList<TrackPoint> trackPoints = new ArrayList<>();
+        while (trackPointIterator.hasNext()) {
+            trackPoints.add(trackPointIterator.next());
+        }
+
         boolean isMetricUnits = PreferencesUtils.isMetricUnits(sharedPreferences, context);
         boolean isReportSpeed = PreferencesUtils.isReportSpeed(sharedPreferences, context, category);
 

--- a/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
+++ b/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
@@ -172,6 +172,7 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
         Track track = contentProviderUtils.getTrack(PreferencesUtils.getRecordingTrackId(sharedPreferences, context));
         String category = track != null ? track.getCategory() : "";
 
+        //TODO Querying all TrackPoints all the time is inefficient; use TrackDataHub
         List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(track.getId());
         boolean isMetricUnits = PreferencesUtils.isMetricUnits(sharedPreferences, context);
         boolean isReportSpeed = PreferencesUtils.isReportSpeed(sharedPreferences, context, category);

--- a/src/main/java/de/dennisguse/opentracks/util/BluetoothUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/BluetoothUtils.java
@@ -126,12 +126,12 @@ public class BluetoothUtils {
             cadence = new SensorDataCycling.Cadence(address, sensorName, crankCount, crankTime);
         }
 
-        SensorDataCycling.Speed speed = null;
+        SensorDataCycling.DistanceSpeed speed = null;
         if (hasWheel && valueLength - index >= 4) {
             int wheelCount = characteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT16, index);
             index += 2;
             int wheelTime = characteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT16, index); // 1/1024s
-            speed = new SensorDataCycling.Speed(address, sensorName, wheelCount, wheelTime);
+            speed = new SensorDataCycling.DistanceSpeed(address, sensorName, wheelCount, wheelTime);
         }
 
         return new SensorDataCycling.CadenceAndSpeed(address, sensorName, cadence, speed);

--- a/src/main/java/de/dennisguse/opentracks/util/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/PreferencesUtils.java
@@ -42,6 +42,7 @@ public class PreferencesUtils {
     private PreferencesUtils() {
     }
 
+    @Deprecated //Should only be used to get a sharedPreference for more than one interaction!
     public static SharedPreferences getSharedPreferences(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context);
     }
@@ -101,7 +102,6 @@ public class PreferencesUtils {
         editor.putBoolean(getKey(context, keyId), value);
         editor.apply();
     }
-
 
     private static int getInt(SharedPreferences sharedPreferences, Context context, int keyId, int defaultValue) {
         try {
@@ -205,7 +205,6 @@ public class PreferencesUtils {
     public static String getBluetoothCyclingPowerSensorAddress(SharedPreferences sharedPreferences, Context context) {
         return getString(sharedPreferences, context, R.string.settings_sensor_bluetooth_cycling_power_key, getBluetoothSensorAddressNone(context));
     }
-
 
     public static boolean shouldShowStatsOnLockscreen(SharedPreferences sharedPreferences, Context context) {
         final boolean STATS_SHOW_ON_LOCKSCREEN_DEFAULT = context.getResources().getBoolean(R.bool.stats_show_on_lockscreen_while_recording_default);

--- a/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatistics.java
@@ -33,7 +33,7 @@ public class IntervalStatistics {
             TrackPoint trackPoint = trackPoints.get(i);
 
             if (trackPoint.hasLocation() && prevTrackPoint.hasLocation()) {
-                interval.distance_m += prevTrackPoint.distanceTo(trackPoint);
+                interval.distance_m += prevTrackPoint.distanceToPrevious(trackPoint);
                 interval.time = interval.time.plus(Duration.between(prevTrackPoint.getTime(), trackPoint.getTime()));
                 interval.gain_m += trackPoint.hasElevationGain() ? trackPoint.getElevationGain() : 0;
                 interval.loss_m += trackPoint.hasElevationLoss() ? trackPoint.getElevationLoss() : 0;


### PR DESCRIPTION
For cycling, we already support wheel rotation (aka speed) sensors.
These can also be used to distance (actually easier than computing the speed).

This PR contains:
* [x] distance derive distance between two sensor measurements (like speed)
* [x] store distance in an extra column (sensor_distance)
* [x] adapt trackStatistics to either use sensor_distance or distance from previous trackpoint (old behavior)
* [x] export distance to KML/KMZ
* [x] (kind ugly) we need to store the distance between two  trackpoints somehow (SensorData only supports between two sensor measurements).
  Actually, we need some integration (e.g., averaging?) of sensor measurements as so far we only store the last provided value; see https://github.com/OpenTracksApp/OpenTracks/pull/592#issuecomment-775488089
* [x] check Garmin Speed 2
* [x] extend trackStatisticsUpdater
* [ ] do some actual testing