### PR TITLE
Bugfix: crash deleting when activity restarts

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackDeleteActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackDeleteActivity.java
@@ -64,24 +64,27 @@ public class TrackDeleteActivity extends AbstractActivity {
 
             runOnUiThread(TrackDeleteActivity.this::onAsyncTaskCompleted);
         });
-    }
-
-    @Override
-    protected void onStart() {
-        super.onStart();
         deleteThread.start();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        deleteThread.interrupt();
     }
 
     @Override
     protected void onDestroy() {
         super.onDestroy();
         viewBinding = null;
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        if (deleteThread.getState() == Thread.State.TERMINATED) {
+            onAsyncTaskCompleted();
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        deleteThread.interrupt();
     }
 
     @Override


### PR DESCRIPTION
**Describe the pull request**
Thread starts on onCreate (once).
Activity's onStart checks if thread was terminated and activity finishes in that case.
Activity's onStop interrupts the thread.

All this avoids crashing when activity restarts while thread is deleting.

**Link to the the issue**
#705 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
