### PR TITLE
registerListener for barometric sensor uses SENSOR_DELAY_FASTEST

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/sensors/AltitudeSumManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/sensors/AltitudeSumManager.java
@@ -40,7 +40,7 @@ public class AltitudeSumManager implements SensorEventListener {
             Log.w(TAG, "No pressure sensor available.");
             isConnected = false;
         } else {
-            isConnected = sensorManager.registerListener(this, pressureSensor, (int) SAMPLING_RATE.toNanos());
+            isConnected = sensorManager.registerListener(this, pressureSensor, SensorManager.SENSOR_DELAY_FASTEST);
         }
 
         lastAcceptedPressureValue_hPa = Float.NaN;


### PR DESCRIPTION
**Describe the pull request**
`sensorManager.registerListener` didn't work because `samplingPeriodUs` arguments was in nanosecons. Seem that delay must be in microseconds. According to the documentation:

The rate `android.hardware.SensorEvent sensor events` are delivered at. This is only a hint to the system. Events may be received faster or slower than the specified rate. Usually events are received faster. The value must be one of `#SENSOR_DELAY_NORMAL`, ` #SENSOR_DELAY_UI`, `#SENSOR_DELAY_GAME`, or `#SENSOR_DELAY_FASTEST` or, the desired delay between events in microseconds. Specifying the delay in microseconds only works from Android 2.3 (API level 9) onwards. For earlier releases, you must use one of the `SENSOR_DELAY_*` constants.

So, I propose to use SENSOR_DELAY_FASTEST.

**Link to the the issue**
This PR fixes #714

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
