### PR TITLE
Track exported names: UUID, track's name and extension

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/util/ExportUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/ExportUtilsTest.java
@@ -1,0 +1,60 @@
+package de.dennisguse.opentracks.util;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class ExportUtilsTest extends TestCase {
+
+    @Test
+    public void testIsExportFileExists_exists() {
+        // given
+        UUID uuid = UUID.randomUUID();
+        String format = "kmz";
+        List<String> fileNames = new ArrayList<>();
+        fileNames.add(uuid.toString().substring(0, 8) + "_name.gpx");
+        fileNames.add(uuid.toString().substring(0, 8) + "_other name name.kmz");
+
+        // when
+        boolean exists = ExportUtils.isExportFileExists(uuid, format, fileNames);
+
+        // then
+        assertTrue(exists);
+    }
+
+    @Test
+    public void testIsExportFileExists_not_exists1() {
+        // given
+        UUID uuid = UUID.randomUUID();
+        String format = "gpx";
+        List<String> fileNames = new ArrayList<>();
+        fileNames.add(UUID.randomUUID().toString().substring(0, 8) + "_name.gpx");
+        fileNames.add(UUID.randomUUID().toString().substring(0, 8) + "_other name name.gpx");
+
+        // when
+        boolean exists = ExportUtils.isExportFileExists(uuid, format, fileNames);
+
+        // then
+        assertFalse(exists);
+    }
+
+    @Test
+    public void testIsExportFileExists_not_exists2() {
+        // given
+        UUID uuid = UUID.randomUUID();
+        String format = "kmz";
+        List<String> fileNames = new ArrayList<>();
+        fileNames.add(uuid.toString().substring(0, 8) + "_name.gpx");
+        fileNames.add(UUID.randomUUID().toString().substring(0, 8) + "_other name name.gpx");
+
+        // when
+        boolean exists = ExportUtils.isExportFileExists(uuid, format, fileNames);
+
+        // then
+        assertFalse(exists);
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/content/data/Track.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Track.java
@@ -109,6 +109,19 @@ public class Track {
         this.trackStatistics = trackStatistics;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Track track = (Track) o;
+        return id.equals(track.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
     public static class Id implements Parcelable {
 
         private final long id;


### PR DESCRIPTION
**Describe the pull request**
Exported track's name like proposed in #512 (see comment: https://github.com/OpenTracksApp/OpenTracks/issues/512#issuecomment-766437523)

Also, it checks if file that result of export process match with the following regular expression:
`<UUID first 8 bytes>.*\.<extension>`

PS/ If it is accepted I'd like to add/update tests, but I need to be sure that it's what was expected in #512.

**Link to the the issue**
#512

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
