### PR TITLE
doc: add Rotor 2INpower cycling powermeter

### DIFF
--- a/README_TESTED_SENSORS.md
+++ b/README_TESTED_SENSORS.md
@@ -50,4 +50,5 @@ Also the distance is not computed.
 * QUARQ Red DZero Powermeter
 * Tacx Satori Smart
 * Wahoo Kickr v4.0
+* Rotor 2INpower DM Road (only supports power measurement, cadence measurement is propietary @ firmware v1.061)
 


### PR DESCRIPTION
# Thanks for your contribution.

**Describe the pull request**
Adds Rotor 2INpower powermeter to the list of tested sensors. I tested one myself