### PR TITLE
Recorded fragment shows name, desc, start datetime.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -17,6 +17,7 @@
 package de.dennisguse.opentracks;
 
 import android.Manifest;
+import android.app.ActivityOptions;
 import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
@@ -29,6 +30,7 @@ import android.location.LocationManager;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.util.Log;
+import android.util.Pair;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -195,17 +197,20 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
 
         viewBinding.trackList.setEmptyView(viewBinding.trackListEmptyView);
         viewBinding.trackList.setOnItemClickListener((parent, view, position, trackId) -> {
-            Intent newIntent;
             if (trackId == recordingTrackId.getId()) {
                 // Is recording -> open record activity.
-                newIntent = IntentUtils.newIntent(TrackListActivity.this, TrackRecordingActivity.class)
+                Intent newIntent = IntentUtils.newIntent(TrackListActivity.this, TrackRecordingActivity.class)
                         .putExtra(TrackRecordedActivity.EXTRA_TRACK_ID, new Track.Id(trackId));
+                startActivity(newIntent);
             } else {
                 // Not recording -> open detail activity.
-                newIntent = IntentUtils.newIntent(TrackListActivity.this, TrackRecordedActivity.class)
+                Intent newIntent = IntentUtils.newIntent(TrackListActivity.this, TrackRecordedActivity.class)
                         .putExtra(TrackRecordedActivity.EXTRA_TRACK_ID, new Track.Id(trackId));
+                ActivityOptions activityOptions = ActivityOptions.makeSceneTransitionAnimation(
+                        this,
+                        new Pair<>(view.findViewById(R.id.list_item_icon), TrackRecordedActivity.VIEW_TRACK_ICON));
+                startActivity(newIntent, activityOptions.toBundle());
             }
-            startActivity(newIntent);
         });
 
         resourceCursorAdapter = new ResourceCursorAdapter(this, R.layout.list_item, null, 0) {

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -24,6 +24,7 @@ import android.view.MenuItem;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
@@ -55,6 +56,8 @@ public class TrackRecordedActivity extends AbstractListActivity implements Confi
 
     private static final String TAG = TrackRecordedActivity.class.getSimpleName();
 
+    public static final String VIEW_TRACK_ICON = "track_icon";
+
     public static final String EXTRA_TRACK_ID = "track_id";
     public static final String EXTRA_MARKER_ID = "marker_id";
 
@@ -84,6 +87,8 @@ public class TrackRecordedActivity extends AbstractListActivity implements Confi
         if (savedInstanceState != null) {
             viewBinding.trackDetailActivityViewPager.setCurrentItem(savedInstanceState.getInt(CURRENT_TAB_TAG_KEY));
         }
+
+        postponeEnterTransition();
     }
 
     @Override
@@ -274,5 +279,10 @@ public class TrackRecordedActivity extends AbstractListActivity implements Confi
                     throw new RuntimeException("There isn't Fragment associated with the position: " + position);
             }
         }
+    }
+
+    public void startPostponedEnterTransitionWith(View viewIcon, View viewName) {
+        ViewCompat.setTransitionName(viewIcon, TrackRecordedActivity.VIEW_TRACK_ICON);
+        startPostponedEnterTransition();
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
@@ -161,10 +161,22 @@ public class StatisticsRecordedFragment extends Fragment {
                         sharedPreferenceChangeListener.onSharedPreferenceChanged(sharedPreferences, getString(R.string.stats_rate_key));
                     }
 
+                    loadTrackDescription(track);
                     updateUI();
                     updateSensorUI();
                 }
             });
+        }
+    }
+
+    private void loadTrackDescription(Track track) {
+        if (track == null) {
+            return;
+        }
+        viewBinding.statsNameValue.setText(track.getName());
+        viewBinding.statsDescriptionValue.setText(track.getDescription());
+        if (track.getTrackStatistics() != null) {
+            viewBinding.statsStartDatetimeValue.setText(StringUtils.formatDateTime(getContext(), track.getTrackStatistics().getStartTime()));
         }
     }
 

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.TrackRecordedActivity;
 import de.dennisguse.opentracks.adapters.SensorsAdapter;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
@@ -63,7 +64,6 @@ public class StatisticsRecordedFragment extends Fragment {
         fragment.setArguments(bundle);
         return fragment;
     }
-
 
     private TrackStatistics trackStatistics;
     private SensorStatistics sensorStatistics;
@@ -164,6 +164,8 @@ public class StatisticsRecordedFragment extends Fragment {
                     loadTrackDescription(track);
                     updateUI();
                     updateSensorUI();
+
+                    ((TrackRecordedActivity) getActivity()).startPostponedEnterTransitionWith(viewBinding.statsActivityTypeIcon, viewBinding.statsNameValue);
                 }
             });
         }

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
@@ -152,10 +152,10 @@ public class StatisticsRecordedFragment extends Fragment {
             getActivity().runOnUiThread(() -> {
                 if (isResumed()) {
                     Track track = contentProviderUtils.getTrack(trackId);
-                    trackStatistics = track != null ? track.getTrackStatistics() : null;
+                    trackStatistics = track.getTrackStatistics();
                     sensorStatistics = contentProviderUtils.getSensorStats(trackId);
 
-                    String newCategory = track != null ? track.getCategory() : "";
+                    String newCategory = track.getCategory();
                     if (!category.equals(newCategory)) {
                         category = newCategory;
                         sharedPreferenceChangeListener.onSharedPreferenceChanged(sharedPreferences, getString(R.string.stats_rate_key));
@@ -169,21 +169,16 @@ public class StatisticsRecordedFragment extends Fragment {
         }
     }
 
-    private void loadTrackDescription(Track track) {
-        if (track == null) {
-            return;
-        }
+    private void loadTrackDescription(@NonNull Track track) {
         viewBinding.statsNameValue.setText(track.getName());
         viewBinding.statsDescriptionValue.setText(track.getDescription());
-        if (track.getTrackStatistics() != null) {
-            viewBinding.statsStartDatetimeValue.setText(StringUtils.formatDateTime(getContext(), track.getTrackStatistics().getStartTime()));
-        }
+        viewBinding.statsStartDatetimeValue.setText(StringUtils.formatDateTime(getContext(), trackStatistics.getStartTime()));
     }
 
     private void updateUI() {
         // Set total distance
         {
-            double totalDistance = trackStatistics == null ? Double.NaN : trackStatistics.getTotalDistance();
+            double totalDistance = trackStatistics.getTotalDistance();
             Pair<String, String> parts = StringUtils.getDistanceParts(getContext(), totalDistance, preferenceMetricUnits);
 
             viewBinding.statsDistanceValue.setText(parts.first);
@@ -197,14 +192,14 @@ public class StatisticsRecordedFragment extends Fragment {
         }
 
         // Set time and start datetime
-        if (trackStatistics != null) {
+        {
             viewBinding.statsMovingTimeValue.setText(StringUtils.formatElapsedTime(trackStatistics.getMovingTime()));
             viewBinding.statsTotalTimeValue.setText(StringUtils.formatElapsedTime(trackStatistics.getTotalTime()));
         }
 
         // Set average speed/pace
         {
-            double speed = trackStatistics != null ? trackStatistics.getAverageSpeed() : Double.NaN;
+            double speed = trackStatistics.getAverageSpeed();
             viewBinding.statsAverageSpeedLabel.setText(preferenceReportSpeed ? R.string.stats_average_speed : R.string.stats_average_pace);
 
             Pair<String, String> parts = StringUtils.getSpeedParts(getContext(), speed, preferenceMetricUnits, preferenceReportSpeed);
@@ -214,7 +209,7 @@ public class StatisticsRecordedFragment extends Fragment {
 
         // Set max speed/pace
         {
-            double speed = trackStatistics == null ? Double.NaN : trackStatistics.getMaxSpeed();
+            double speed = trackStatistics.getMaxSpeed();
 
             viewBinding.statsMaxSpeedLabel.setText(preferenceReportSpeed ? R.string.stats_max_speed : R.string.stats_fastest_pace);
 
@@ -225,7 +220,7 @@ public class StatisticsRecordedFragment extends Fragment {
 
         // Set moving speed/pace
         {
-            double speed = trackStatistics != null ? trackStatistics.getAverageMovingSpeed() : Double.NaN;
+            double speed = trackStatistics.getAverageMovingSpeed();
 
             viewBinding.statsMovingSpeedLabel.setText(preferenceReportSpeed ? R.string.stats_average_moving_speed : R.string.stats_average_moving_pace);
 
@@ -240,8 +235,8 @@ public class StatisticsRecordedFragment extends Fragment {
             boolean showElevation = PreferencesUtils.isShowStatsElevation(getContext());
             viewBinding.statsElevationGroup.setVisibility(showElevation ? View.VISIBLE : View.GONE);
 
-            Float elevationGain_m = trackStatistics != null ? trackStatistics.getTotalElevationGain() : null;
-            Float elevationLoss_m = trackStatistics != null ? trackStatistics.getTotalElevationLoss() : null;
+            Float elevationGain_m = trackStatistics.getTotalElevationGain();
+            Float elevationLoss_m = trackStatistics.getTotalElevationLoss();
 
             Pair<String, String> parts;
 

--- a/src/main/res/layout/sensor_item.xml
+++ b/src/main/res/layout/sensor_item.xml
@@ -25,8 +25,9 @@
         android:id="@+id/stats_sensor_value"
         style="@style/StatsLargeValue"
         android:value="@string/value_unknown"
+        app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/stats_sensor_unit"
         app:layout_constraintTop_toBottomOf="@id/stats_sensor_sensor_value"
         tools:text="90" />
 
@@ -34,8 +35,8 @@
         android:id="@+id/stats_sensor_unit"
         style="@style/StatsUnit"
         tools:text="@string/sensor_unit_beats_per_minute"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/stats_sensor_value"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/stats_sensor_value" />
+        app:layout_constraintBottom_toBottomOf="@id/stats_sensor_value" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/main/res/layout/statistics_recorded.xml
+++ b/src/main/res/layout/statistics_recorded.xml
@@ -30,71 +30,88 @@
             android:orientation="vertical"
             app:layout_constraintGuide_end="8dp" />
 
+        <!-- Activity information: icon, name, description and start datetime -->
+        <ImageView
+            android:id="@+id/stats_activity_type_icon"
+            style="@style/IconStats"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintTop_toTopOf="@id/stats_name_value"
+            tools:src="@drawable/ic_activity_bike_24dp" />
+
+        <TextView
+            android:id="@+id/stats_name_value"
+            style="@style/TextLargeStats"
+            android:layout_width="0dp"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintStart_toEndOf="@id/stats_activity_type_icon"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Name of the activity" />
+
+        <TextView
+            android:id="@+id/stats_description_value"
+            style="@style/TextMediumStats"
+            android:layout_width="0dp"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintStart_toStartOf="@id/stats_name_value"
+            app:layout_constraintTop_toBottomOf="@id/stats_name_value"
+            tools:text="Here will be a description that could be really long and it would show completely without problems." />
+
+        <TextView
+            android:id="@+id/stats_start_datetime_value"
+            style="@style/TextSmallStats"
+            android:layout_width="0dp"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintStart_toStartOf="@id/guideline"
+            app:layout_constraintTop_toBottomOf="@id/stats_description_barrier"
+            tools:text="Saturday 6th, 16:44" />
+
+        <!-- Barrier -->
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/stats_description_barrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="stats_activity_type_icon,stats_name_value,stats_description_value" />
+
+        <!-- Horizontal line -->
+        <View
+            android:id="@+id/stats_information_horizontal_line"
+            style="@style/StatsHorizontalLine"
+            android:layout_marginBottom="8dp"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintTop_toBottomOf="@id/stats_start_datetime_value" />
+
         <!-- Distance -->
         <TextView
             android:id="@+id/stats_distance_label"
             style="@style/StatsLargeLabel"
             android:text="@string/stats_distance"
             app:layout_constrainedWidth="true"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/guideline2"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/guideline2"
+            app:layout_constraintTop_toBottomOf="@id/stats_information_horizontal_line" />
 
         <TextView
             android:id="@+id/stats_distance_value"
             style="@style/StatsLargeValue"
             android:value="@string/value_unknown"
             app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/stats_distance_unit"
-            app:layout_constraintTop_toBottomOf="@+id/stats_distance_label"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/stats_distance_unit"
+            app:layout_constraintTop_toBottomOf="@id/stats_distance_label"
             tools:text="100" />
 
         <TextView
             android:id="@+id/stats_distance_unit"
             style="@style/StatsUnit"
-            app:layout_constraintBottom_toBottomOf="@+id/stats_distance_value"
-            app:layout_constraintStart_toEndOf="@+id/stats_distance_value"
-            app:layout_constraintEnd_toStartOf="@+id/guideline2"
+            app:layout_constraintBottom_toBottomOf="@id/stats_distance_value"
+            app:layout_constraintStart_toEndOf="@id/stats_distance_value"
+            app:layout_constraintEnd_toStartOf="@id/guideline2"
             tools:text="km" />
-
-        <!-- Activity Type -->
-        <TextView
-            android:id="@+id/stats_activity_type_label"
-            style="@style/StatsLargeLabel"
-            android:text="@string/track_edit_activity_type_hint"
-            app:layout_constrainedWidth="true"
-            app:layout_constraintStart_toEndOf="@+id/guideline2"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-            android:id="@+id/stats_activity_type_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintStart_toEndOf="@+id/guideline2"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
-            app:layout_constraintBottom_toBottomOf="@+id/stats_distance_value"
-            app:layout_constraintTop_toTopOf="@+id/stats_distance_value"
-            app:tint="?android:textColorPrimary" />
-
-        <!-- Total time -->
-        <TextView
-            android:id="@+id/stats_total_time_label"
-            style="@style/StatsLargeLabel"
-            android:text="@string/stats_total_time"
-            app:layout_constrainedWidth="true"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/guideline2"
-            app:layout_constraintTop_toBottomOf="@+id/stats_distance_value" />
-
-        <TextView
-            android:id="@+id/stats_total_time_value"
-            style="@style/StatsLargeValue"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/guideline2"
-            app:layout_constraintTop_toBottomOf="@+id/stats_total_time_label"
-            tools:text="00:00:00" />
 
         <!-- Moving time -->
         <TextView
@@ -102,19 +119,35 @@
             style="@style/StatsLargeLabel"
             android:text="@string/stats_moving_time"
             app:layout_constrainedWidth="true"
-            app:layout_constraintBottom_toBottomOf="@+id/stats_total_time_label"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
-            app:layout_constraintStart_toEndOf="@+id/guideline2"
-            app:layout_constraintTop_toTopOf="@+id/stats_total_time_label"
-            app:layout_constraintVertical_bias="1.0" />
+            app:layout_constraintStart_toEndOf="@id/guideline2"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintTop_toBottomOf="@id/stats_information_horizontal_line" />
 
         <TextView
             android:id="@+id/stats_moving_time_value"
             style="@style/StatsLargeValue"
             android:value="@string/value_unknown"
-            app:layout_constraintStart_toEndOf="@+id/guideline2"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
-            app:layout_constraintTop_toBottomOf="@+id/stats_moving_time_label"
+            app:layout_constraintStart_toEndOf="@id/guideline2"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintTop_toBottomOf="@id/stats_moving_time_label"
+            tools:text="00:00:00" />
+
+        <!-- Total time -->
+        <TextView
+            android:id="@+id/stats_total_time_label"
+            style="@style/StatsSmallLabel"
+            android:text="@string/stats_total_time"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintStart_toEndOf="@id/guideline2"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintTop_toBottomOf="@id/stats_moving_time_value" />
+
+        <TextView
+            android:id="@+id/stats_total_time_value"
+            style="@style/StatsSmallValue"
+            app:layout_constraintStart_toEndOf="@id/guideline2"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintTop_toBottomOf="@id/stats_total_time_label"
             tools:text="00:00:00" />
 
         <!-- Barrier -->
@@ -130,18 +163,74 @@
             android:id="@+id/stats_speed_horizontal_line"
             style="@style/StatsHorizontalLine"
             android:layout_marginBottom="8dp"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
-            app:layout_constraintTop_toBottomOf="@+id/stats_time_barrier" />
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintTop_toBottomOf="@id/stats_time_barrier" />
+
+        <!-- Speed/Pace max -->
+        <TextView
+            android:id="@+id/stats_max_speed_label"
+            style="@style/StatsLargeLabel"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/guideline2"
+            app:layout_constraintTop_toBottomOf="@id/stats_speed_horizontal_line"
+            tools:text="Max. Speed" />
+
+        <TextView
+            android:id="@+id/stats_max_speed_value"
+            style="@style/StatsLargeValue"
+            android:value="@string/value_unknown"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/stats_max_speed_unit"
+            app:layout_constraintTop_toBottomOf="@id/stats_max_speed_label"
+            tools:text="30.00" />
+
+        <TextView
+            android:id="@+id/stats_max_speed_unit"
+            style="@style/StatsUnit"
+            app:layout_constraintBottom_toBottomOf="@id/stats_max_speed_value"
+            app:layout_constraintStart_toEndOf="@id/stats_max_speed_value"
+            app:layout_constraintEnd_toStartOf="@id/guideline2"
+            tools:text="km/h" />
+
+        <!-- Avg. moving speed/pace -->
+        <TextView
+            android:id="@+id/stats_moving_speed_label"
+            style="@style/StatsLargeLabel"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintStart_toEndOf="@id/guideline2"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintTop_toBottomOf="@id/stats_speed_horizontal_line"
+            tools:text="Avg. Moving Speed" />
+
+        <TextView
+            android:id="@+id/stats_moving_speed_value"
+            style="@style/StatsLargeValue"
+            android:value="@string/value_unknown"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/guideline2"
+            app:layout_constraintEnd_toStartOf="@id/stats_moving_speed_unit"
+            app:layout_constraintTop_toBottomOf="@id/stats_moving_speed_label"
+            tools:text="30.00" />
+
+        <TextView
+            android:id="@+id/stats_moving_speed_unit"
+            style="@style/StatsUnit"
+            app:layout_constraintBottom_toBottomOf="@id/stats_moving_speed_value"
+            app:layout_constraintStart_toEndOf="@id/stats_moving_speed_value"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            tools:text="km/h" />
 
         <!-- Average speed/pace -->
         <TextView
             android:id="@+id/stats_average_speed_label"
             style="@style/StatsSmallLabel"
             app:layout_constrainedWidth="true"
-            app:layout_constraintStart_toEndOf="@+id/guideline2"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
-            app:layout_constraintTop_toBottomOf="@id/stats_speed_horizontal_line"
+            app:layout_constraintStart_toEndOf="@id/guideline2"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintTop_toBottomOf="@id/stats_moving_speed_value"
             tools:text="Avg. Speed" />
 
         <TextView
@@ -149,73 +238,17 @@
             style="@style/StatsSmallValue"
             android:value="@string/value_unknown"
             app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toEndOf="@+id/guideline2"
-            app:layout_constraintEnd_toStartOf="@+id/stats_average_speed_unit"
-            app:layout_constraintTop_toBottomOf="@+id/stats_average_speed_label"
+            app:layout_constraintStart_toEndOf="@id/guideline2"
+            app:layout_constraintEnd_toStartOf="@id/stats_average_speed_unit"
+            app:layout_constraintTop_toBottomOf="@id/stats_average_speed_label"
             tools:text="30.00" />
 
         <TextView
             android:id="@+id/stats_average_speed_unit"
             style="@style/StatsUnit"
-            app:layout_constraintBottom_toBottomOf="@+id/stats_average_speed_value"
-            app:layout_constraintStart_toEndOf="@+id/stats_average_speed_value"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
-            tools:text="km/h" />
-
-        <!-- Speed max -->
-        <TextView
-            android:id="@+id/stats_max_speed_label"
-            style="@style/StatsSmallLabel"
-            app:layout_constrainedWidth="true"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/guideline2"
-            app:layout_constraintTop_toBottomOf="@id/stats_average_speed_value"
-            tools:text="Max. Speed" />
-
-        <TextView
-            android:id="@+id/stats_max_speed_value"
-            style="@style/StatsSmallValue"
-            android:value="@string/value_unknown"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/stats_max_speed_unit"
-            app:layout_constraintTop_toBottomOf="@+id/stats_max_speed_label"
-            tools:text="30.00" />
-
-        <TextView
-            android:id="@+id/stats_max_speed_unit"
-            style="@style/StatsUnit"
-            app:layout_constraintBottom_toBottomOf="@+id/stats_max_speed_value"
-            app:layout_constraintStart_toEndOf="@+id/stats_max_speed_value"
-            app:layout_constraintEnd_toStartOf="@+id/guideline2"
-            tools:text="km/h" />
-
-        <!-- Moving speed max -->
-        <TextView
-            android:id="@+id/stats_moving_speed_label"
-            style="@style/StatsSmallLabel"
-            app:layout_constrainedWidth="true"
-            app:layout_constraintStart_toEndOf="@+id/guideline2"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
-            app:layout_constraintTop_toBottomOf="@id/stats_average_speed_value"
-            tools:text="Max. Moving Speed" />
-
-        <TextView
-            android:id="@+id/stats_moving_speed_value"
-            style="@style/StatsSmallValue"
-            android:value="@string/value_unknown"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toEndOf="@+id/guideline2"
-            app:layout_constraintEnd_toStartOf="@+id/stats_moving_speed_unit"
-            app:layout_constraintTop_toBottomOf="@+id/stats_moving_speed_label"
-            tools:text="30.00" />
-
-        <TextView
-            android:id="@+id/stats_moving_speed_unit"
-            style="@style/StatsUnit"
-            app:layout_constraintBottom_toBottomOf="@+id/stats_moving_speed_value"
-            app:layout_constraintStart_toEndOf="@+id/stats_moving_speed_value"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
+            app:layout_constraintBottom_toBottomOf="@id/stats_average_speed_value"
+            app:layout_constraintStart_toEndOf="@id/stats_average_speed_value"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
             tools:text="km/h" />
 
         <!-- Barrier -->
@@ -224,16 +257,16 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:barrierDirection="bottom"
-            app:constraint_referenced_ids="stats_moving_speed_value,stats_max_speed_value" />
+            app:constraint_referenced_ids="stats_max_speed_value,stats_moving_speed_value,stats_average_speed_value" />
 
         <!-- Horizontal line -->
         <View
             android:id="@+id/stats_elevation_horizontal_line"
             style="@style/StatsHorizontalLine"
             android:layout_marginBottom="8dp"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
-            app:layout_constraintTop_toBottomOf="@+id/stats_speed_barrier" />
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintTop_toBottomOf="@id/stats_speed_barrier" />
 
         <!-- Elevation gain and loss -->
         <androidx.constraintlayout.widget.Group
@@ -244,56 +277,56 @@
 
         <TextView
             android:id="@+id/stats_elevation_gain_label"
-            style="@style/StatsSmallLabel"
+            style="@style/StatsLargeLabel"
             android:text="@string/stats_gain"
             app:layout_constrainedWidth="true"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/guideline2"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/guideline2"
             app:layout_constraintTop_toBottomOf="@id/stats_elevation_horizontal_line" />
 
         <TextView
             android:id="@+id/stats_elevation_gain_value"
-            style="@style/StatsSmallValue"
+            style="@style/StatsLargeValue"
             android:value="@string/value_unknown"
             app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/stats_elevation_gain_unit"
-            app:layout_constraintTop_toBottomOf="@+id/stats_elevation_gain_label"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/stats_elevation_gain_unit"
+            app:layout_constraintTop_toBottomOf="@id/stats_elevation_gain_label"
             tools:text="100" />
 
         <TextView
             android:id="@+id/stats_elevation_gain_unit"
             style="@style/StatsUnit"
-            app:layout_constraintBottom_toBottomOf="@+id/stats_elevation_gain_value"
-            app:layout_constraintStart_toEndOf="@+id/stats_elevation_gain_value"
-            app:layout_constraintEnd_toStartOf="@+id/guideline2"
+            app:layout_constraintBottom_toBottomOf="@id/stats_elevation_gain_value"
+            app:layout_constraintStart_toEndOf="@id/stats_elevation_gain_value"
+            app:layout_constraintEnd_toStartOf="@id/guideline2"
             tools:text="m" />
 
         <TextView
             android:id="@+id/stats_elevation_loss_label"
-            style="@style/StatsSmallLabel"
+            style="@style/StatsLargeLabel"
             android:text="@string/stats_loss"
             app:layout_constrainedWidth="true"
-            app:layout_constraintStart_toEndOf="@+id/guideline2"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
+            app:layout_constraintStart_toEndOf="@id/guideline2"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
             app:layout_constraintTop_toBottomOf="@id/stats_elevation_horizontal_line" />
 
         <TextView
             android:id="@+id/stats_elevation_loss_value"
-            style="@style/StatsSmallValue"
+            style="@style/StatsLargeValue"
             android:value="@string/value_unknown"
             app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toEndOf="@+id/guideline2"
-            app:layout_constraintEnd_toStartOf="@+id/stats_elevation_loss_unit"
-            app:layout_constraintTop_toBottomOf="@+id/stats_elevation_loss_label"
+            app:layout_constraintStart_toEndOf="@id/guideline2"
+            app:layout_constraintEnd_toStartOf="@id/stats_elevation_loss_unit"
+            app:layout_constraintTop_toBottomOf="@id/stats_elevation_loss_label"
             tools:text="100" />
 
         <TextView
             android:id="@+id/stats_elevation_loss_unit"
             style="@style/StatsUnit"
-            app:layout_constraintBottom_toBottomOf="@+id/stats_elevation_loss_value"
-            app:layout_constraintStart_toEndOf="@+id/stats_elevation_loss_value"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
+            app:layout_constraintBottom_toBottomOf="@id/stats_elevation_loss_value"
+            app:layout_constraintStart_toEndOf="@id/stats_elevation_loss_value"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
             tools:text="m" />
 
         <!-- Barrier -->
@@ -309,9 +342,9 @@
             android:id="@+id/stats_end_horizontal_line"
             style="@style/StatsHorizontalLine"
             android:layout_marginBottom="8dp"
-            app:layout_constraintStart_toEndOf="@+id/guideline"
-            app:layout_constraintEnd_toStartOf="@+id/guideline3"
-            app:layout_constraintTop_toBottomOf="@+id/stats_elevation_barrier" />
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/guideline3"
+            app:layout_constraintTop_toBottomOf="@id/stats_elevation_barrier" />
 
         <!-- Sensors data -->
         <androidx.recyclerview.widget.RecyclerView

--- a/src/main/res/values/do_not_translate.xml
+++ b/src/main/res/values/do_not_translate.xml
@@ -25,9 +25,9 @@ limitations under the License.
 
     <string name="marker_icon_url" translatable="false">http://maps.google.com/mapfiles/ms/micons/blue-pushpin.png</string>
 
-    <string name="sensor_unit_beats_per_minute" translatable="false">BPM</string>
-    <string name="sensor_unit_rounds_per_minute" translatable="false">RPM</string>
-    <string name="sensor_unit_power" translatable="false">W</string>
+    <string name="sensor_unit_beats_per_minute" translatable="false">bpm</string>
+    <string name="sensor_unit_rounds_per_minute" translatable="false">rpm</string>
+    <string name="sensor_unit_power" translatable="false">w</string>
 
     <string name="value_unknown" translatable="false">-</string>
 

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -209,6 +209,38 @@ limitations under the License.
         <item name="android:singleLine">true</item>
     </style>
 
+    <style name="TextLargeStats" parent="TextAppearance.AppCompat.Large">
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:paddingLeft">8dp</item>
+        <item name="android:paddingRight">4dp</item>
+        <item name="android:layout_marginTop">16dp</item>
+    </style>
+
+    <style name="TextMediumStats" parent="TextAppearance.AppCompat.Medium">
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:paddingLeft">8dp</item>
+        <item name="android:paddingRight">4dp</item>
+        <item name="android:color">@android:color/secondary_text_light</item>
+    </style>
+
+    <style name="TextSmallStats" parent="TextAppearance.AppCompat.Small">
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:paddingLeft">8dp</item>
+        <item name="android:paddingRight">4dp</item>
+        <item name="android:paddingTop">8dp</item>
+        <item name="android:textAlignment">viewEnd</item>
+        <item name="android:color">@android:color/secondary_text_light</item>
+    </style>
+
+    <style name="IconStats">
+        <item name="android:layout_width">48dp</item>
+        <item name="android:layout_height">48dp</item>
+        <item name="tint">?android:textColorPrimary</item>
+    </style>
+
     <style name="TextMicro" parent="@style/TextSmall">
         <item name="android:textSize">12sp</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
**Describe the pull request**
Following up #566 I've re-design stats recorded fragment layout:
- Added name, description and start datetime.
- Moving stats are primary (total time and avg. speed are secondary).
- Sensor units next to their values instead of behind them (like the others stats).

There are UI changes so this PR is open for discussion. I've put the focus on moving stats because I consider that they are the more important one. On the other hand, IMHO all stats are equally important so all of them use Large values and labels.

**Screenshots**
![imagen](https://user-images.githubusercontent.com/4819612/110214163-b1a3c080-7ea3-11eb-8932-4bfd17289e93.png)


**Link to the the issue**
#566 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

