### PR TITLE
Normalize hr, cadence and power averages

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TestSensorDataUtil.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TestSensorDataUtil.java
@@ -1,0 +1,92 @@
+package de.dennisguse.opentracks.content.data;
+
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestSensorDataUtil {
+
+    private List<TrackPoint> trackPointList = new ArrayList<>();
+    private List<SensorData> sensorDataList = new ArrayList<>();
+
+    public void add(Instant time, Float hr, Float cadence, Float power, TrackPoint.Type type) {
+        sensorDataList.add(new TestSensorDataUtil.SensorData(time, hr, cadence, power, type));
+        TrackPoint tp = new TrackPoint(type);
+        int i = trackPointList.size() + 1;
+        tp.setLatitude(TestDataUtil.INITIAL_LATITUDE + (double) i / 10000.0);
+        tp.setLongitude(TestDataUtil.INITIAL_LONGITUDE - (double) i / 10000.0);
+        tp.setHeartRate_bpm(hr);
+        tp.setCyclingCadence_rpm(cadence);
+        tp.setPower(power);
+        tp.setAccuracy(1f);
+        tp.setAltitude(1f);
+        tp.setTime(time);
+        tp.setSpeed(5f + (i / 10f));
+        tp.setElevationGain(3f);
+        tp.setElevationLoss(3f);
+        trackPointList.add(tp);
+    }
+
+    public List<TrackPoint> getTrackPointList() {
+        return this.trackPointList;
+    }
+
+    public SensorDataStats computeStats() {
+        if (sensorDataList == null || sensorDataList.size() <= 1) {
+            return null;
+        }
+
+        SensorDataStats stats = new SensorDataStats();
+        long timeElapsed;
+        long movingTime = 0;
+        SensorData dataPrev = sensorDataList.get(0);
+        stats.maxHr = dataPrev.hr;
+        stats.maxCadence = dataPrev.cadence;
+        SensorData dataCurrent;
+        for (int i = 1; i < sensorDataList.size(); i++) {
+            dataCurrent = sensorDataList.get(i);
+            if (dataPrev.type != TrackPoint.Type.SEGMENT_START_MANUAL) {
+                timeElapsed = dataCurrent.type != TrackPoint.Type.SEGMENT_START_MANUAL ? dataCurrent.time.getEpochSecond() - dataPrev.time.getEpochSecond() : 0;
+                stats.avgHr += (dataPrev.hr * timeElapsed);
+                stats.maxHr = dataPrev.hr > stats.maxHr ? dataPrev.hr : stats.maxHr;
+                stats.avgCadence += (dataPrev.cadence * timeElapsed);
+                stats.maxCadence = dataPrev.cadence > stats.maxCadence ? dataPrev.cadence : stats.maxCadence;
+                stats.avgPower += (dataPrev.power * timeElapsed);
+
+                movingTime += timeElapsed;
+            }
+            dataPrev = dataCurrent;
+        }
+
+        stats.avgHr /= movingTime;
+        stats.avgCadence /= movingTime;
+        stats.avgPower /= movingTime;
+
+        return stats;
+    }
+
+    private static class SensorData {
+        Instant time;
+        float hr;
+        float cadence;
+        float power;
+        TrackPoint.Type type;
+
+        public SensorData(Instant time, Float hr, Float cadence, Float power, TrackPoint.Type type) {
+            this.time = time;
+            this.hr = hr == null ? 0 : hr;
+            this.cadence = cadence == null ? 0 : cadence;
+            this.power = power == null ? 0 : power;
+            this.type = type;
+        }
+    }
+
+    public static class SensorDataStats {
+        public float avgHr = 0f;
+        public float maxHr = 0f;
+        public float avgCadence = 0f;
+        public float maxCadence = 0f;
+        public float avgPower = 0f;
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/content/data/TrackPointsColumns.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TrackPointsColumns.java
@@ -54,6 +54,13 @@ public interface TrackPointsColumns extends BaseColumns {
     String ELEVATION_GAIN = "elevation_gain";
     String ELEVATION_LOSS = "elevation_loss";
 
+    // Alias for sensor statistics
+    String ALIAS_AVG_HR = "avg_hr";
+    String ALIAS_MAX_HR = "max_hr";
+    String ALIAS_AVG_CADENCE = "avg_cadence";
+    String ALIAS_MAX_CADENCE = "max_cadence";
+    String ALIAS_AVG_POWER = "avg_power";
+
     String CREATE_TABLE = "CREATE TABLE " + TABLE_NAME + " ("
             + _ID + " INTEGER PRIMARY KEY AUTOINCREMENT, "
             + TRACKID + " INTEGER NOT NULL, "

--- a/src/main/java/de/dennisguse/opentracks/content/data/TracksColumns.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TracksColumns.java
@@ -30,6 +30,7 @@ public interface TracksColumns extends BaseColumns {
 
     String TABLE_NAME = "tracks";
     Uri CONTENT_URI = Uri.parse(ContentProviderUtils.CONTENT_BASE_URI + "/" + TABLE_NAME);
+    Uri CONTENT_URI_SENSOR_STATS = Uri.parse(ContentProviderUtils.CONTENT_BASE_URI + "/" + TABLE_NAME + "/sensorstats");
     String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.de.dennisguse.track";
     String CONTENT_ITEMTYPE = "vnd.android.cursor.item/vnd.de.dennisguse.track";
     String DEFAULT_SORT_ORDER = _ID;

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -17,6 +17,7 @@
 package de.dennisguse.opentracks.content.provider;
 
 import android.content.ContentResolver;
+import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -837,31 +838,19 @@ public class ContentProviderUtils {
         return TextUtils.split(url.getLastPathSegment(), ID_SEPARATOR);
     }
 
-    public SensorStatistics getSensorStats(Track.Id trackId) {
-        if (trackId == null) {
-            return null;
-        }
-        String[] projection = {
-                "MAX(" + TrackPointsColumns.SENSOR_HEARTRATE + ") max_hr",
-                "AVG(" + TrackPointsColumns.SENSOR_HEARTRATE + ") avg_hr",
-                "MAX(" + TrackPointsColumns.SENSOR_CADENCE + ") max_cadence",
-                "AVG(" + TrackPointsColumns.SENSOR_CADENCE + ") avg_cadence",
-                "AVG(" + TrackPointsColumns.SENSOR_POWER + ") avg_power"
-        };
-        String selection = TrackPointsColumns.TRACKID + "=?";
-        String[] selectionArgs = new String[]{Long.toString(trackId.getId())};
+    public SensorStatistics getSensorStats(@NonNull Track.Id trackId) {
         SensorStatistics sensorStatistics = null;
-        try (Cursor cursor = getTrackPointCursor(projection, selection, selectionArgs, null)) {
-            if (cursor != null && cursor.moveToFirst()) {
-                sensorStatistics = new SensorStatistics(
-                        !cursor.isNull(cursor.getColumnIndexOrThrow("max_hr")) ? cursor.getFloat(cursor.getColumnIndexOrThrow("max_hr")) : null,
-                        !cursor.isNull(cursor.getColumnIndexOrThrow("avg_hr")) ? cursor.getFloat(cursor.getColumnIndexOrThrow("avg_hr")) : null,
-                        !cursor.isNull(cursor.getColumnIndexOrThrow("max_cadence")) ? cursor.getFloat(cursor.getColumnIndexOrThrow("max_cadence")) : null,
-                        !cursor.isNull(cursor.getColumnIndexOrThrow("avg_cadence")) ? cursor.getFloat(cursor.getColumnIndexOrThrow("avg_cadence")) : null,
-                        !cursor.isNull(cursor.getColumnIndexOrThrow("avg_power")) ? cursor.getFloat(cursor.getColumnIndexOrThrow("avg_power")) : null
-                );
-            }
+        Cursor cursor = contentResolver.query(ContentUris.withAppendedId(TracksColumns.CONTENT_URI_SENSOR_STATS, trackId.getId()), null, null, null, null);
+        if (cursor != null && cursor.moveToFirst()) {
+            sensorStatistics = new SensorStatistics(
+                    !cursor.isNull(cursor.getColumnIndexOrThrow("max_hr")) ? cursor.getFloat(cursor.getColumnIndexOrThrow(TrackPointsColumns.ALIAS_MAX_HR)) : null,
+                    !cursor.isNull(cursor.getColumnIndexOrThrow("avg_hr")) ? cursor.getFloat(cursor.getColumnIndexOrThrow(TrackPointsColumns.ALIAS_AVG_HR)) : null,
+                    !cursor.isNull(cursor.getColumnIndexOrThrow("max_cadence")) ? cursor.getFloat(cursor.getColumnIndexOrThrow(TrackPointsColumns.ALIAS_MAX_CADENCE)) : null,
+                    !cursor.isNull(cursor.getColumnIndexOrThrow("avg_cadence")) ? cursor.getFloat(cursor.getColumnIndexOrThrow(TrackPointsColumns.ALIAS_AVG_CADENCE)) : null,
+                    !cursor.isNull(cursor.getColumnIndexOrThrow("avg_power")) ? cursor.getFloat(cursor.getColumnIndexOrThrow(TrackPointsColumns.ALIAS_AVG_POWER)) : null
+            );
         }
+
         return sensorStatistics;
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/stats/SensorStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/SensorStatistics.java
@@ -16,7 +16,7 @@ public class SensorStatistics {
     }
 
     public boolean hasHeartRate() {
-        return maxHr != null;
+        return avgHr != null && maxHr != null;
     }
 
     public float getMaxHeartRate() {
@@ -28,7 +28,7 @@ public class SensorStatistics {
     }
 
     public boolean hasCadence() {
-        return maxCadence != null;
+        return avgCadence != null && maxCadence != null;
     }
 
     public float getMaxCadence() {


### PR DESCRIPTION
**Describe the pull request**
It computes time weighted heart rate, cadence and power averages. So the more time it takes the more important is.
Also, it computes heart rate and cadence maximum.
Finally, it ignores pause time for whatever reason (SEGMENT_START_MANUAL, SEGMENT_START_AUTOMATIC).

For a track with about 7000 trackpints the query takes about 140ms.

**Link to the the issue**
#601 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
