### PR TITLE
Bugfix: TrackStatisticsUpdater was computing distance incorrectly.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TrackPointTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TrackPointTest.java
@@ -1,10 +1,13 @@
 package de.dennisguse.opentracks.content.data;
 
+import android.location.Location;
+
 import org.junit.Test;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -24,5 +27,36 @@ public class TrackPointTest {
         tp.setTime(Instant.now().minus(2, ChronoUnit.MINUTES));
 
         assertFalse(tp.isRecent());
+    }
+
+    @Test
+    public void distanceToPrevious() {
+        Location l1 = new Location("test");
+        l1.setLatitude(0);
+        l1.setLongitude(0.0001);
+        TrackPoint tp1 = new TrackPoint(l1);
+
+        Location l2 = new Location("test");
+        l2.setLatitude(0);
+        l2.setLongitude(0.0002);
+        TrackPoint tp2 = new TrackPoint(l2);
+
+        // without sensor distance
+        assertEquals(11.13, tp2.distanceToPrevious(tp1).toM(), 0.01);
+
+        // tp1 has sensor distance
+        tp1.setSensorDistance(Distance.of(5));
+        tp1.setSensorDistance(null);
+        assertEquals(11.13, tp2.distanceToPrevious(tp1).toM(), 0.01);
+
+        // tp2 has sensor distance
+        tp1.setSensorDistance(null);
+        tp2.setSensorDistance(Distance.of(5));
+        assertEquals(5, tp2.distanceToPrevious(tp1).toM(), 0.01);
+
+        // tp1 and tp2 have sensor distance
+        tp1.setSensorDistance(Distance.of(10));
+        tp2.setSensorDistance(Distance.of(5));
+        assertEquals(5, tp2.distanceToPrevious(tp1).toM(), 0.01);
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/content/sensor/SensorDataCyclingTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/sensor/SensorDataCyclingTest.java
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.util.UintUtils;
 
 import static org.junit.Assert.assertEquals;
@@ -100,7 +101,7 @@ public class SensorDataCyclingTest {
         SensorDataCycling.DistanceSpeed current = new SensorDataCycling.DistanceSpeed("sensorAddress", "sensorName", 2, 8016);
 
         // when
-        current.compute(previous, 2150);
+        current.compute(previous, Distance.ofMM(2150));
 
         // then
         assertEquals(2.15, current.getValue().distance.toM(), 0.01);
@@ -114,7 +115,7 @@ public class SensorDataCyclingTest {
         SensorDataCycling.DistanceSpeed current = new SensorDataCycling.DistanceSpeed("sensorAddress", "sensorName", 0, 2048);
 
         // when
-        current.compute(previous, 2000);
+        current.compute(previous, Distance.ofMM(2000));
 
         // then
         assertEquals(2, current.getValue().distance.toM(), 0.01);

--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
@@ -146,6 +146,34 @@ public class TrackStatisticsUpdaterTest {
         assertEquals(15, subject.getTrackStatistics().getTotalDistance().toM(), 0.01);
     }
 
+    @Test
+    public void addTrackPoint_distance_from_GPS_moving_and_sensor_disconnecting() {
+        // given
+        TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
+
+        TrackPoint tp1 = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochMilli(1000));
+        TrackPoint tp2 = new TrackPoint(0, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(2000));
+        TrackPoint tp3 = new TrackPoint(0.00001, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(3000));
+        tp3.setSensorDistance(Distance.of(5f));
+        TrackPoint tp4 = new TrackPoint(0.0005, 0, Altitude.WGS84.of(5.0), Instant.ofEpochMilli(4000));
+        TrackPoint tp5 = new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.ofEpochMilli(5000));
+
+        // when
+        subject.addTrackPoint(tp1, GPS_DISTANCE);
+        subject.addTrackPoint(tp2, GPS_DISTANCE);
+        subject.addTrackPoint(tp3, GPS_DISTANCE);
+
+        // then
+        assertEquals(5, subject.getTrackStatistics().getTotalDistance().toM(), 0.01);
+
+        // when
+        subject.addTrackPoint(tp4, GPS_DISTANCE);
+        subject.addTrackPoint(tp5, GPS_DISTANCE);
+
+        // then
+        assertEquals(59.18, subject.getTrackStatistics().getTotalDistance().toM(), 0.01);
+    }
+
     @Ignore("TODO: create a concept ont to compute speed from GPS and sensor")
     @Test
     public void addTrackPoint_speed_from_GPS_not_moving() {

--- a/src/main/java/de/dennisguse/opentracks/content/data/Distance.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Distance.java
@@ -24,6 +24,10 @@ public class Distance {
         return of(distance_km * UnitConversions.KM_TO_M);
     }
 
+    public static Distance ofMM(double distance_mm) {
+        return of(distance_mm * UnitConversions.MM_TO_M);
+    }
+
     public static Distance one(boolean metricUnit) {
         if (metricUnit) {
             return Distance.ofKilometer(1);

--- a/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataCycling.java
+++ b/src/main/java/de/dennisguse/opentracks/content/sensor/SensorDataCycling.java
@@ -123,7 +123,7 @@ public final class SensorDataCycling {
             return wheelRevolutionsTime;
         }
 
-        public void compute(DistanceSpeed previous, int wheel_circumference_mm) {
+        public void compute(DistanceSpeed previous, Distance wheelCircumference) {
             if (hasData() && previous != null && previous.hasData()) {
                 float timeDiff_ms = UintUtils.diff(wheelRevolutionsTime, previous.wheelRevolutionsTime, UintUtils.UINT16_MAX) / 1024f * UnitConversions.S_TO_MS;
                 Duration timeDiff = Duration.ofMillis((long) timeDiff_ms);
@@ -134,7 +134,7 @@ public final class SensorDataCycling {
                     long wheelDiff = UintUtils.diff(wheelRevolutionsCount, previous.wheelRevolutionsCount, UintUtils.UINT16_MAX);
                     wheelDiff = Math.abs(wheelDiff); //HACK for Garmin Speed 2 as some of those seem to count backwards
 
-                    Distance distance = Distance.of(wheelDiff * wheel_circumference_mm * UnitConversions.MM_TO_M);
+                    Distance distance = wheelCircumference.multipliedBy(wheelDiff);
                     Distance distanceOverall = distance;
                     if (previous.hasValue()) {
                         distanceOverall = distance.plus(previous.getValue().distanceOverall);

--- a/src/main/java/de/dennisguse/opentracks/services/sensors/BluetoothRemoteSensorManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/sensors/BluetoothRemoteSensorManager.java
@@ -25,6 +25,7 @@ import android.util.Log;
 import java.time.Duration;
 
 import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.sensor.SensorData;
 import de.dennisguse.opentracks.content.sensor.SensorDataCycling;
 import de.dennisguse.opentracks.content.sensor.SensorDataSet;
@@ -57,7 +58,7 @@ public class BluetoothRemoteSensorManager implements BluetoothConnectionManager.
     private boolean started = false;
 
     private final SharedPreferences sharedPreferences;
-    private int preferenceWheelCircumference;
+    private Distance preferenceWheelCircumference;
 
     private final BluetoothConnectionManager.HeartRate heartRate = new BluetoothConnectionManager.HeartRate(this);
     private final BluetoothConnectionManager.CyclingCadence cyclingCadence = new BluetoothConnectionManager.CyclingCadence(this);

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdater.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdater.java
@@ -159,7 +159,7 @@ public class TrackStatisticsUpdater {
 
         if (!trackPoint.hasSensorDistance()) {
             // GPS-based distance/speed
-            Distance movingDistance = lastMovingTrackPoint.distanceToPrevious(trackPoint);
+            Distance movingDistance = trackPoint.distanceToPrevious(lastMovingTrackPoint);
             if (movingDistance.lessThan(minGPSDistance) && !trackPoint.isMoving()) {
                 speedBuffer_mps.reset();
                 lastTrackPoint = trackPoint;

--- a/src/main/java/de/dennisguse/opentracks/util/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/PreferencesUtils.java
@@ -142,9 +142,9 @@ public class PreferencesUtils {
         return getString(sharedPreferences, context, R.string.settings_sensor_bluetooth_cycling_speed_key, getBluetoothSensorAddressNone(context));
     }
 
-    public static int getWheelCircumference(SharedPreferences sharedPreferences, Context context) {
+    public static Distance getWheelCircumference(SharedPreferences sharedPreferences, Context context) {
         final int DEFAULT = Integer.parseInt(context.getResources().getString(R.string.settings_sensor_bluetooth_cycling_speed_wheel_circumference_default));
-        return getInt(sharedPreferences, context, R.string.settings_sensor_bluetooth_cycling_speed_wheel_circumference_key, DEFAULT);
+        return Distance.ofMM(getInt(sharedPreferences, context, R.string.settings_sensor_bluetooth_cycling_speed_wheel_circumference_key, DEFAULT));
     }
 
     public static String getBluetoothCyclingPowerSensorAddress(SharedPreferences sharedPreferences, Context context) {


### PR DESCRIPTION
While using a cycling speed and distance sensor, the updater was not using the distance from the most recent trackpoint but rather the one considered last moving.

Fixes #762.

Added test.