### PR TITLE
Added EGM2008 undulation data.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.content.data.Altitude;
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Marker;
 import de.dennisguse.opentracks.content.data.Speed;
@@ -416,7 +417,7 @@ public class ExportImportTest {
             }
             assertEquals(trackPoint.hasAltitude(), importedTrackPoint.hasAltitude());
             if (trackPoint.hasAltitude()) {
-                assertEquals(trackPoint.getAltitude(), importedTrackPoint.getAltitude(), 0.001);
+                assertEquals(trackPoint.getAltitude().toM(), importedTrackPoint.getAltitude().toM(), 0.001);
             }
 
             if (type.equals(TrackPoint.Type.SEGMENT_START_MANUAL) || type.equals(TrackPoint.Type.SEGMENT_END_MANUAL)) {
@@ -486,7 +487,7 @@ public class ExportImportTest {
     }
 
     private static TrackPoint createTrackPoint(long time, double latitude, double longitude, float accuracy, float speed, float altitude, float altitudeGain, float heartRate, float cyclingCadence, float power, Distance distance) {
-        TrackPoint tp = new TrackPoint(latitude, longitude, (double) altitude, Instant.ofEpochMilli(time));
+        TrackPoint tp = new TrackPoint(latitude, longitude, Altitude.WGS84.of(altitude), Instant.ofEpochMilli(time));
         tp.setAccuracy(accuracy);
         tp.setSpeed(Speed.of(speed));
         tp.setHeartRate_bpm(heartRate);

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/LegacyImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/LegacyImportTest.java
@@ -152,7 +152,7 @@ public class LegacyImportTest {
         if (altitude == null) {
             assertFalse(trackPoint.hasAltitude());
         } else {
-            assertEquals(altitude, (Double) trackPoint.getAltitude());
+            assertEquals(altitude, (Double) trackPoint.getAltitude().toM());
         }
 
     }

--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import java.time.Duration;
 import java.time.Instant;
 
+import de.dennisguse.opentracks.content.data.Altitude;
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Speed;
 import de.dennisguse.opentracks.content.data.TestDataUtil;
@@ -53,8 +54,8 @@ public class TrackStatisticsUpdaterTest {
         TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
 
         TrackPoint tp1 = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochMilli(1000));
-        TrackPoint tp2 = new TrackPoint(0, 0, 5.0, Instant.ofEpochMilli(2000));
-        TrackPoint tp3 = new TrackPoint(0.00001, 0, 5.0, Instant.ofEpochMilli(3000));
+        TrackPoint tp2 = new TrackPoint(0, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(2000));
+        TrackPoint tp3 = new TrackPoint(0.00001, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(3000));
 
         // when
         subject.addTrackPoint(tp1, GPS_DISTANCE);
@@ -71,8 +72,8 @@ public class TrackStatisticsUpdaterTest {
         TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
 
         TrackPoint tp1 = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochMilli(1000));
-        TrackPoint tp2 = new TrackPoint(0, 0, 5.0, Instant.ofEpochMilli(2000));
-        TrackPoint tp3 = new TrackPoint(0.00001, 0, 5.0, Instant.ofEpochMilli(3000));
+        TrackPoint tp2 = new TrackPoint(0, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(2000));
+        TrackPoint tp3 = new TrackPoint(0.00001, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(3000));
         tp3.setSpeed(Speed.of(5f));
 
         // when
@@ -90,11 +91,11 @@ public class TrackStatisticsUpdaterTest {
         TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
 
         TrackPoint tp1 = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochMilli(1000));
-        TrackPoint tp2 = new TrackPoint(0, 0, 5.0, Instant.ofEpochMilli(2000));
+        TrackPoint tp2 = new TrackPoint(0, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(2000));
         tp2.setSpeed(Speed.of(5f));
-        TrackPoint tp3 = new TrackPoint(0.001, 0, 5.0, Instant.ofEpochMilli(3000));
+        TrackPoint tp3 = new TrackPoint(0.001, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(3000));
         tp2.setSpeed(Speed.of(5f));
-        TrackPoint tp4 = new TrackPoint(0.001, 0, 5.0, Instant.ofEpochMilli(4000));
+        TrackPoint tp4 = new TrackPoint(0.001, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(4000));
         tp2.setSpeed(Speed.of(5f));
         tp4.setSensorDistance(Distance.of(5f));
         TrackPoint tp5 = new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.ofEpochMilli(5000));
@@ -122,9 +123,9 @@ public class TrackStatisticsUpdaterTest {
         TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
 
         TrackPoint tp1 = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochMilli(1000));
-        TrackPoint tp2 = new TrackPoint(0, 0, 5.0, Instant.ofEpochMilli(2000));
-        TrackPoint tp3 = new TrackPoint(0.00001, 0, 5.0, Instant.ofEpochMilli(3000));
-        TrackPoint tp4 = new TrackPoint(0.00001, 0, 5.0, Instant.ofEpochMilli(4000));
+        TrackPoint tp2 = new TrackPoint(0, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(2000));
+        TrackPoint tp3 = new TrackPoint(0.00001, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(3000));
+        TrackPoint tp4 = new TrackPoint(0.00001, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(4000));
         tp4.setSensorDistance(Distance.of(5f));
         TrackPoint tp5 = new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.ofEpochMilli(5000));
         tp5.setSensorDistance(Distance.of(10f));

--- a/src/androidTest/java/de/dennisguse/opentracks/util/EGM2008UtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/EGM2008UtilsTest.java
@@ -75,7 +75,7 @@ public class EGM2008UtilsTest {
         trackPoint.setAltitude(0);
 
         // when
-        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createCorrection(context, trackPoint.getLocation());
 
         // then
         assertEquals(-14.8980, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
@@ -90,7 +90,7 @@ public class EGM2008UtilsTest {
         trackPoint.setAltitude(0);
 
         // when
-        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createCorrection(context, trackPoint.getLocation());
 
         // then
         assertEquals(30.15, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
@@ -105,7 +105,7 @@ public class EGM2008UtilsTest {
         trackPoint.setAltitude(0);
 
         // when
-        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createCorrection(context, trackPoint.getLocation());
 
         // then
         assertEquals(30.15, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
@@ -120,7 +120,7 @@ public class EGM2008UtilsTest {
         trackPoint.setAltitude(0);
 
         // when
-        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createCorrection(context, trackPoint.getLocation());
 
         // then
         assertEquals(30.15, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
@@ -135,7 +135,7 @@ public class EGM2008UtilsTest {
         trackPoint.setAltitude(0);
 
         // when
-        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createCorrection(context, trackPoint.getLocation());
 
         // then
         assertEquals(-17.2260, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
@@ -150,7 +150,7 @@ public class EGM2008UtilsTest {
         trackPoint.setAltitude(0);
 
         // when
-        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createCorrection(context, trackPoint.getLocation());
 
         // then
         assertEquals(-39.4865, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
@@ -170,7 +170,7 @@ public class EGM2008UtilsTest {
         trackPoint2.setAltitude(0);
 
         // when
-        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint1.getLocation());
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createCorrection(context, trackPoint1.getLocation());
 
         // then
         assertNotEquals(altitude_egm2008.correctAltitude(trackPoint1.getLocation()), altitude_egm2008.correctAltitude(trackPoint2.getLocation()), 0.0001);
@@ -185,7 +185,7 @@ public class EGM2008UtilsTest {
         trackPoint.setAltitude(0);
 
         // when
-        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createCorrection(context, trackPoint.getLocation());
 
         // then
         assertEquals(-85.824, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);

--- a/src/androidTest/java/de/dennisguse/opentracks/util/EGM2008UtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/EGM2008UtilsTest.java
@@ -1,0 +1,229 @@
+package de.dennisguse.opentracks.util;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import de.dennisguse.opentracks.content.data.TrackPoint;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(JUnit4.class)
+public class EGM2008UtilsTest {
+
+    private static final double MAX_BILINEAR_ERROR = 0.478;
+
+    private final Context context = ApplicationProvider.getApplicationContext();
+
+    @Test
+    public void fileVerification() throws IOException {
+        // given
+        int expectedLength = 18671444;
+        int expectedHeaderLength = 404;
+
+        String expectedHeader = "P5\n" +
+                "# Geoid file in PGM format for the GeographicLib::Geoid class\n" +
+                "# Description WGS84 EGM2008, 5-minute grid\n" +
+                "# URL http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm2008\n" +
+                "# DateTime 2009-08-29 18:45:00\n" +
+                "# MaxBilinearError 0.478\n" +
+                "# RMSBilinearError 0.012\n" +
+                "# MaxCubicError 0.294\n" +
+                "# RMSCubicError 0.005\n" +
+                "# Offset -108\n" +
+                "# Scale 0.003\n" +
+                "# Origin 90N 0E\n" +
+                "# AREA_OR_POINT Point\n" +
+                "# Vertical_Datum WGS84\n" +
+                "4320    2161\n" +
+                "65535" +
+                "\n";
+
+        // when
+        try (InputStream inputStream = context.getResources().openRawResource(EGM2008Utils.EGM2008_5_DATA)) {
+            assertEquals(expectedLength, inputStream.available());
+
+            InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.US_ASCII);
+            char[] data = new char[expectedHeaderLength];
+            int length = reader.read(data);
+
+            // then
+            assertEquals(expectedHeaderLength, length);
+            assertEquals(expectedHeader, new String(data));
+        }
+    }
+
+    @Test
+    public void data_Northpole() throws IOException {
+        // given
+        TrackPoint trackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochMilli(0));
+        trackPoint.setLatitude(90);
+        trackPoint.setLongitude(0.1);
+        trackPoint.setAltitude(0);
+
+        // when
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+
+        // then
+        assertEquals(-14.8980, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
+    }
+
+    @Test
+    public void data_Southpole() throws IOException {
+        // given
+        TrackPoint trackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochMilli(0));
+        trackPoint.setLatitude(-90);
+        trackPoint.setLongitude(0);
+        trackPoint.setAltitude(0);
+
+        // when
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+
+        // then
+        assertEquals(30.15, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
+    }
+
+    @Test
+    public void data_Southpole2() throws IOException {
+        // given
+        TrackPoint trackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochMilli(0));
+        trackPoint.setLatitude(-90);
+        trackPoint.setLongitude(180);
+        trackPoint.setAltitude(0);
+
+        // when
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+
+        // then
+        assertEquals(30.15, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
+    }
+
+    @Test
+    public void data_Southpole3() throws IOException {
+        // given
+        TrackPoint trackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochMilli(0));
+        trackPoint.setLatitude(-90);
+        trackPoint.setLongitude(-180);
+        trackPoint.setAltitude(0);
+
+        // when
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+
+        // then
+        assertEquals(30.15, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
+    }
+
+    @Test
+    public void data_0() throws IOException {
+        // given
+        TrackPoint trackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochMilli(0));
+        trackPoint.setLatitude(0);
+        trackPoint.setLongitude(0);
+        trackPoint.setAltitude(0);
+
+        // when
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+
+        // then
+        assertEquals(-17.2260, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
+    }
+
+    @Test
+    public void data_Berlin() throws IOException {
+        // given
+        TrackPoint trackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochMilli(0));
+        trackPoint.setLatitude(52.530644);
+        trackPoint.setLongitude(13.383068);
+        trackPoint.setAltitude(0);
+
+        // when
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+
+        // then
+        assertEquals(-39.4865, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
+    }
+
+    @Test
+    public void data_Berlin_Caching() throws IOException {
+        // given
+        TrackPoint trackPoint1 = new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochMilli(0));
+        trackPoint1.setLatitude(52.530644);
+        trackPoint1.setLongitude(13.383068);
+        trackPoint1.setAltitude(0);
+
+        TrackPoint trackPoint2 = new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochMilli(0));
+        trackPoint2.setLatitude(52.530000);
+        trackPoint2.setLongitude(13.380000);
+        trackPoint2.setAltitude(0);
+
+        // when
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint1.getLocation());
+
+        // then
+        assertNotEquals(altitude_egm2008.correctAltitude(trackPoint1.getLocation()), altitude_egm2008.correctAltitude(trackPoint2.getLocation()), 0.0001);
+    }
+
+    @Test
+    public void data_MaxUndulation() throws IOException {
+        // given
+        TrackPoint trackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochMilli(0));
+        trackPoint.setLatitude(-8.417);
+        trackPoint.setLongitude(147.367);
+        trackPoint.setAltitude(0);
+
+        // when
+        EGM2008Utils.EGM2008Correction altitude_egm2008 = EGM2008Utils.createEGM2008Correction(context, trackPoint.getLocation());
+
+        // then
+        assertEquals(-85.824, altitude_egm2008.correctAltitude(trackPoint.getLocation()), MAX_BILINEAR_ERROR);
+    }
+
+    @Test
+    public void getIndices() {
+        TrackPoint trackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochMilli(0));
+        trackPoint.setLatitude(90);
+        trackPoint.setLongitude(0);
+        assertEquals(new EGM2008Utils.Indices(0, 0), EGM2008Utils.getIndices(trackPoint.getLocation()));
+
+        trackPoint.setLatitude(0);
+        trackPoint.setLongitude(0);
+        assertEquals(new EGM2008Utils.Indices(1080, 0), EGM2008Utils.getIndices(trackPoint.getLocation()));
+
+        trackPoint.setLatitude(-90);
+        trackPoint.setLongitude(180);
+        assertEquals(new EGM2008Utils.Indices(2160, 4320 / 2), EGM2008Utils.getIndices(trackPoint.getLocation()));
+
+        trackPoint.setLatitude(-90);
+        trackPoint.setLongitude(-180);
+        assertEquals(new EGM2008Utils.Indices(2160, 0), EGM2008Utils.getIndices(trackPoint.getLocation()));
+    }
+
+    @Test
+    public void getUndulationRaw_ok() throws IOException {
+        try (DataInputStream dataInputStream = new DataInputStream(context.getResources().openRawResource(EGM2008Utils.EGM2008_5_DATA))) {
+            assertEquals(40966, EGM2008Utils.getUndulationRaw(dataInputStream, new EGM2008Utils.Indices(0, 0)));
+            assertEquals(41742, EGM2008Utils.getUndulationRaw(dataInputStream, new EGM2008Utils.Indices(1081, 0)));
+            assertEquals(25950, EGM2008Utils.getUndulationRaw(dataInputStream, new EGM2008Utils.Indices(2160, 4319)));
+        }
+    }
+
+    @Test(expected = EOFException.class)
+    public void getUndulationRaw_error() throws IOException {
+        try (DataInputStream dataInputStream = new DataInputStream(context.getResources().openRawResource(EGM2008Utils.EGM2008_5_DATA))) {
+            assertEquals(0, EGM2008Utils.getUndulationRaw(dataInputStream, new EGM2008Utils.Indices(2161, 4320)), 0.01);
+        }
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/content/data/Altitude.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Altitude.java
@@ -1,0 +1,39 @@
+package de.dennisguse.opentracks.content.data;
+
+public abstract class Altitude {
+
+    private final double altitude_m;
+
+    private Altitude(double altitude_m) {
+        this.altitude_m = altitude_m;
+    }
+
+    public double toM() {
+        return altitude_m;
+    }
+
+    public static class WGS84 extends Altitude {
+
+        private WGS84(double altitude_m) {
+            super(altitude_m);
+        }
+
+
+        public static Altitude of(double altitude_m) {
+            return new WGS84(altitude_m);
+        }
+    }
+
+    public static class EGM2008 extends Altitude {
+
+        private EGM2008(double altitude_m) {
+            super(altitude_m);
+        }
+
+
+        public static Altitude of(double altitude_m) {
+            return new EGM2008(altitude_m);
+        }
+    }
+}
+

--- a/src/main/java/de/dennisguse/opentracks/content/data/Marker.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Marker.java
@@ -50,7 +50,7 @@ public final class Marker {
     private Double latitude;
     private Double longitude;
     private Float accuracy;
-    private Double altitude_m;
+    private Altitude altitude;
     private Float bearing;
 
     //TODO It is the distance from the track starting point; rename to something more meaningful
@@ -77,7 +77,7 @@ public final class Marker {
         this.latitude = trackPoint.getLatitude();
         this.longitude = trackPoint.getLongitude();
         if (trackPoint.hasAccuracy()) this.accuracy = trackPoint.getAccuracy();
-        if (trackPoint.hasAltitude()) this.altitude_m = trackPoint.getAltitude();
+        if (trackPoint.hasAltitude()) this.altitude = trackPoint.getAltitude();
         if (trackPoint.hasBearing()) this.bearing = trackPoint.getBearing();
 
         this.length = Distance.of(0); //TODO Not cool!
@@ -167,7 +167,7 @@ public final class Marker {
             location.setAccuracy(accuracy);
         }
         if (hasAltitude()) {
-            location.setAltitude(altitude_m);
+            location.setAltitude(altitude.toM());
         }
 
         return location;
@@ -202,15 +202,15 @@ public final class Marker {
     }
 
     public boolean hasAltitude() {
-        return altitude_m != null;
+        return altitude != null;
     }
 
-    public Double getAltitude() {
-        return altitude_m;
+    public Altitude getAltitude() {
+        return altitude;
     }
 
-    public void setAltitude(double altitude_m) {
-        this.altitude_m = altitude_m;
+    public void setAltitude(Altitude altitude) {
+        this.altitude = altitude;
     }
 
     public boolean hasBearing() {

--- a/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
@@ -20,6 +20,7 @@ import android.os.Parcel;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -51,7 +52,7 @@ public class TrackPoint {
     private Double latitude;
     private Double longitude;
     private Float accuracy;
-    private Double altitude_m;
+    private Altitude altitude;
     private Speed speed;
     private Float bearing;
     private Distance sensorDistance_m;
@@ -102,7 +103,7 @@ public class TrackPoint {
 
         this.latitude = location.getLatitude();
         this.longitude = location.getLongitude();
-        this.altitude_m = location.getAltitude();
+        this.altitude = Altitude.WGS84.of(location.getAltitude());
         this.speed = Speed.of(location.getSpeed());
         this.accuracy = location.getAccuracy();
 
@@ -114,11 +115,11 @@ public class TrackPoint {
         this.time = time;
     }
 
-    public TrackPoint(double latitude, double longitude, Double altitude, Instant time) {
+    public TrackPoint(double latitude, double longitude, Altitude altitude, Instant time) {
         this(Type.TRACKPOINT);
         this.latitude = latitude;
         this.longitude = longitude;
-        this.altitude_m = altitude;
+        this.altitude = altitude;
         this.time = time;
     }
 
@@ -212,7 +213,7 @@ public class TrackPoint {
             location.setAccuracy(accuracy);
         }
         if (hasAltitude()) {
-            location.setAltitude(altitude_m);
+            location.setAltitude(altitude.toM());
         }
 
         return location;
@@ -257,15 +258,20 @@ public class TrackPoint {
 
 
     public boolean hasAltitude() {
-        return altitude_m != null;
+        return altitude != null;
     }
 
-    public double getAltitude() {
-        return altitude_m;
+    public Altitude getAltitude() {
+        return altitude;
     }
 
-    public void setAltitude(double altitude) {
-        this.altitude_m = altitude;
+    @VisibleForTesting
+    public void setAltitude(double altitude_m) {
+        this.altitude = Altitude.WGS84.of(altitude_m);
+    }
+
+    public void setAltitude(Altitude altitude) {
+        this.altitude = altitude;
     }
 
     public boolean hasSpeed() {

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.UUID;
 
 import de.dennisguse.opentracks.BuildConfig;
+import de.dennisguse.opentracks.content.data.Altitude;
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Marker;
 import de.dennisguse.opentracks.content.data.MarkerColumns;
@@ -320,7 +321,7 @@ public class ContentProviderUtils {
             marker.setLatitude(((double) cursor.getInt(latitudeIndex)) / 1E6);
         }
         if (!cursor.isNull(altitudeIndex)) {
-            marker.setAltitude(cursor.getFloat(altitudeIndex));
+            marker.setAltitude(Altitude.WGS84.of(cursor.getFloat(altitudeIndex)));
         }
         if (!cursor.isNull(accuracyIndex)) {
             marker.setAccuracy(cursor.getFloat(accuracyIndex));
@@ -489,7 +490,7 @@ public class ContentProviderUtils {
         values.put(MarkerColumns.LATITUDE, (int) (marker.getLatitude() * 1E6));
         values.put(MarkerColumns.TIME, marker.getTime().toEpochMilli());
         if (marker.hasAltitude()) {
-            values.put(MarkerColumns.ALTITUDE, marker.getAltitude());
+            values.put(MarkerColumns.ALTITUDE, marker.getAltitude().toM());
         }
         if (marker.hasAccuracy()) {
             values.put(MarkerColumns.ACCURACY, marker.getAccuracy());
@@ -539,7 +540,7 @@ public class ContentProviderUtils {
             trackPoint.setTime(Instant.ofEpochMilli(cursor.getLong(indexes.timeIndex)));
         }
         if (!cursor.isNull(indexes.altitudeIndex)) {
-            trackPoint.setAltitude(cursor.getFloat(indexes.altitudeIndex));
+            trackPoint.setAltitude(Altitude.WGS84.of(cursor.getFloat(indexes.altitudeIndex)));
         }
         if (!cursor.isNull(indexes.accuracyIndex)) {
             trackPoint.setAccuracy(cursor.getFloat(indexes.accuracyIndex));
@@ -690,7 +691,7 @@ public class ContentProviderUtils {
         }
         values.put(TrackPointsColumns.TIME, trackPoint.getTime().toEpochMilli());
         if (trackPoint.hasAltitude()) {
-            values.put(TrackPointsColumns.ALTITUDE, trackPoint.getAltitude());
+            values.put(TrackPointsColumns.ALTITUDE, trackPoint.getAltitude().toM());
         }
         if (trackPoint.hasAccuracy()) {
             values.put(TrackPointsColumns.ACCURACY, trackPoint.getAccuracy());

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
@@ -444,7 +444,7 @@ public class StatisticsRecordingFragment extends Fragment implements TrackDataLi
 
         if (preferenceShowAltitude) {
             // Current altitude
-            Float altitude = lastTrackPoint != null && lastTrackPoint.hasAltitude() ? (float) lastTrackPoint.getAltitude() : null;
+            Float altitude = lastTrackPoint != null && lastTrackPoint.hasAltitude() ? (float) lastTrackPoint.getAltitude().toM() : null;
             Pair<String, String> parts = StringUtils.formatAltitude(getContext(), altitude, preferenceMetricUnits);
             viewBinding.statsAltitudeCurrentValue.setText(parts.first);
             viewBinding.statsAltitudeCurrentUnit.setText(parts.second);

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
@@ -237,7 +237,7 @@ public class GPXTrackExporter implements TrackExporter {
         if (printWriter != null) {
             printWriter.println("<wpt " + formatLocation(marker.getLatitude(), marker.getLongitude()) + ">");
             if (marker.hasAltitude()) {
-                printWriter.println("<ele>" + ALTITUDE_FORMAT.format(marker.getAltitude()) + "</ele>");
+                printWriter.println("<ele>" + ALTITUDE_FORMAT.format(marker.getAltitude().toM()) + "</ele>");
             }
             printWriter.println("<time>" + StringUtils.formatDateTimeIso8601(marker.getTime()) + "</time>");
             printWriter.println("<name>" + StringUtils.formatCData(marker.getName()) + "</name>");
@@ -281,7 +281,7 @@ public class GPXTrackExporter implements TrackExporter {
             printWriter.println("<trkpt " + formatLocation(trackPoint.getLatitude(), trackPoint.getLongitude()) + ">");
 
             if (trackPoint.hasAltitude()) {
-                printWriter.println("<ele>" + ALTITUDE_FORMAT.format(trackPoint.getAltitude()) + "</ele>");
+                printWriter.println("<ele>" + ALTITUDE_FORMAT.format(trackPoint.getAltitude().toM()) + "</ele>");
             }
 
             printWriter.println("<time>" + StringUtils.formatDateTimeIso8601(trackPoint.getTime()) + "</time>");

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/AbstractFileTrackImporter.java
@@ -36,6 +36,7 @@ import java.util.Locale;
 import java.util.UUID;
 
 import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.content.data.Altitude;
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Marker;
 import de.dennisguse.opentracks.content.data.Speed;
@@ -428,7 +429,7 @@ abstract class AbstractFileTrackImporter extends DefaultHandler implements XMLIm
 
         if (altitude != null) {
             try {
-                trackPoint.setAltitude(Double.parseDouble(altitude));
+                trackPoint.setAltitude(Altitude.WGS84.of(Double.parseDouble(altitude)));
             } catch (NumberFormatException e) {
                 throw new ParsingException(createErrorMessage(String.format(Locale.US, "Unable to parse altitude: %s", altitude)), e);
             }

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdater.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdater.java
@@ -148,7 +148,7 @@ public class TrackStatisticsUpdater {
 
         //Update absolute (GPS-based) altitude
         if (trackPoint.hasAltitude()) {
-            updateAbsoluteAltitude(trackPoint.getAltitude());
+            updateAbsoluteAltitude(trackPoint.getAltitude().toM());
         }
 
         if (lastTrackPoint == null || lastMovingTrackPoint == null) {

--- a/src/main/java/de/dennisguse/opentracks/util/EGM2008Utils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/EGM2008Utils.java
@@ -1,0 +1,176 @@
+package de.dennisguse.opentracks.util;
+
+import android.content.Context;
+import android.location.Location;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.Objects;
+
+import de.dennisguse.opentracks.R;
+
+/**
+ * Converts WGS84 altitude to EGM2008 (should be close to height above sea level).
+ * <p>
+ * Uses <a href="https://geographiclib.sourceforge.io/">GeographicLib</a>] EGM2008 5minute undulation data.
+ * https://geographiclib.sourceforge.io/html/geoid.html
+ * <p>
+ * File starts at 90N, 0E (North pole) and is encoded in parallel bands as unsigned shorts.
+ */
+public class EGM2008Utils {
+
+    static final int EGM2008_5_DATA = R.raw.egm2008_5;
+
+    private static final int HEADER_LENGTH = 404;
+
+    private static final int RESOLUTION_IN_MINUTES = 60 / 5;
+
+    private static final int LATITUDE_CORRECTION = 360 * RESOLUTION_IN_MINUTES;
+
+    private EGM2008Utils() {
+    }
+
+    public static EGM2008Correction createEGM2008Correction(Context context, Location location) throws IOException {
+        Indices indices = getIndices(location);
+
+        try (DataInputStream dataInputStream = new DataInputStream(context.getResources().openRawResource(EGM2008_5_DATA))) {
+            return new EGM2008Correction(indices, dataInputStream);
+        }
+    }
+
+    @VisibleForTesting
+    static int getUndulationRaw(DataInputStream dataInputStream, Indices indices) throws IOException {
+        dataInputStream.reset();
+        int absoluteIndex = indices.getAbsoluteIndex();
+        return getUndulationRaw(dataInputStream, absoluteIndex);
+    }
+
+    private static int getUndulationRaw(DataInputStream dataInputStream, int undulationIndex) throws IOException {
+        dataInputStream.reset();
+        int index = HEADER_LENGTH + undulationIndex * 2;  //byte size is 2
+        long ignored = dataInputStream.skip(index);
+
+        return dataInputStream.readUnsignedShort();
+    }
+
+    @VisibleForTesting
+    static Indices getIndices(Location location) {
+        double latitude = -location.getLatitude() + 90;
+        int latitudeIndex = (int) (latitude * RESOLUTION_IN_MINUTES);
+
+        double longitude;
+        if (location.getLongitude() >= 0) {
+            longitude = location.getLongitude();
+        } else {
+            longitude = 180 + Math.abs(location.getLongitude());
+        }
+        int longitudeIndex = (int) (longitude * RESOLUTION_IN_MINUTES);
+
+        if (longitudeIndex >= 360 * RESOLUTION_IN_MINUTES) {
+            longitudeIndex = 0;
+        }
+        return new Indices(latitudeIndex, longitudeIndex);
+    }
+
+    public static class EGM2008Correction {
+
+        protected final Indices indices;
+
+        protected final int v00;
+        protected final int v10;
+        protected final int v01;
+        protected final int v11;
+
+        public EGM2008Correction(Indices indices, DataInputStream dataInputStream) throws IOException {
+            this.indices = indices;
+
+            v00 = getUndulationRaw(dataInputStream, indices);
+            if (!isSouthPole()) {
+                v10 = getUndulationRaw(dataInputStream, indices.offset(0, 1));
+                v01 = getUndulationRaw(dataInputStream, indices.offset(1, 0));
+                v11 = getUndulationRaw(dataInputStream, indices.offset(1, 1));
+            } else {
+                v10 = 0;
+                v01 = 0;
+                v11 = 0;
+            }
+        }
+
+        public boolean canCorrect(@NonNull Location location) {
+            return indices.getAbsoluteIndex() == getIndices(location).getAbsoluteIndex();
+        }
+
+        public double correctAltitude(@NonNull Location location) {
+            if (!canCorrect(location))
+                throw new RuntimeException("Undulation data not loaded for this location.");
+            if (!location.hasAltitude())
+                throw new RuntimeException("Location has no altitude");
+
+            double undulationRaw;
+            if (isSouthPole()) {
+                // No bilinear interpolation on South Pole (not worth the time)
+                undulationRaw = v00;
+            } else {
+                double fLongitude = location.getLongitude() * RESOLUTION_IN_MINUTES -
+                        (int) (location.getLongitude() * RESOLUTION_IN_MINUTES);
+
+                double fLatitude = (-location.getLatitude() + 90) * RESOLUTION_IN_MINUTES
+                        - (int) ((-location.getLatitude() + 90) * RESOLUTION_IN_MINUTES);
+
+                // Bilinear interpolation (optimized; taken from GeopgrahicLib/Geoid.cpp)
+                double
+                        a = (1 - fLongitude) * v00 + fLongitude * v01,
+                        b = (1 - fLongitude) * v10 + fLongitude * v11;
+                undulationRaw = (1 - fLatitude) * a + fLatitude * b;
+            }
+            // Bilinear interpolation (not optimized)
+            //undulationRaw = v00 * (1 - fLongitude) * (1 - fLatitude)
+            //        + v10 * fLongitude * (1 - fLatitude)
+            //        + v01 * (1 - fLongitude) * fLatitude
+            //        + v11 * fLongitude * fLatitude;
+
+            double h = 0.003 * undulationRaw - 108;
+
+            return location.getAltitude() - h;
+        }
+
+        private boolean isSouthPole() {
+            return indices.latitudeIndex == 2160;
+        }
+    }
+
+    @VisibleForTesting
+    static class Indices {
+        final int latitudeIndex;
+        final int longitudeIndex;
+
+        Indices(int latitudeIndex, int longitudeIndex) {
+            this.latitudeIndex = latitudeIndex;
+            this.longitudeIndex = longitudeIndex;
+        }
+
+        Indices offset(int latitudeOffset, int longitudeOffset) {
+            return new Indices(latitudeIndex + latitudeOffset, longitudeIndex + longitudeOffset);
+        }
+
+        int getAbsoluteIndex() {
+            return latitudeIndex * LATITUDE_CORRECTION + longitudeIndex;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            Indices indices = (Indices) o;
+            return latitudeIndex == indices.latitudeIndex &&
+                    longitudeIndex == indices.longitudeIndex;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(latitudeIndex, longitudeIndex);
+        }
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/util/EGM2008Utils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/EGM2008Utils.java
@@ -33,7 +33,7 @@ public class EGM2008Utils {
     private EGM2008Utils() {
     }
 
-    public static EGM2008Correction createEGM2008Correction(Context context, Location location) throws IOException {
+    public static EGM2008Correction createCorrection(Context context, Location location) throws IOException {
         Indices indices = getIndices(location);
 
         try (DataInputStream dataInputStream = new DataInputStream(context.getResources().openRawResource(EGM2008_5_DATA))) {
@@ -84,7 +84,7 @@ public class EGM2008Utils {
         protected final int v01;
         protected final int v11;
 
-        public EGM2008Correction(Indices indices, DataInputStream dataInputStream) throws IOException {
+        private EGM2008Correction(Indices indices, DataInputStream dataInputStream) throws IOException {
             this.indices = indices;
 
             v00 = getUndulationRaw(dataInputStream, indices);

--- a/src/main/res/layout/about.xml
+++ b/src/main/res/layout/about.xml
@@ -16,31 +16,28 @@
             android:orientation="vertical"
             android:padding="20dp">
 
-            <ImageView
-                android:id="@+id/imageView"
-                android:layout_width="match_parent"
-                android:layout_height="239dp"
-                android:contentDescription="@string/app_name"
-                android:scaleType="fitCenter"
-                android:src="@drawable/ic_logo_color_24dp" />
-
-            <TextView
-                style="@style/TextLarge"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="@string/app_name"
-                android:textSize="24sp" />
+                android:orientation="horizontal"
+                android:layout_margin="8dp">
 
-            <View style="@style/StatsHorizontalLine" />
+                <ImageView
+                    android:id="@+id/imageView"
+                    android:layout_width="30dp"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@string/app_name"
+                    android:scaleType="fitCenter"
+                    android:src="@drawable/ic_logo_color_24dp" />
 
-            <TextView
-                android:id="@+id/about_text_description"
-                style="@style/TextMedium"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:padding="12dp" />
+                <TextView
+                    android:id="@+id/about_text_description"
+                    style="@style/TextMedium"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:padding="12dp" />
+            </LinearLayout>
 
             <View style="@style/StatsHorizontalLine" />
 
@@ -74,9 +71,25 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"
-                android:padding="6dp"
                 android:linksClickable="true"
+                android:padding="6dp"
                 android:text="@string/about_history" />
+
+            <View style="@style/StatsHorizontalLine" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="12dp"
+                android:text="@string/about_third_party_data" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="12dp"
+                android:text="@string/third_party_data" />
 
             <View style="@style/StatsHorizontalLine" />
 

--- a/src/main/res/layout/statistics_recording.xml
+++ b/src/main/res/layout/statistics_recording.xml
@@ -282,6 +282,17 @@
             app:layout_constraintTop_toBottomOf="@id/stats_altitude_horizontal_line" />
 
         <TextView
+            android:id="@+id/stats_elevation_current_label_egm"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="0dp"
+            android:text="@string/egm2008"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toStartOf="@id/guideline2"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintTop_toBottomOf="@id/stats_altitude_current_value" />
+
+        <TextView
             android:id="@+id/stats_altitude_current_value"
             style="@style/StatsSmallValue"
             android:value="@string/value_unknown"

--- a/src/main/res/values/do_not_translate.xml
+++ b/src/main/res/values/do_not_translate.xml
@@ -17,6 +17,11 @@ limitations under the License.
     <string name="app_web_url" translatable="false">https://github.com/OpenTracksApp/OpenTracks</string>
     <string name="app_name" translatable="false">OpenTracks</string>
 
+    <string name="third_party_data" translatable="false">
+        <a href="https://earth-info.nga.mil/">National Geospatial-Intelligence Agency (NGA)\'s EGM2008 model</a> 5\' minute resolution.
+        Data provided by <a href="https://geographiclib.sourceforge.io/html/geoid.html">GeographicLib</a>.
+    </string>
+
     <!-- List here all used libraries (will be shown in the about activity -->
     <string name="third_party_libraries" translatable="false">
         <a href="https://developer.android.com/topic/libraries/support-library/">Google\'s androidX support</a> (Apache License, Version 2.0) \n

--- a/src/main/res/values/do_not_translate.xml
+++ b/src/main/res/values/do_not_translate.xml
@@ -17,6 +17,8 @@ limitations under the License.
     <string name="app_web_url" translatable="false">https://github.com/OpenTracksApp/OpenTracks</string>
     <string name="app_name" translatable="false">OpenTracks</string>
 
+    <string name="egm2008" translatable="false">EGM2008</string>
+
     <string name="third_party_data" translatable="false">
         <a href="https://earth-info.nga.mil/">National Geospatial-Intelligence Agency (NGA)\'s EGM2008 model</a> 5\' minute resolution.
         Data provided by <a href="https://geographiclib.sourceforge.io/html/geoid.html">GeographicLib</a>.

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@ limitations under the License.
     <string name="about_version_name">Version name: %1$s</string>
     <string name="about_version_code">Version code: %1$d</string>
     <string name="about_history">OpenTracks is a fork of <a href="https://code.google.com/archive/p/mytracks/"><i>Google\'s MyTracks</i></a> (discontinued in 2016).</string>
+    <string name="about_third_party_data">Third-party data</string>
     <string name="about_libraries">Libraries</string>
     <!-- Help -->
     <string name="help_feature_title">OpenTracks has the following features:</string>


### PR DESCRIPTION
* [x] add EGM2008 data (5 minute resolution from GeographicLib, PGM format)
* [x] parse EGM2008 data
* [x] use EGM2008 corrected in UI (@dennisguse)
* [x] bilinear ~~or bicubic interpolation~~ + fix tests expectations
* [x] add EGM2008 data source reference to about page 
* [x]  use EGM2008 corrected in charts (@dennisguse) (more complicated than it looks like
* [x] show that we use EGM2008 in the StatisticsRecordingFragment? Or make it configurable: WGS84 or EGM2008.

PS: EGM2008 lookup is cached, but happens currently in the UI thread.
For now that is okay, but is not cool.
Lookup should only happens once per track at a 5' minute resolution.

Adds about ~~20MB~~ 16MB as data to the APK.

More infos: https://geographiclib.sourceforge.io/html/geoid.html 