### PR TITLE
GPX: export and import power data.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -301,7 +301,7 @@ public class ExportImportTest {
         trackPointsWithCoordinates.get(0).setType(TrackPoint.Type.SEGMENT_START_AUTOMATIC);
         trackPointsWithCoordinates.get(3).setType(TrackPoint.Type.SEGMENT_START_AUTOMATIC);
 
-        assertTrackpoints(trackPointsWithCoordinates, false, true, true, true, true);
+        assertTrackpoints(trackPointsWithCoordinates, true, true, true, true, true);
 
         // 3. trackstatistics
         assertTrackStatistics(true, true);
@@ -391,13 +391,13 @@ public class ExportImportTest {
             }
 
             if (verifyHeartrate) {
-                assertEquals(trackPoint.getHeartRate_bpm(), importedTrackPoint.getHeartRate_bpm(), 0.01);
+                assertEquals("" + trackPoint, trackPoint.getHeartRate_bpm(), importedTrackPoint.getHeartRate_bpm(), 0.01);
             }
             if (verifyCadence) {
-                assertEquals(trackPoint.getCyclingCadence_rpm(), importedTrackPoint.getCyclingCadence_rpm(), 0.01);
+                assertEquals("" + trackPoint, trackPoint.getCyclingCadence_rpm(), importedTrackPoint.getCyclingCadence_rpm(), 0.01);
             }
             if (verifyPower) {
-                assertEquals(trackPoint.getPower(), importedTrackPoint.getPower(), 0.01);
+                assertEquals("" + trackPoint, trackPoint.getPower(), importedTrackPoint.getPower(), 0.01);
             }
             if (verifyElevationGain) {
                 assertEquals(trackPoint.getElevationGain(), importedTrackPoint.getElevationGain(), 0.01);

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
@@ -51,6 +51,7 @@ public class GPXTrackExporter implements TrackExporter {
     private static final NumberFormat SPEED_FORMAT = NumberFormat.getInstance(Locale.US);
     private static final NumberFormat HEARTRATE_FORMAT = NumberFormat.getInstance(Locale.US);
     private static final NumberFormat CADENCE_FORMAT = NumberFormat.getInstance(Locale.US);
+    private static final NumberFormat POWER_FORMAT = NumberFormat.getInstance(Locale.US);
 
     static {
         /*
@@ -72,6 +73,9 @@ public class GPXTrackExporter implements TrackExporter {
 
         CADENCE_FORMAT.setMaximumFractionDigits(0);
         CADENCE_FORMAT.setGroupingUsed(false);
+
+        POWER_FORMAT.setMaximumFractionDigits(0);
+        POWER_FORMAT.setGroupingUsed(false);
     }
 
     private final ContentProviderUtils contentProviderUtils;
@@ -196,10 +200,12 @@ public class GPXTrackExporter implements TrackExporter {
             printWriter.println("xmlns:atom=\"http://www.w3.org/2005/Atom\"");
             printWriter.println("xmlns:opentracks=\"http://opentracksapp.com/xmlschemas/v1\"");
             printWriter.println("xmlns:gpxtpx=\"http://www.garmin.com/xmlschemes/TrackPointExtension/v2\"");
+            printWriter.println("xmlns:pwr=\"http://www.garmin.com/xmlschemas/PowerExtension/v1\"");
             printWriter.println("xsi:schemaLocation=" +
                     "\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
                     + " http://www.topografix.com/GPX/Private/TopoGrafix/0/1 http://www.topografix.com/GPX/Private/TopoGrafix/0/1/topografix.xsd"
                     + " http://www.garmin.com/xmlschemas/TrackPointExtension/v2 https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd"
+                    + " http://www.garmin.com/xmlschemas/PowerExtension/v1 https://www8.garmin.com/xmlschemas/PowerExtensionv1.xsd"
                     + " http://opentracksapp.com/xmlschemas/v1 http://opentracksapp.com/xmlschemas/OpenTracks_v1.xsd\">");
         }
     }
@@ -292,6 +298,10 @@ public class GPXTrackExporter implements TrackExporter {
 
                 if (trackPoint.hasCyclingCadence()) {
                     printWriter.println("<gpxtpx:cad>" + CADENCE_FORMAT.format(trackPoint.getCyclingCadence_rpm()) + "</gpxtpx:cad>");
+                }
+
+                if (trackPoint.hasPower()) {
+                    printWriter.println("<pwr:PowerInWatts>" + POWER_FORMAT.format(trackPoint.getPower()) + "</pwr:PowerInWatts>");
                 }
 
                 if (trackPoint.hasElevationGain()) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -479,6 +479,14 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements Track
             }
         }
 
+        if (power != null) {
+            try {
+                trackPoint.setPower(Float.parseFloat(power));
+            } catch (Exception e) {
+                throw new ParsingException(createErrorMessage(String.format(Locale.US, "Unable to parse power: %s", power)), e);
+            }
+        }
+
         if (gain != null) {
             try {
                 trackPoint.setElevationGain(Float.parseFloat(gain));

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxFileTrackImporter.java
@@ -28,7 +28,9 @@ import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 
 /**
  * Imports a GPX file.
- * Uses https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd
+ * Uses:
+ * * https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd
+ * * https://www8.garmin.com/xmlschemas/PowerExtensionv1.xsd
  * <p>
  * {@link de.dennisguse.opentracks.io.file.exporter.GPXTrackExporter} does not export information if a segment was started automatic or manually.
  * Therefore, all segments starts are marked as SEGMENT_START_AUTOMATIC.
@@ -57,6 +59,7 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
     private static final String TAG_EXTENSION_SPEED = "gpxtpx:speed";
     private static final String TAG_EXTENSION_HEARTRATE = "gpxtpx:hr";
     private static final String TAG_EXTENSION_CADENCE = "gpxtpx:cad";
+    private static final String TAG_EXTENSION_POWER = "pwr:PowerInWatts";
 
     private static final String TAG_EXTENSION_GAIN = "opentracks:gain";
     private static final String TAG_EXTENSION_LOSS = "opentracks:loss";
@@ -156,6 +159,11 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
                     cadence = content.trim();
                 }
                 break;
+            case TAG_EXTENSION_POWER:
+                if (content != null) {
+                    power = content.trim();
+                }
+                break;
             case TAG_ID:
                 if (content != null) {
                     uuid = content.trim();
@@ -196,11 +204,12 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
         altitude = null;
         time = null;
         speed = null;
+        power = null;
         gain = null;
         loss = null;
     }
 
-    private void onTrackPointEnd() throws SAXException {
+    private void onTrackPointEnd() {
         boolean isFirstTrackPointInSegment = isFirstTrackPointInSegment();
         TrackPoint trackPoint = getTrackPoint();
         if (isFirstTrackPointInSegment) {
@@ -221,7 +230,7 @@ public class GpxFileTrackImporter extends AbstractFileTrackImporter {
         markerType = null;
     }
 
-    private void onMarkerEnd() throws SAXException {
+    private void onMarkerEnd() {
         addMarker();
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlFileTrackImporter.java
@@ -35,6 +35,7 @@ import de.dennisguse.opentracks.io.file.exporter.KMLTrackExporter;
  *
  * @author Jimmy Shih
  */
+//TODO Do not use AbstractFileTrackImporter as TrackPoint sensor generation is done differently here.
 public class KmlFileTrackImporter extends AbstractFileTrackImporter {
 
     private static final String TAG = KmlFileTrackImporter.class.getSimpleName();


### PR DESCRIPTION
Uses Garmin extensions to export power data.
This is compatible with Golden Cheetah.

This is NOT supported by Strava.
They would require to use "power" instead of "PowerInWatts"./
See https://developers.strava.com/docs/uploads/

Fixes #638.