### PR TITLE
Announcement potencial bug and race condition fixed.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
+++ b/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
@@ -146,9 +146,9 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
             @Override
             public void onTrackRecordingId(Track.Id trackId) {
                 recordingTrackId = trackId;
+                announce(trackRecordingService.getTrackStatistics());
             }
         });
-        announce(trackRecordingService.getTrackStatistics());
     }
 
     /**
@@ -181,7 +181,11 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
         }
 
         Track track = contentProviderUtils.getTrack(recordingTrackId);
-        String category = track != null ? track.getCategory() : "";
+        if (track == null) {
+            Log.i(TAG, "It doesn't exists a track with trackid = " + recordingTrackId);
+            return;
+        }
+        String category = track.getCategory();
 
         //TODO Querying all TrackPoints all the time is inefficient; use TrackDataHub or something else.
         TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), null);


### PR DESCRIPTION
**Describe the pull request**
`announce` should be called after getting `recordingTrackId`.

Also, if `track` is null then `announce` should be stopped (announcement cannot be used).

**Link to the the issue**
(If available): The link to the issue that this pull request solves.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
