### PR TITLE
TrackListActivity: re-enable search.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/MarkerListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/MarkerListActivity.java
@@ -261,15 +261,16 @@ public class MarkerListActivity extends AbstractActivity implements DeleteMarker
 
     @Override
     public void onBackPressed() {
+        SearchView searchView = (SearchView) searchMenuItem.getActionView();
+        if (!searchView.isIconified()) {
+            searchView.setIconified(true);
+        }
+
         if (loaderCallbacks.getSearchQuery() != null) {
             loaderCallbacks.setSearch(null);
             return;
         }
-        SearchView searchView = (SearchView) searchMenuItem.getActionView();
-        if (!searchView.isIconified()) {
-            searchView.setIconified(true);
-            return;
-        }
+
         super.onBackPressed();
     }
 

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -276,7 +276,13 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
         getMenuInflater().inflate(R.menu.track_list, menu);
 
         searchMenuItem = menu.findItem(R.id.track_list_search);
-        ActivityUtils.configureSearchWidget(this, searchMenuItem);
+        SearchView searchView = ActivityUtils.configureSearchWidget(this, searchMenuItem);
+        searchView.setOnCloseListener(() -> {
+            searchView.clearFocus();
+            searchMenuItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
+            return true;
+        });
+
         startGpsMenuItem = menu.findItem(R.id.track_list_start_gps);
 
         return super.onCreateOptionsMenu(menu);
@@ -333,6 +339,12 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
             return true;
         }
 
+        if (item.getItemId() == R.id.track_list_search) {
+            SearchView searchView = (SearchView) searchMenuItem.getActionView();
+            searchView.setIconified(false);
+            searchMenuItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        }
+
         return super.onOptionsItemSelected(item);
     }
 
@@ -345,16 +357,22 @@ public class TrackListActivity extends AbstractListActivity implements ConfirmDe
     }
 
     @Override
+    public void overridePendingTransition(int enterAnim, int exitAnim) {
+        //Disable animations as it is weird going into searchMode; looks okay for SplashScreen.
+    }
+
+    @Override
     public void onBackPressed() {
+        SearchView searchView = (SearchView) searchMenuItem.getActionView();
+        if (!searchView.isIconified()) {
+            searchView.setIconified(true);
+        }
+
         if (loaderCallbacks.getSearchQuery() != null) {
             loaderCallbacks.setSearch(null);
             return;
         }
-        SearchView searchView = (SearchView) searchMenuItem.getActionView();
-        if (!searchView.isIconified()) {
-            searchView.setIconified(true);
-            return;
-        }
+
         super.onBackPressed();
     }
 

--- a/src/main/java/de/dennisguse/opentracks/util/ActivityUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/ActivityUtils.java
@@ -87,7 +87,7 @@ public class ActivityUtils {
         });
     }
 
-    public static void configureSearchWidget(Activity activity, final MenuItem menuItem) {
+    public static SearchView configureSearchWidget(Activity activity, final MenuItem menuItem) {
         final SearchView searchView = (SearchView) menuItem.getActionView();
         SearchManager searchManager = (SearchManager) activity.getSystemService(Context.SEARCH_SERVICE);
         if (searchManager != null) {
@@ -96,33 +96,8 @@ public class ActivityUtils {
         } else {
             Log.w(TAG, "Could not retrieve SearchManager.");
         }
-        searchView.setQueryRefinementEnabled(true);
         searchView.setSubmitButtonEnabled(true);
-
-        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-            @Override
-            public boolean onQueryTextSubmit(String query) {
-                menuItem.collapseActionView();
-                return false;
-            }
-
-            @Override
-            public boolean onQueryTextChange(String newText) {
-                return false;
-            }
-        });
-        searchView.setOnSuggestionListener(new SearchView.OnSuggestionListener() {
-            @Override
-            public boolean onSuggestionSelect(int position) {
-                return false;
-            }
-
-            @Override
-            public boolean onSuggestionClick(int position) {
-                menuItem.collapseActionView();
-                return false;
-            }
-        });
+        return searchView;
     }
 
     public static void vibrate(Context context, int milliseconds) {

--- a/src/main/res/menu/track_list.xml
+++ b/src/main/res/menu/track_list.xml
@@ -32,7 +32,6 @@ limitations under the License.
         android:id="@+id/track_list_search"
         android:title="@string/menu_search"
         app:actionViewClass="androidx.appcompat.widget.SearchView"
-        android:visible="false"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/track_list_markers"


### PR DESCRIPTION
Fixes #757.

Search can be used if on search start, the menu item is upgraded to an Action (i.e., `searchMenuItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);`).

Also simplify search setup.