### PR TITLE
Some improvements for #719

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/chart/ChartPointTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/chart/ChartPointTest.java
@@ -1,0 +1,94 @@
+package de.dennisguse.opentracks.chart;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.time.Duration;
+
+import de.dennisguse.opentracks.content.data.Distance;
+import de.dennisguse.opentracks.content.data.Speed;
+import de.dennisguse.opentracks.content.data.TrackPoint;
+import de.dennisguse.opentracks.fragments.TrackStubUtils;
+import de.dennisguse.opentracks.stats.TrackStatistics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(AndroidJUnit4.class)
+public class ChartPointTest {
+
+    @Test
+    public void create_by_time() {
+        // given
+        TrackStatistics statistics = new TrackStatistics();
+        statistics.setTotalTime(Duration.ofSeconds(1000));
+
+        // when
+        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(0), 0, false, false);
+
+        // then
+        assertEquals(1000000, (long) point.getTimeOrDistance());
+    }
+
+    @Test
+    public void create_by_distance() {
+        // given
+        TrackStatistics statistics = new TrackStatistics();
+        statistics.setTotalDistance(Distance.of(1000));
+
+        // when
+        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(0), 0, true, true);
+
+        // then
+        assertEquals(1, (long) point.getTimeOrDistance());
+    }
+
+    @Test
+    public void create_get_altitude_speed_and_pace() {
+        // given
+        TrackStatistics statistics = new TrackStatistics();
+
+        // when
+        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(10), 50, false, true);
+
+        // then
+        assertEquals(0.05, point.getAltitude(), 0.01);
+        assertEquals(36, point.getSpeed(), 0.01);
+        assertEquals(1.66, point.getPace(), 0.01);
+    }
+
+    @Test
+    public void create_sensorNotAvailable() {
+        // given
+        TrackStatistics statistics = new TrackStatistics();
+
+        // when
+        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(10), 50, false, true);
+
+        // then
+        assertNull(point.getHeartRate());
+        assertNull(point.getCadence());
+        assertNull(point.getPower());
+    }
+
+    @Test
+    public void create_sensorAvailable() {
+        // given
+        TrackPoint trackPoint = TrackStubUtils.createDefaultTrackPoint();
+        trackPoint.setHeartRate_bpm(100f);
+        trackPoint.setCyclingCadence_rpm(101f);
+        trackPoint.setPower(102f);
+
+        TrackStatistics statistics = new TrackStatistics();
+
+        // when
+        ChartPoint point = new ChartPoint(statistics, trackPoint, Speed.of(10), 50, false, true);
+
+        // then
+        assertEquals(100.0, point.getHeartRate(), 0.01);
+        assertEquals(101.0, point.getCadence(), 0.01);
+        assertEquals(102.0, point.getPower(), 0.01);
+    }
+}

--- a/src/androidTest/java/de/dennisguse/opentracks/fragments/ChartFragmentTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/fragments/ChartFragmentTest.java
@@ -16,7 +16,6 @@
 
 package de.dennisguse.opentracks.fragments;
 
-import android.location.Location;
 import android.os.Looper;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -28,24 +27,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.time.Duration;
-import java.time.Instant;
-
-import de.dennisguse.opentracks.chart.ChartPoint;
 import de.dennisguse.opentracks.chart.ChartView;
 import de.dennisguse.opentracks.content.data.Distance;
-import de.dennisguse.opentracks.content.data.Speed;
-import de.dennisguse.opentracks.content.data.TrackPoint;
-import de.dennisguse.opentracks.util.UnitConversions;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Tests {@link ChartFragment}.
  *
  * @author Youtao Liu
  */
+//TODO Add tests that check ChartFragment
 @RunWith(AndroidJUnit4.class)
 public class ChartFragmentTest {
 
@@ -72,261 +62,8 @@ public class ChartFragmentTest {
         chartFragment.setRecordingDistanceInterval(Distance.of(50));
     }
 
-    /**
-     * Tests the logic to get the incorrect values of sensor in {@link ChartFragment#createPendingPoint(TrackPoint)}.
-     */
     @Test
-    public void testCreatePendingPoint_sensorIncorrect() {
-        // given
-        TrackPoint trackPoint = TrackStubUtils.createDefaultTrackPoint();
-
-        // when
-        ChartPoint point = chartFragment.createPendingPoint(trackPoint);
-
-        // then
-        assertNull(point.getHeartRate());
-        assertNull(point.getCadence());
-        assertNull(point.getPower());
-    }
-
-    /**
-     * Tests the logic to get the correct values of sensor in {@link ChartFragment#createPendingPoint(TrackPoint)}.
-     */
-    @Test
-    public void testCreatePendingPoint_sensorCorrect() {
-        // given
-        TrackPoint trackPoint = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint.setHeartRate_bpm(100f);
-        trackPoint.setCyclingCadence_rpm(101f);
-        trackPoint.setPower(102f);
-
-        // when
-        ChartPoint point = chartFragment.createPendingPoint(trackPoint);
-
-        // then
-        assertEquals(100.0, point.getHeartRate(), 0.01);
-        assertEquals(101.0, point.getCadence(), 0.01);
-        assertEquals(102.0, point.getPower(), 0.01);
-    }
-
-    /**
-     * Tests the logic to get the value of metric Distance in {@link ChartFragment#createPendingPoint(TrackPoint)}.
-     */
-    @Test
-    public void testCreatePendingPoint_distanceMetric() {
-        chartFragment.setChartByDistance(true);
-        // Resets last location and writes first location.
-        TrackPoint trackPoint1 = TrackStubUtils.createDefaultTrackPoint();
-        ChartPoint point = chartFragment.createPendingPoint(trackPoint1);
-        assertEquals(0.0, point.getTimeOrDistance(), 0.01);
-
-        // The second is a same location, just different time.
-        TrackPoint trackPoint2 = TrackStubUtils.createDefaultTrackPoint();
-        point = chartFragment.createPendingPoint(trackPoint2);
-        assertEquals(0.0, point.getTimeOrDistance(), 0.01);
-
-        // The third location is a new location, and use metric.
-        TrackPoint trackPoint3 = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint3.setLatitude(23);
-        point = chartFragment.createPendingPoint(trackPoint3);
-
-        // Computes the distance between Latitude 22 and 23.
-        float[] results = new float[4];
-        Location.distanceBetween(trackPoint2.getLatitude(), trackPoint2.getLongitude(),
-                trackPoint3.getLatitude(), trackPoint3.getLongitude(), results);
-        double distance1 = results[0] * UnitConversions.M_TO_KM;
-        assertEquals(distance1, point.getTimeOrDistance(), 0.01);
-
-        // The fourth location is a new location, and use metric.
-        TrackPoint trackPoint4 = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint4.setLatitude(24);
-        point = chartFragment.createPendingPoint(trackPoint4);
-
-        // Computes the distance between Latitude 23 and 24.
-        Location.distanceBetween(trackPoint3.getLatitude(), trackPoint3.getLongitude(),
-                trackPoint4.getLatitude(), trackPoint4.getLongitude(), results);
-        double distance2 = results[0] * UnitConversions.M_TO_KM;
-        assertEquals((distance1 + distance2), point.getTimeOrDistance(), 0.01);
-    }
-
-    /**
-     * Tests the logic to get the value of imperial Distance in {@link ChartFragment#createPendingPoint(TrackPoint)}.
-     */
-    @Test
-    public void testCreatePendingPoint_distanceImperial() {
-        // By distance.
-        chartFragment.setChartByDistance(true);
-        // Setups to use imperial.
-        chartFragment.setMetricUnits(false);
-
-        // The first is a same location, just different time.
-        TrackPoint trackPoint1 = TrackStubUtils.createDefaultTrackPoint();
-        ChartPoint point = chartFragment.createPendingPoint(trackPoint1);
-        assertEquals(0.0, point.getTimeOrDistance(), 0.01);
-
-        // The second location is a new location, and use imperial.
-        TrackPoint trackPoint2 = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint2.setLatitude(23);
-        point = chartFragment.createPendingPoint(trackPoint2);
-
-        /*
-         * Computes the distance between Latitude 22 and 23.
-         * And for we set using * imperial, the distance should be multiplied by UnitConversions.KM_TO_MI.
-         */
-        float[] results = new float[4];
-        Location.distanceBetween(trackPoint1.getLatitude(), trackPoint1.getLongitude(), trackPoint2.getLatitude(), trackPoint2.getLongitude(), results);
-        double distance1 = results[0] * UnitConversions.M_TO_KM * UnitConversions.KM_TO_MI;
-        assertEquals(distance1, point.getTimeOrDistance(), 0.01);
-
-        // The third location is a new location, and use imperial.
-        TrackPoint trackPoint3 = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint3.setLatitude(24);
-        point = chartFragment.createPendingPoint(trackPoint3);
-
-        /*
-         * Computes the distance between Latitude 23 and 24.
-         * And for we set using * imperial, the distance should be multiplied by UnitConversions.KM_TO_MI.
-         */
-        Location.distanceBetween(trackPoint2.getLatitude(), trackPoint2.getLongitude(), trackPoint3.getLatitude(), trackPoint3.getLongitude(), results);
-        double distance2 = results[0] * UnitConversions.M_TO_KM * UnitConversions.KM_TO_MI;
-        assertEquals(distance1 + distance2, point.getTimeOrDistance(), 0.01);
-    }
-
-    /**
-     * Tests the logic to get the values of time in {@link ChartFragment#createPendingPoint(TrackPoint)}.
-     */
-    @Test
-    public void testCreatePendingPoint_time() {
-        // given
-        chartFragment.setChartByDistance(false);
-        TrackPoint trackPoint1 = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint1.setTime(Instant.ofEpochMilli(TrackStubUtils.INITIAL_TIME)); //Keep old TrackPoint behavior of having time=0 for this test
-
-        // when
-        ChartPoint point = chartFragment.createPendingPoint(trackPoint1);
-
-        // then
-        assertEquals(0.0, point.getTimeOrDistance(), 0.01);
-        Duration timeSpan = Duration.ofMillis(222);
-        TrackPoint trackPoint2 = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint2.setTime(Instant.ofEpochMilli(TrackStubUtils.INITIAL_TIME).plus(timeSpan));
-        point = chartFragment.createPendingPoint(trackPoint2);
-        assertEquals(timeSpan, Duration.ofMillis((long) point.getTimeOrDistance()));
-    }
-
-    /**
-     * Tests the logic to get the value of altitude in {@link ChartFragment#createPendingPoint(TrackPoint)} by one and two points.
-     */
-    @Test
-    public void testCreatePendingPoint_altitude() {
-        TrackPoint trackPoint1 = TrackStubUtils.createDefaultTrackPoint();
-
-        /*
-         * At first, clear old points of altitude, so give true to the second parameter.
-         * Then only one value INITIAL_ALTITUDE in buffer.
-         */
-        ChartPoint point = chartFragment.createPendingPoint(trackPoint1);
-        assertEquals(TrackStubUtils.INITIAL_ALTITUDE, point.getAltitude(), 0.01);
-
-        /*
-         * Send another value to buffer, now there are two values, INITIAL_ALTITUDE and INITIAL_ALTITUDE * 2.
-         */
-        TrackPoint trackPoint2 = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint2.setAltitude(TrackStubUtils.INITIAL_ALTITUDE * 2);
-        point = chartFragment.createPendingPoint(trackPoint2);
-        assertEquals((TrackStubUtils.INITIAL_ALTITUDE + TrackStubUtils.INITIAL_ALTITUDE * 2) / 2.0, point.getAltitude(), 0.01);
-    }
-
-    /**
-     * Tests the logic to get the value of speed in {@link ChartFragment#createPendingPoint(TrackPoint)}.
-     * In this test, firstly remove all points in memory, and then fill in two points one by one.
-     * The speed values of these points are 129, 130.
-     */
-    @Test
-    public void testCreatePendingPoint_speed() {
-        /*
-         * At first, clear old points of speed, so give true to the second parameter.
-         * It will not be filled in to the speed buffer.
-         */
-        TrackPoint trackPoint1 = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint1.setSpeed(Speed.of(128.5f));
-        ChartPoint point = chartFragment.createPendingPoint(trackPoint1);
-        assertEquals(0.0, point.getSpeed(), 0.01);
-
-        /*
-         * Tests the logic when both metricUnits and reportSpeed are true.
-         * This location will be filled into speed buffer.
-         */
-        TrackPoint trackPoint2 = TrackStubUtils.createDefaultTrackPoint();
-
-        /*
-         * Add a time span here to make sure the second point is valid, the value 222 here is doesn't matter.
-         */
-        trackPoint2.setTime(trackPoint1.getTime().plusMillis(222));
-        trackPoint2.setSpeed(Speed.of(130f));
-        point = chartFragment.createPendingPoint(trackPoint2);
-        assertEquals(130.0 * UnitConversions.MPS_TO_KMH, point.getSpeed(), 0.01);
-    }
-
-    /**
-     * Tests the logic to compute speed when use Imperial.
-     */
-    @Test
-    public void testCreatePendingPoint_speedImperial() {
-        chartFragment.setMetricUnits(false);
-
-        // First data point is not added to the speed buffer
-        TrackPoint trackPoint1 = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint1.setSpeed(Speed.of(100.0f));
-        ChartPoint point = chartFragment.createPendingPoint(trackPoint1);
-        assertEquals(0.0, point.getSpeed(), 0.01);
-
-        TrackPoint trackPoint2 = TrackStubUtils.createDefaultTrackPoint();
-
-        /*
-         * Add a time span here to make sure the second point and the speed is valid.
-         * Speed is valid if: speedDifference > Constants.MAX_ACCELERATION * timeDifference speedDifference = 102 -100 timeDifference = 222
-         */
-        trackPoint2.setTime(trackPoint2.getTime().plusMillis(222));
-        trackPoint2.setSpeed(Speed.of(102f));
-        point = chartFragment.createPendingPoint(trackPoint2);
-        assertEquals(102.0 * UnitConversions.MPS_TO_KMH * UnitConversions.KM_TO_MI, point.getSpeed(), 0.01);
-    }
-
-    /**
-     * Tests the logic to get pace value when reportSpeed is false.
-     */
-    @Test
-    public void testCreatePendingPoint_pace_nonZeroSpeed() {
-        chartFragment.setReportSpeed(false);
-
-        // First data point is not added to the speed buffer
-        TrackPoint trackPoint1 = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint1.setSpeed(Speed.of(100.0f));
-        ChartPoint point = chartFragment.createPendingPoint(trackPoint1);
-        assertEquals(0.0, point.getSpeed(), 0.01);
-
-        TrackPoint trackPoint2 = TrackStubUtils.createDefaultTrackPoint();
-
-        /*
-         * Add a time span here to make sure the second point and the speed is valid.
-         * Speed is valid if: speedDifference > Constants.MAX_ACCELERATION * timeDifference speedDifference = 102 -100 timeDifference = 222
-         */
-        trackPoint2.setTime(trackPoint2.getTime().plusMillis(222));
-        trackPoint2.setSpeed(Speed.of(102f));
-        point = chartFragment.createPendingPoint(trackPoint2);
-        assertEquals(HOURS_PER_UNIT / (102.0 * UnitConversions.MPS_TO_KMH), point.getPace(), 0.01);
-    }
-
-    /**
-     * Tests the logic to get pace value when reportSpeed is false and average speed is zero.
-     */
-    @Test
-    public void testCreatePendingPoint_pace_zeroSpeed() {
-        chartFragment.setReportSpeed(false);
-        TrackPoint trackPoint = TrackStubUtils.createDefaultTrackPoint();
-        trackPoint.setSpeed(Speed.of(0f));
-        ChartPoint point = chartFragment.createPendingPoint(trackPoint);
-        assertEquals(0.0, point.getPace(), 0.01);
+    public void nothing() {
+        //TODO
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/AbstractListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/AbstractListActivity.java
@@ -29,7 +29,7 @@ import de.dennisguse.opentracks.util.IntentUtils;
 
 /**
  * An abstract class for the following common tasks across
- * {@link TrackListActivity}, {@link TrackRecordedActivity}, and {@link TrackRecordedActivity}:
+ * {@link TrackListActivity} and {@link TrackRecordedActivity}:
  * <p>
  * - share track <br>
  * - delete tracks <br>

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -53,6 +53,7 @@ import de.dennisguse.opentracks.util.IntentUtils;
  * @author Leif Hendrik Wilden
  * @author Rodrigo Damazio
  */
+//TODO Should not use TrackRecordingServiceConnection; only used to determine if there is NO current recording, to enable resume functionality.
 public class TrackRecordedActivity extends AbstractListActivity implements ConfirmDeleteDialogFragment.ConfirmDeleteCaller, TrackActivityDataHubInterface, TrackRecordingServiceStatus.Listener {
 
     private static final String TAG = TrackRecordedActivity.class.getSimpleName();
@@ -299,7 +300,7 @@ public class TrackRecordedActivity extends AbstractListActivity implements Confi
         }
     }
 
-    public void startPostponedEnterTransitionWith(View viewIcon, View viewName) {
+    public void startPostponedEnterTransitionWith(View viewIcon) {
         ViewCompat.setTransitionName(viewIcon, TrackRecordedActivity.VIEW_TRACK_ICON);
         startPostponedEnterTransition();
     }

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -211,6 +211,8 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
 
         if (trackId != null) {
             trackDataHub.loadTrack(trackId);
+            trackDataHub.setRecordingTrackId(trackId);
+            trackDataHub.setRecordingTrackPaused(recordingTrackPaused);
             trackController.onResume(true, recordingTrackPaused);
         }
 

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -87,6 +87,8 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
 
                 // A recording track is on.
                 trackDataHub.loadTrack(trackId);
+                trackDataHub.setRecordingTrackId(trackId);
+
                 trackController.update(true, false);
                 trackController.onResume(true, recordingTrackPaused);
             }
@@ -404,17 +406,20 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
     public void onTrackRecordingPaused(boolean isPaused) {
         if (recordingTrackPaused != isPaused) {
             trackController.update(true, isPaused);
+            trackDataHub.setRecordingTrackPaused(isPaused);
         }
         recordingTrackPaused = isPaused;
         setLockscreenPolicy();
         setScreenOnPolicy();
     }
 
+    //TODO Why should this be interesting? This activity is only used for currently recording tracks.
     @Override
     public void onTrackRecordingId(Track.Id newTrackId) {
         if (newTrackId != null && !newTrackId.equals(trackId)) {
             trackId = newTrackId;
             trackController.update(true, recordingTrackPaused);
+            trackDataHub.setRecordingTrackId(newTrackId);
         }
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/chart/ChartPoint.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartPoint.java
@@ -3,9 +3,10 @@ package de.dennisguse.opentracks.chart;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
+import de.dennisguse.opentracks.content.data.Distance;
+import de.dennisguse.opentracks.content.data.Speed;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.stats.TrackStatistics;
-import de.dennisguse.opentracks.stats.TrackStatisticsUpdater;
 import de.dennisguse.opentracks.util.UnitConversions;
 
 public class ChartPoint {
@@ -13,44 +14,38 @@ public class ChartPoint {
     private double timeOrDistance;
 
     //Y-axis
-    private double altitude;
+    private final double altitude;
     private Double speed;
     private Double pace;
     private Double heartRate;
     private Double cadence;
     private Double power;
 
+    @Deprecated
     @VisibleForTesting
     ChartPoint(double altitude) {
         this.altitude = altitude;
     }
 
-    public ChartPoint(@NonNull TrackStatisticsUpdater trackStatisticsUpdater, TrackPoint trackPoint, boolean chartByDistance, boolean metricUnits) {
-        TrackStatistics trackStatistics = trackStatisticsUpdater.getTrackStatistics();
-
+    public ChartPoint(@NonNull TrackStatistics trackStatistics, @NonNull TrackPoint trackPoint, Speed smoothedSpeed, double smoothedAltitude_m, boolean chartByDistance, boolean metricUnits) {
         if (chartByDistance) {
             timeOrDistance = trackStatistics.getTotalDistance().to(metricUnits);
         } else {
             timeOrDistance = trackStatistics.getTotalTime().toMillis();
         }
 
-        altitude = trackStatisticsUpdater.getSmoothedAltitude();
-        if (!metricUnits) {
-            altitude *= UnitConversions.M_TO_FT;
-        }
+        altitude = Distance.of(smoothedAltitude_m).to(metricUnits);
 
-        speed = trackStatisticsUpdater.getSmoothedSpeed().to(metricUnits);
-        pace = trackStatisticsUpdater.getSmoothedSpeed().toPace(metricUnits).toMillis() * UnitConversions.MS_TO_S * UnitConversions.S_TO_MIN;
-        if (trackPoint != null) {
-            if (trackPoint.hasHeartRate()) {
-                heartRate = (double) trackPoint.getHeartRate_bpm();
-            }
-            if (trackPoint.hasCyclingCadence()) {
-                cadence = (double) trackPoint.getCyclingCadence_rpm();
-            }
-            if (trackPoint.hasPower()) {
-                power = (double) trackPoint.getPower();
-            }
+        speed = smoothedSpeed.to(metricUnits);
+        pace = smoothedSpeed.toPace(metricUnits).toMillis() * UnitConversions.MS_TO_S * UnitConversions.S_TO_MIN;
+        if (trackPoint.hasHeartRate()) {
+            heartRate = (double) trackPoint.getHeartRate_bpm();
+        }
+        if (trackPoint.hasCyclingCadence()) {
+            cadence = (double) trackPoint.getCyclingCadence_rpm();
+        }
+        if (trackPoint.hasPower()) {
+            power = (double) trackPoint.getPower();
         }
     }
 

--- a/src/main/java/de/dennisguse/opentracks/content/TrackDataListener.java
+++ b/src/main/java/de/dennisguse/opentracks/content/TrackDataListener.java
@@ -19,8 +19,10 @@ package de.dennisguse.opentracks.content;
 import androidx.annotation.NonNull;
 
 import de.dennisguse.opentracks.content.data.Marker;
+import de.dennisguse.opentracks.content.data.Speed;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
+import de.dennisguse.opentracks.stats.TrackStatistics;
 
 /**
  * Listener for track data changes.
@@ -47,20 +49,23 @@ public interface TrackDataListener {
      *
      * @param trackPoint the trackPoint
      */
-    void onSampledInTrackPoint(@NonNull TrackPoint trackPoint);
+    default void onSampledInTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics trackStatistics, Speed smoothedSpeed, double smoothedAltitude_m) {
+    }
 
     /**
      * Called when a sampled out track point is read.
      *
      * @param trackPoint the trackPoint
      */
-    void onSampledOutTrackPoint(@NonNull TrackPoint trackPoint);
+    default void onSampledOutTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics trackStatistics) {
+    }
 
     /**
      * Called when finish sending new track points.
-     * This gets called after every batch of calls to {@link #onSampledInTrackPoint(TrackPoint)} and {@link #onSampledOutTrackPoint(TrackPoint)}.
+     * This gets called after every batch of calls to {@link #onSampledInTrackPoint(TrackPoint, TrackStatistics, Speed, double)} and {@link #onSampledOutTrackPoint(TrackPoint, TrackStatistics)}.
      */
-    void onNewTrackPointsDone(@NonNull TrackPoint lastTrackPoint);
+    default void onNewTrackPointsDone(@NonNull TrackPoint lastTrackPoint, @NonNull TrackStatistics trackStatistics) {
+    }
 
     /**
      * Called to clear previously sent markers.

--- a/src/main/java/de/dennisguse/opentracks/content/TrackDataManager.java
+++ b/src/main/java/de/dennisguse/opentracks/content/TrackDataManager.java
@@ -41,10 +41,10 @@ class TrackDataManager {
     }
 
     void unregisterTrackDataListener(TrackDataListener trackDataListener) {
-        dataListenerTracks.add(trackDataListener);
-        dataListenerMarkers.add(trackDataListener);
-        dataListenerTrackPoints_SampledIn.add(trackDataListener);
-        dataListenerTrackPoints_SampledOut.add(trackDataListener);
+        dataListenerTracks.remove(trackDataListener);
+        dataListenerMarkers.remove(trackDataListener);
+        dataListenerTrackPoints_SampledIn.remove(trackDataListener);
+        dataListenerTrackPoints_SampledOut.remove(trackDataListener);
     }
 
     boolean hasListeners() {

--- a/src/main/java/de/dennisguse/opentracks/fragments/ChartFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/ChartFragment.java
@@ -306,6 +306,8 @@ public class ChartFragment extends Fragment implements TrackDataListener {
      * Returns true if the selected track is recording.
      * Needs to be synchronized because trackDataHub can be accessed by multiple threads.
      */
+    @Deprecated
+    //TODO Should not be dynamic but instead set while instantiating, i.e., newFragment().
     private synchronized boolean isSelectedTrackRecording() {
         return trackDataHub != null && trackDataHub.isSelectedTrackRecording();
     }

--- a/src/main/java/de/dennisguse/opentracks/fragments/IntervalsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/IntervalsFragment.java
@@ -25,9 +25,11 @@ import de.dennisguse.opentracks.adapters.IntervalStatisticsAdapter;
 import de.dennisguse.opentracks.content.TrackDataHub;
 import de.dennisguse.opentracks.content.TrackDataListener;
 import de.dennisguse.opentracks.content.data.Marker;
+import de.dennisguse.opentracks.content.data.Speed;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.databinding.IntervalListViewBinding;
+import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.util.PreferencesUtils;
 import de.dennisguse.opentracks.viewmodels.IntervalStatistics;
 import de.dennisguse.opentracks.viewmodels.IntervalStatisticsModel;
@@ -229,21 +231,21 @@ public class IntervalsFragment extends Fragment implements TrackDataListener {
     }
 
     @Override
-    public void onSampledInTrackPoint(@NonNull TrackPoint trackPoint) {
+    public void onSampledInTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics unused, Speed unused2, double unused3) {
         if (isResumed()) {
             viewModel.add(trackPoint);
         }
     }
 
     @Override
-    public void onSampledOutTrackPoint(@NonNull TrackPoint trackPoint) {
+    public void onSampledOutTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics unused) {
         if (isResumed()) {
             viewModel.add(trackPoint);
         }
     }
 
     @Override
-    public void onNewTrackPointsDone(@NonNull TrackPoint unused) {
+    public void onNewTrackPointsDone(@NonNull TrackPoint unused, @NonNull TrackStatistics alsoUnused) {
         if (isResumed()) {
             runOnUiThread(viewModel::onNewTrackPoints);
         }

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
@@ -166,7 +166,7 @@ public class StatisticsRecordedFragment extends Fragment {
                     updateUI();
                     updateSensorUI();
 
-                    ((TrackRecordedActivity) getActivity()).startPostponedEnterTransitionWith(viewBinding.statsActivityTypeIcon, viewBinding.statsNameValue);
+                    ((TrackRecordedActivity) getActivity()).startPostponedEnterTransitionWith(viewBinding.statsActivityTypeIcon);
                 }
             });
         }

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
@@ -34,6 +34,7 @@ import de.dennisguse.opentracks.content.sensor.SensorDataSet;
 import de.dennisguse.opentracks.databinding.StatisticsRecordingBinding;
 import de.dennisguse.opentracks.services.TrackRecordingService;
 import de.dennisguse.opentracks.services.TrackRecordingServiceConnection;
+import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.util.PreferencesUtils;
 import de.dennisguse.opentracks.util.StringUtils;
 import de.dennisguse.opentracks.util.TrackIconUtils;
@@ -211,17 +212,7 @@ public class StatisticsRecordingFragment extends Fragment implements TrackDataLi
     }
 
     @Override
-    public void onSampledInTrackPoint(@NonNull TrackPoint trackPoint) {
-        // We don't care.
-    }
-
-    @Override
-    public void onSampledOutTrackPoint(@NonNull TrackPoint trackPoint) {
-        // We don't care.
-    }
-
-    @Override
-    public void onNewTrackPointsDone(@NonNull TrackPoint newLastTrackPoint) {
+    public void onNewTrackPointsDone(@NonNull TrackPoint newLastTrackPoint, @NonNull TrackStatistics trackStatistics) {
         if (isResumed()) {
             getActivity().runOnUiThread(() -> {
                 if (isResumed()) {
@@ -388,7 +379,7 @@ public class StatisticsRecordingFragment extends Fragment implements TrackDataLi
         }
 
         // Set time
-        if (track != null && track.getTrackStatistics() != null) {
+        if (track != null) {
             viewBinding.statsMovingTimeValue.setText(StringUtils.formatElapsedTime(track.getTrackStatistics().getMovingTime()));
             updateTotalTime();
         }

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -256,7 +256,7 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
      */
     public Track.Id startNewTrack() {
         if (isRecording()) {
-            Log.d(TAG, "Ignore startNewTrack. Already recording.");
+            Log.w(TAG, "Ignore startNewTrack. Already recording.");
             return null;
         }
 
@@ -316,7 +316,7 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     public void resumeCurrentTrack() {
         if (!isRecording() || !isPaused()) {
-            Log.d(TAG, "Ignore resumeCurrentTrack. Not recording or not paused.");
+            Log.w(TAG, "Ignore resumeCurrentTrack. Not recording or not paused.");
             return;
         }
 
@@ -365,10 +365,10 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-    public Track.Id endCurrentTrack() {
+    public void endCurrentTrack() {
         if (!isRecording()) {
-            Log.d(TAG, "Ignore endCurrentTrack. Not recording.");
-            return null;
+            Log.w(TAG, "Ignore endCurrentTrack. Not recording.");
+            return;
         }
 
         // Need to remember the recordingTrackId before setting it to null
@@ -394,14 +394,12 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
         ExportUtils.postWorkoutExport(this, track, new ExportServiceResultReceiver(new Handler(), this));
 
         endRecording(true);
-
-        return trackId;
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     public void pauseCurrentTrack() {
         if (!isRecording() || isPaused()) {
-            Log.d(TAG, "Ignore pauseCurrentTrack. Not recording or paused.");
+            Log.w(TAG, "Ignore pauseCurrentTrack. Not recording or paused.");
             return;
         }
 

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -18,6 +18,7 @@ package de.dennisguse.opentracks.stats;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -193,6 +194,7 @@ public class TrackStatistics {
         this.movingTime = movingTime;
     }
 
+    @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     public void addMovingTime(Duration time) {
         movingTime = movingTime.plus(time);
     }
@@ -265,6 +267,7 @@ public class TrackStatistics {
         this.totalAltitudeGain_m = totalAltitudeGain_m;
     }
 
+    @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     public void addTotalAltitudeGain(float gain_m) {
         if (totalAltitudeGain_m == null) {
             totalAltitudeGain_m = 0f;
@@ -285,6 +288,7 @@ public class TrackStatistics {
         this.totalAltitudeLoss_m = totalAltitudeLoss_m;
     }
 
+    @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     public void addTotalAltitudeLoss(float loss_m) {
         if (totalAltitudeLoss_m == null) {
             totalAltitudeLoss_m = 0f;


### PR DESCRIPTION
Does not fix #719.

TrackDataHub does not need to register for TrackRecordingService status changes as this can be handled by TrackRecordingActivity alone.

* reduces impact of memory leak as TrackDataHub keeps references to fragments; now only the activities are referenced by TrackRecordingServices and those at least remove all there references.
* (so far) TrackDataHub started TrackRecordingSevice due to binding to the service (even if only showing already recorded tracks)
