### PR TITLE
Provide option to use network provider for location data

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/util/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/PreferencesUtils.java
@@ -286,6 +286,11 @@ public class PreferencesUtils {
         return getBoolean(context, R.string.stats_fullscreen_while_recording_key, DEFAULT);
     }
 
+    public static boolean shouldUseNetworkProvider(Context context) {
+        final boolean DEFAULT = context.getResources().getBoolean(R.bool.stats_use_network_provider_default);
+        return getBoolean(context, R.string.stats_use_network_provider_key, DEFAULT);
+    }
+
     public static boolean isShowStatsElevation(Context context) {
         final boolean STATS_SHOW_ELEVATION = context.getResources().getBoolean(R.bool.stats_show_elevation_default);
         return getBoolean(context, R.string.stats_show_grade_elevation_key, STATS_SHOW_ELEVATION);

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -16,6 +16,9 @@
     <string name="stats_fullscreen_while_recording_key" translatable="false">trackdetail_fullscreen_while_recording</string>
     <bool name="stats_fullscreen_while_recording_default" translatable="false">false</bool>
 
+    <string name="stats_use_network_provider_key" translatable="false">trackdetail_use_network_provider</string>
+    <bool name="stats_use_network_provider_default" translatable="false">false</bool>
+
     <string name="settings_reset_key" translatable="false">settingsReset</string>
 
     <string name="settings_sensor_bluetooth_heart_rate_key" translatable="false">bluetoothSensor</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -390,6 +390,8 @@ limitations under the License.
     <string name="settings_recording_keep_screen_on_while_recording_summary">While recording, keep the screen on.</string>
     <string name="settings_recording_fullscreen_on_while_recording_title">Fullscreen</string>
     <string name="settings_recording_fullscreen_on_while_recording_summary">While recording, present in fullscreen.</string>
+    <string name="settings_recording_use_network_provider_title">Network provider.</string>
+    <string name="settings_recording_use_network_provider_summary">Use inaccurate network provider instead of gps.</string>
     <string name="settings_recording">Recording</string>
     <string name="settings_recording_auto_resume_track_timeout_always_summary">Always resume a recording after reboot</string>
     <string name="settings_recording_auto_resume_track_timeout_never_summary">Never resume a recording after reboot</string>

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -120,6 +120,11 @@ limitations under the License.
             android:key="@string/recording_gps_accuracy_key"
             android:title="@string/settings_recording_min_required_accuracy_title"
             app:useSimpleSummaryProvider="true" />
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/stats_use_network_provider_default"
+            android:key="@string/stats_use_network_provider_key"
+            android:summary="@string/settings_recording_use_network_provider_summary"
+            android:title="@string/settings_recording_use_network_provider_title" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_sensor_bluetooth">


### PR DESCRIPTION
Listening on this setting to request location updates

# Thanks for your contribution.

**Describe the pull request**
I am using a Nexus 5X without any Google Play Services which results in no location data. The workaround i propose here is to let the user decide in the settings to use the inaccurate NETWORK_PROVIDER instead of the GPS_PROVIDER to be able to use the app even without Google Play Services

**Link to the the issue**
- No linked issue

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
- No new deps
