### PR TITLE
Disable hasFragileUserData for production.

### DIFF
--- a/src/debug/AndroidManifest.xml
+++ b/src/debug/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+Copyright 2010 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:hasFragileUserData="true"
+        tools:replace="android:hasFragileUserData" />
+</manifest>

--- a/src/debug/AndroidManifest.xml
+++ b/src/debug/AndroidManifest.xml
@@ -1,18 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-Copyright 2010 Google Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@ limitations under the License.
         android:name=".Startup"
         android:allowBackup="false"
         android:hardwareAccelerated="true"
-        android:hasFragileUserData="true"
+        android:hasFragileUserData="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
Should fix #685 and #129.

`hasFragileUserData=true` allows user to uninstall OpenTracks without deleting the app-internal data (actually the user can choose).

__Problem 1:__ Seemingly `hasFragileUserData=true` prevents uninstalling OpenTracks (best guess: some bugs in older Android variants).

__Problem 2:__ Anyhow: `hasFragileUserData=true` is actually an anti-feature from a privacy perspective.
It is likely that a user uninstalled OpenTracks without deleting the app-internal data.
So, the data might stay on the device and the user might not be aware of it (and that is an issue).
I even don't know if the data can be removed without wiping the device or installing OpenTracks again (and the uninstalling again).

Side note: for testing it is actually quite nice to have `hasFragileUserData=true`, e.g., testing a database downgrade etc.

__Proposed solution:__ only `hasFragileUserData=true` in debug mode.
Production releases will be build with `hasFragileUserData=false` .
