### PR TITLE
Reproducible build: disable PNG crunching.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ android {
         viewBinding = true
     }
 
+    aaptOptions {
+        cruncherEnabled = false
+    }
+
     defaultConfig {
         applicationId "de.dennisguse.opentracks"
         versionCode 4009


### PR DESCRIPTION
Increases APK size by 4kB.