### PR TITLE
Fix #711: declare TextToSpeech.Engine.INTENT_ACTION_TTS_SERVICE on qu…

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -351,4 +351,10 @@ limitations under the License.
             android:exported="false"
             android:permission="android.permission.BIND_JOB_SERVICE" />
     </application>
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.TTS_SERVICE" />
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
This enables the use of TextToSpeech engine on Android 11.
Ref.: https://developer.android.com/reference/android/speech/tts/TextToSpeech

Issue: https://github.com/OpenTracksApp/OpenTracks/issues/711#issuecomment-820925033