### PR TITLE
Distance interval bugfixed: interval options are km/mi values

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/content/data/Distance.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Distance.java
@@ -20,9 +20,13 @@ public class Distance {
         return of(distance_mile * UnitConversions.MI_TO_M);
     }
 
+    public static Distance ofKilometer(double distance_km) {
+        return of(distance_km * UnitConversions.KM_TO_M);
+    }
+
     public static Distance one(boolean metricUnit) {
         if (metricUnit) {
-            return Distance.of(1);
+            return Distance.ofKilometer(1);
         } else {
             return Distance.ofMile(1);
         }

--- a/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsModel.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsModel.java
@@ -35,7 +35,7 @@ public class IntervalStatisticsModel extends AndroidViewModel {
                 }
 
                 intervalsLiveData = new MutableLiveData<>();
-                distanceInterval = interval.getValue();
+                distanceInterval = interval.getDistance(metricUnits);
                 loadIntervalStatistics();
             }
             return intervalsLiveData;
@@ -73,7 +73,7 @@ public class IntervalStatisticsModel extends AndroidViewModel {
                 interval = IntervalOption.OPTION_1;
             }
 
-            distanceInterval = interval.getValue();
+            distanceInterval = interval.getDistance(metricUnits);
             loadIntervalStatistics();
         }
     }
@@ -91,19 +91,21 @@ public class IntervalStatisticsModel extends AndroidViewModel {
         OPTION_20(20),
         OPTION_50(50);
 
-        private final Distance value;
+        private final int multiplier;
 
-        IntervalOption(int value) {
-            this.value = Distance.of(value);
+        IntervalOption(int multiplier) {
+            this.multiplier = multiplier;
         }
 
-        public Distance getValue() {
-            return value;
+        public Distance getDistance(boolean metricUnits) {
+            return Distance
+                    .one(metricUnits)
+                    .multipliedBy(multiplier);
         }
 
         @Override
         public String toString() {
-            return "" + (int) value.toM(); //TODO Somehow IntervalsFragment relies on a parsable Integer.
+            return "" + multiplier; //TODO Somehow IntervalsFragment relies on a parsable Integer.
         }
     }
 }


### PR DESCRIPTION
@dennisguse maybe we need a new release because intervals are computed using 1m, 2m, 5m, 10m, 20m, 50m instead of 1km, 2km, 5km, 10km, 20km, 50km.

Sorry, but I couldn't test new Distance code until now :(

This PR fixes that.