### PR TITLE
While recording show coordinates by default.

### DIFF
--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Do not translate anything in this file directly. -->
     <string name="stats_show_coordinate_key" translatable="false">statsShowCoordinate</string>
-    <bool name="stats_show_coordinate_default" translatable="false">false</bool>
+    <bool name="stats_show_coordinate_default" translatable="false">true</bool>
 
     <string name="stats_show_grade_altitude_key" translatable="false">statsShowGradeElevation</string>
     <bool name="stats_show_altitude_default" translatable="false">true</bool>


### PR DESCRIPTION
Show the coordinates by default, so new users are aware that they can get them if needed.