### PR TITLE
Bugfix: AnnouncementPeriodicTask does register at TrackRecordingServiceListener

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -192,6 +192,10 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
         return serviceStatus.getRecordingTrackPaused();
     }
 
+    public Track.Id getRecordingTrackId() {
+        return serviceStatus.getRecordingTrackId();
+    }
+
     public TrackStatistics getTrackStatistics() {
         if (trackStatisticsUpdater == null) {
             return null;
@@ -567,6 +571,12 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
 
     public void addListener(@NonNull TrackRecordingServiceStatus.Listener listener) {
         serviceStatus.addListener(listener);
+    }
+
+    //TODO Check that this is used everywhere, where addListener is called!
+    //Otherwise, we keep objects in referenced and waste memory until this service instance is terminated.
+    public void removeListener(@NonNull TrackRecordingServiceStatus.Listener listener) {
+        serviceStatus.removeListener(listener);
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceStatus.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceStatus.java
@@ -19,13 +19,17 @@ public class TrackRecordingServiceStatus {
 
     private final List<Listener> listeners = new ArrayList<>();
 
-    public void addListener(@NonNull Listener listener) {
+    void addListener(@NonNull Listener listener) {
         if (this.listeners.contains(listener)) {
             return;
         }
         this.listeners.add(listener);
         listener.onTrackRecordingId(recordingTrackId);
         listener.onTrackRecordingPaused(recordingTrackPaused);
+    }
+
+    void removeListener(@NonNull Listener listener) {
+        this.listeners.remove(listener);
     }
 
     public boolean getRecordingTrackPaused() {

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdater.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdater.java
@@ -106,7 +106,7 @@ public class TrackStatisticsUpdater {
      */
     public void addTrackPoint(TrackPoint trackPoint, Distance minGPSDistance) {
         internalAddTrackPoint(trackPoint, minGPSDistance);
-        Log.d(TAG, this.toString());
+        Log.v(TAG, this.toString());
     }
 
     private void internalAddTrackPoint(TrackPoint trackPoint, Distance minGPSDistance) {


### PR DESCRIPTION
Related to #719, but does not (yet) fix the memory leak.

We need to make sure this is executed by every listener.
```
TrackRecordingService.removeListener()
```
