### PR TITLE
Intervals: performance improvement and TrackStatisticsUpdater to compute them

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/EspressoDeleteTrackTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/EspressoDeleteTrackTest.java
@@ -4,7 +4,6 @@ package de.dennisguse.opentracks;
 import android.app.ActivityManager;
 import android.app.Instrumentation;
 import android.content.Context;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;

--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
@@ -14,6 +14,7 @@ import java.util.List;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 import de.dennisguse.opentracks.content.provider.TrackPointIterator;
 import de.dennisguse.opentracks.stats.TrackStatistics;
+import de.dennisguse.opentracks.stats.TrackStatisticsUpdater;
 import de.dennisguse.opentracks.util.FileUtils;
 
 public class TestDataUtil {
@@ -165,5 +166,21 @@ public class TestDataUtil {
             trackPoints.add(trackPointIterator.next());
         }
         return trackPoints;
+    }
+
+    public static Pair<Track.Id, TrackStatistics> buildTrackWithTrackPoints(ContentProviderUtils contentProviderUtils, int numberOfPoints) {
+        Track dummyTrack = new Track();
+        dummyTrack.setId(new Track.Id(System.currentTimeMillis()));
+        dummyTrack.setName("Dummy Track");
+        contentProviderUtils.insertTrack(dummyTrack);
+        TrackStatisticsUpdater trackStatisticsUpdater = new TrackStatisticsUpdater();
+        for (int i = 0; i < numberOfPoints; i++) {
+            TrackPoint tp = TestDataUtil.createTrackPoint(i);
+            contentProviderUtils.insertTrackPoint(tp, dummyTrack.getId());
+            trackStatisticsUpdater.addTrackPoint(tp, Distance.of(0));
+        }
+        dummyTrack.setTrackStatistics(trackStatisticsUpdater.getTrackStatistics());
+        contentProviderUtils.updateTrack(dummyTrack);
+        return new Pair<>(dummyTrack.getId(), trackStatisticsUpdater.getTrackStatistics());
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/util/AnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/AnnouncementUtilsTest.java
@@ -52,7 +52,7 @@ public class AnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         List<TrackPoint> trackPoints = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second;
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.of(1000));
+        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.of(1000), Distance.of(0));
         IntervalStatistics.Interval lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
 
         // when

--- a/src/androidTest/java/de/dennisguse/opentracks/util/AnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/AnnouncementUtilsTest.java
@@ -1,21 +1,23 @@
 package de.dennisguse.opentracks.util;
 
 import android.content.Context;
+import android.util.Pair;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.time.Duration;
-import java.util.List;
 
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Speed;
 import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.content.data.Track;
-import de.dennisguse.opentracks.content.data.TrackPoint;
+import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
+import de.dennisguse.opentracks.content.provider.TrackPointIterator;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.viewmodels.IntervalStatistics;
 
@@ -25,6 +27,12 @@ import static org.junit.Assert.assertEquals;
 public class AnnouncementUtilsTest {
 
     private final Context context = ApplicationProvider.getApplicationContext();
+    private ContentProviderUtils contentProviderUtils;
+
+    @Before
+    public void setUp() {
+        contentProviderUtils = new ContentProviderUtils(context);
+    }
 
     @Test
     public void getAnnouncement_metric_speed() {
@@ -44,23 +52,31 @@ public class AnnouncementUtilsTest {
 
     @Test
     public void getAnnouncement_withInterval_metric_speed() {
-        TrackStatistics stats = new TrackStatistics();
-        stats.setTotalDistance(Distance.of(20000));
-        stats.setTotalTime(Duration.ofHours(2).plusMinutes(5).plusSeconds(10));
-        stats.setMovingTime(Duration.ofHours(1).plusMinutes(5).plusSeconds(10));
-        stats.setMaxSpeed(Speed.of(100));
-        stats.setTotalAltitudeGain(6000f);
-
-        List<TrackPoint> trackPoints = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second;
-        IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
-        intervalStatistics.addTrackPoints(trackPoints);
-        IntervalStatistics.Interval lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
+        // given
+        int numberOfPoints = 1000;
+        Pair<Track.Id, TrackStatistics> trackWithStats = TestDataUtil.buildTrackWithTrackPoints(contentProviderUtils, numberOfPoints);
+        Track.Id trackId = trackWithStats.first;
+        TrackStatistics stats = trackWithStats.second;
+        IntervalStatistics.Interval lastInterval;
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(trackId, null)) {
+            assertEquals(trackPointIterator.getCount(), numberOfPoints);
+            IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
+            lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
+        }
 
         // when
         String announcement = AnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval);
 
         // then
-        assertEquals("OpenTracks total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 18.4 kilometers per hour Lap speed of 51.2 kilometers per hour", announcement);
+        assertEquals(
+                "OpenTracks total distance " +
+                        StringUtils.getDistanceParts(context, stats.getTotalDistance(), true).first +
+                        " kilometers in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
+                        StringUtils.getSpeedParts(context, stats.getAverageMovingSpeed(), true, true).first +
+                        " kilometers per hour Lap speed of " +
+                        StringUtils.getSpeedParts(context, lastInterval.getSpeed(), true, true).first +
+                        " kilometers per hour",
+                announcement);
     }
 
     @Test
@@ -81,23 +97,31 @@ public class AnnouncementUtilsTest {
 
     @Test
     public void getAnnouncement_withInterval_metric_pace() {
-        TrackStatistics stats = new TrackStatistics();
-        stats.setTotalDistance(Distance.of(20000));
-        stats.setTotalTime(Duration.ofHours(2).plusMinutes(5).plusSeconds(10));
-        stats.setMovingTime(Duration.ofHours(1).plusMinutes(5).plusSeconds(10));
-        stats.setMaxSpeed(Speed.of(100));
-        stats.setTotalAltitudeGain(6000f);
-
-        List<TrackPoint> trackPoints = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second;
-        IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
-        intervalStatistics.addTrackPoints(trackPoints);
-        IntervalStatistics.Interval lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
+        // given
+        int numberOfPoints = 1000;
+        Pair<Track.Id, TrackStatistics> trackWithStats = TestDataUtil.buildTrackWithTrackPoints(contentProviderUtils, numberOfPoints);
+        Track.Id trackId = trackWithStats.first;
+        TrackStatistics stats = trackWithStats.second;
+        IntervalStatistics.Interval lastInterval;
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(trackId, null)) {
+            assertEquals(trackPointIterator.getCount(), numberOfPoints);
+            IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
+            lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
+        }
 
         // when
         String announcement = AnnouncementUtils.getAnnouncement(context, stats, true, false, lastInterval);
 
         // then
-        assertEquals("OpenTracks total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 3 minutes 15 seconds per kilometer Lap time of 1 minute 10 seconds per kilometer", announcement);
+        assertEquals(
+                "OpenTracks total distance " +
+                        StringUtils.getDistanceParts(context, stats.getTotalDistance(), true).first +
+                        " kilometers in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
+                        buildAndGetTimeText(stats.getAverageMovingSpeed().toPace(true), true) +
+                        " per kilometer Lap time of " +
+                        buildAndGetTimeText(lastInterval.getSpeed().toPace(true), true) +
+                        " per kilometer",
+                announcement);
     }
 
     @Test
@@ -118,23 +142,31 @@ public class AnnouncementUtilsTest {
 
     @Test
     public void getAnnouncement_withInterval_imperial_speed() {
-        TrackStatistics stats = new TrackStatistics();
-        stats.setTotalDistance(Distance.of(20000));
-        stats.setTotalTime(Duration.ofHours(2).plusMinutes(5).plusSeconds(10));
-        stats.setMovingTime(Duration.ofHours(1).plusMinutes(5).plusSeconds(10));
-        stats.setMaxSpeed(Speed.of(100));
-        stats.setTotalAltitudeGain(6000f);
-
-        List<TrackPoint> trackPoints = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second;
-        IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
-        intervalStatistics.addTrackPoints(trackPoints);
-        IntervalStatistics.Interval lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
+        // given
+        int numberOfPoints = 1000;
+        Pair<Track.Id, TrackStatistics> trackWithStats = TestDataUtil.buildTrackWithTrackPoints(contentProviderUtils, numberOfPoints);
+        Track.Id trackId = trackWithStats.first;
+        TrackStatistics stats = trackWithStats.second;
+        IntervalStatistics.Interval lastInterval;
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(trackId, null)) {
+            assertEquals(trackPointIterator.getCount(), numberOfPoints);
+            IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
+            lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
+        }
 
         // when
         String announcement = AnnouncementUtils.getAnnouncement(context, stats, false, true, lastInterval);
 
         // then
-        assertEquals("OpenTracks total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 11.4 miles per hour Lap speed of 31.8 miles per hour", announcement);
+        assertEquals(
+                "OpenTracks total distance " +
+                        StringUtils.getDistanceParts(context, stats.getTotalDistance(), false).first +
+                        " miles in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
+                        StringUtils.getSpeedParts(context, stats.getAverageMovingSpeed(), false, true).first +
+                        " miles per hour Lap speed of " +
+                        StringUtils.getSpeedParts(context, lastInterval.getSpeed(), false, true).first +
+                        " miles per hour",
+                announcement);
     }
 
     @Test
@@ -155,22 +187,60 @@ public class AnnouncementUtilsTest {
 
     @Test
     public void getAnnouncement_withInterval_imperial_pace() {
-        TrackStatistics stats = new TrackStatistics();
-        stats.setTotalDistance(Distance.of(20000));
-        stats.setTotalTime(Duration.ofHours(2).plusMinutes(5).plusSeconds(10));
-        stats.setMovingTime(Duration.ofHours(1).plusMinutes(5).plusSeconds(10));
-        stats.setMaxSpeed(Speed.of(100));
-        stats.setTotalAltitudeGain(6000f);
-
-        List<TrackPoint> trackPoints = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second;
-        IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
-        intervalStatistics.addTrackPoints(trackPoints);
-        IntervalStatistics.Interval lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
+        // given
+        int numberOfPoints = 1000;
+        Pair<Track.Id, TrackStatistics> trackWithStats = TestDataUtil.buildTrackWithTrackPoints(contentProviderUtils, numberOfPoints);
+        Track.Id trackId = trackWithStats.first;
+        TrackStatistics stats = trackWithStats.second;
+        IntervalStatistics.Interval lastInterval;
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(trackId, null)) {
+            assertEquals(trackPointIterator.getCount(), numberOfPoints);
+            IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
+            lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
+        }
 
         // when
         String announcement = AnnouncementUtils.getAnnouncement(context, stats, false, false, lastInterval);
 
         // then
-        assertEquals("OpenTracks total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile Lap time of 1 minute 53 seconds per mile", announcement);
+        //assertEquals("OpenTracks total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile Lap time of 1 minute 53 seconds per mile", announcement);
+        assertEquals(
+                "OpenTracks total distance " +
+                        StringUtils.getDistanceParts(context, stats.getTotalDistance(), false).first +
+                        " miles in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
+                        buildAndGetTimeText(stats.getAverageMovingSpeed().toPace(false), true) +
+                        " per mile Lap time of " +
+                        buildAndGetTimeText(lastInterval.getSpeed().toPace(false), true) +
+                        " per mile",
+                announcement);
+    }
+
+    /**
+     * Builds an returns the text representing the duration's time.
+     *
+     * @param duration        Duration object.
+     * @param showFromMinutes show minutes tough it's 0.
+     * @return                text representing the duratin's time.
+     */
+    private String buildAndGetTimeText(Duration duration, boolean showFromMinutes) {
+        long hours = Math.abs(duration.getSeconds()) / 3600;
+        long minutes = (Math.abs(duration.getSeconds()) % 3600) / 60;
+        long seconds = Math.abs(duration.getSeconds()) % 60;
+        String hUnit = hours > 1 || hours == 0 ? "hours" : "hour";
+        String mUnit = minutes > 1 || minutes == 0 ? "minutes" : "minute";
+        String sUnit = seconds > 1 || seconds == 0 ? "seconds" : "second";
+
+        String res = hours > 0 ? hours + " " + hUnit : "";
+        if (hours > 0) {
+            res += minutes > 0 || showFromMinutes ? " " + minutes + " " + mUnit : "";
+        } else {
+            res += minutes > 0 || showFromMinutes ? minutes + " " + mUnit : "";
+        }
+        if (hours > 0 || minutes > 0 || showFromMinutes) {
+            res += " " + seconds + " " + sUnit;
+        } else {
+            res += seconds + " " + sUnit;
+        }
+        return res;
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/util/AnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/AnnouncementUtilsTest.java
@@ -52,7 +52,8 @@ public class AnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         List<TrackPoint> trackPoints = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second;
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.of(1000), Distance.of(0));
+        IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
+        intervalStatistics.addTrackPoints(trackPoints);
         IntervalStatistics.Interval lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
 
         // when
@@ -88,7 +89,8 @@ public class AnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         List<TrackPoint> trackPoints = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second;
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.of(1000));
+        IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
+        intervalStatistics.addTrackPoints(trackPoints);
         IntervalStatistics.Interval lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
 
         // when
@@ -124,7 +126,8 @@ public class AnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         List<TrackPoint> trackPoints = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second;
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.of(1000));
+        IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
+        intervalStatistics.addTrackPoints(trackPoints);
         IntervalStatistics.Interval lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
 
         // when
@@ -160,7 +163,8 @@ public class AnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         List<TrackPoint> trackPoints = TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), 10).second;
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.of(1000));
+        IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000), Distance.of(0));
+        intervalStatistics.addTrackPoints(trackPoints);
         IntervalStatistics.Interval lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
 
         // when

--- a/src/androidTest/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsTest.java
@@ -114,7 +114,7 @@ public class IntervalStatisticsTest {
     }
 
     private void whenAndThen(List<TrackPoint> trackPoints, TrackStatistics trackStatistics, float distanceInterval) {
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.of(distanceInterval));
+        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.of(distanceInterval), Distance.of(0));
         List<IntervalStatistics.Interval> intervalList = intervalStatistics.getIntervalList();
         Distance totalDistance = Distance.of(0);
         float totalTime = 0L;

--- a/src/androidTest/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsTest.java
@@ -114,7 +114,8 @@ public class IntervalStatisticsTest {
     }
 
     private void whenAndThen(List<TrackPoint> trackPoints, TrackStatistics trackStatistics, float distanceInterval) {
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.of(distanceInterval), Distance.of(0));
+        IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(distanceInterval), Distance.of(0));
+        intervalStatistics.addTrackPoints(trackPoints);
         List<IntervalStatistics.Interval> intervalList = intervalStatistics.getIntervalList();
         Distance totalDistance = Distance.of(0);
         float totalTime = 0L;

--- a/src/androidTest/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsTest.java
@@ -1,5 +1,11 @@
 package de.dennisguse.opentracks.viewmodels;
 
+import android.content.Context;
+import android.util.Pair;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -10,6 +16,8 @@ import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
+import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
+import de.dennisguse.opentracks.content.provider.TrackPointIterator;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.stats.TrackStatisticsUpdater;
 import de.dennisguse.opentracks.util.UnitConversions;
@@ -21,8 +29,12 @@ public class IntervalStatisticsTest {
 
     private static final String TAG = IntervalStatisticsTest.class.getSimpleName();
 
-    private List<TrackPoint> buildTrackPoints(int numberOfTrackPoints) {
-        return TestDataUtil.createTrack(new Track.Id(System.currentTimeMillis()), numberOfTrackPoints).second;
+    private final Context context = ApplicationProvider.getApplicationContext();
+    private ContentProviderUtils contentProviderUtils;
+
+    @Before
+    public void setUp() {
+        contentProviderUtils = new ContentProviderUtils(context);
     }
 
     private TrackStatistics buildTrackStatistics(List<TrackPoint> trackPoints) {
@@ -41,12 +53,10 @@ public class IntervalStatisticsTest {
         // With 50 points and interval distance of 1000m.
 
         // given
-        List<TrackPoint> trackPoints = buildTrackPoints(50);
-        TrackStatistics trackStatistics = buildTrackStatistics(trackPoints);
         float distanceInterval = 1000f;
 
         // when and then
-        whenAndThen(trackPoints, trackStatistics, distanceInterval);
+        whenAndThen(50, distanceInterval);
     }
 
     /**
@@ -57,12 +67,10 @@ public class IntervalStatisticsTest {
         // With 200 points and interval distance of 1000m.
 
         // given
-        List<TrackPoint> trackPoints = buildTrackPoints(200);
-        TrackStatistics trackStatistics = buildTrackStatistics(trackPoints);
         float distanceInterval = 1000f;
 
         // when and then
-        whenAndThen(trackPoints, trackStatistics, distanceInterval);
+        whenAndThen(200, distanceInterval);
     }
 
     /**
@@ -73,12 +81,10 @@ public class IntervalStatisticsTest {
         // With 200 points and interval distance of 3000m.
 
         // given
-        List<TrackPoint> trackPoints = buildTrackPoints(200);
-        TrackStatistics trackStatistics = buildTrackStatistics(trackPoints);
         float distanceInterval = 3000f;
 
         // when and then
-        whenAndThen(trackPoints, trackStatistics, distanceInterval);
+        whenAndThen(3000, distanceInterval);
     }
 
     /**
@@ -89,12 +95,10 @@ public class IntervalStatisticsTest {
         // With 1000 points and interval distance of 3000m.
 
         // given
-        List<TrackPoint> trackPoints = buildTrackPoints(1000);
-        TrackStatistics trackStatistics = buildTrackStatistics(trackPoints);
         float distanceInterval = 3000f;
 
         // when and then
-        whenAndThen(trackPoints, trackStatistics, distanceInterval);
+        whenAndThen(1000, distanceInterval);
     }
 
     /**
@@ -105,17 +109,21 @@ public class IntervalStatisticsTest {
         // With 10000 points and interval distance of 1000m.
 
         // given
-        List<TrackPoint> trackPoints = buildTrackPoints(10000);
-        TrackStatistics trackStatistics = buildTrackStatistics(trackPoints);
         float distanceInterval = 1000f;
 
         // when and then
-        whenAndThen(trackPoints, trackStatistics, distanceInterval);
+        whenAndThen(10000, distanceInterval);
     }
 
-    private void whenAndThen(List<TrackPoint> trackPoints, TrackStatistics trackStatistics, float distanceInterval) {
+    private void whenAndThen(int numberOfPoints, float distanceInterval) {
         IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(distanceInterval), Distance.of(0));
-        intervalStatistics.addTrackPoints(trackPoints);
+        Pair<Track.Id, TrackStatistics> trackWithStats = TestDataUtil.buildTrackWithTrackPoints(contentProviderUtils, numberOfPoints);
+        Track.Id trackId = trackWithStats.first;
+        TrackStatistics trackStatistics = trackWithStats.second;
+        try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(trackId, null)) {
+            assertEquals(trackPointIterator.getCount(), numberOfPoints);
+            intervalStatistics.addTrackPoints(trackPointIterator);
+        }
         List<IntervalStatistics.Interval> intervalList = intervalStatistics.getIntervalList();
         Distance totalDistance = Distance.of(0);
         float totalTime = 0L;
@@ -130,7 +138,7 @@ public class IntervalStatisticsTest {
         assertEquals(trackStatistics.getTotalDistance().toM(), totalDistance.toM(), 0.01);
         assertEquals(trackStatistics.getTotalTime().toMillis(), totalTime * UnitConversions.S_TO_MS, 1);
         assertEquals(intervalList.size(), (int) Math.ceil(trackStatistics.getTotalDistance().toM() / distanceInterval));
-        assertEquals(totalGain, trackPoints.size() * TestDataUtil.ALTITUDE_GAIN, 0.1);
+        assertEquals(totalGain, numberOfPoints * TestDataUtil.ALTITUDE_GAIN, 0.1);
 
         for (int i = 0; i < intervalList.size() - 1; i++) {
             assertEquals(intervalList.get(i).getDistance().toM(), distanceInterval, 0.001);

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -289,7 +289,7 @@ public class TrackRecordedActivity extends AbstractTrackDeleteActivity implement
                 case 0:
                     return StatisticsRecordedFragment.newInstance(trackId);
                 case 1:
-                    return IntervalsFragment.newInstance(true);
+                    return IntervalsFragment.newInstance(trackId, true);
                 case 2:
                     return ChartFragment.newInstance(false);
                 case 3:

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -360,7 +360,7 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
                 case 0:
                     return StatisticsRecordingFragment.newInstance();
                 case 1:
-                    return IntervalsFragment.newInstance(false);
+                    return IntervalsFragment.newInstance(trackId, false);
                 case 2:
                     return ChartFragment.newInstance(false);
                 case 3:

--- a/src/main/java/de/dennisguse/opentracks/adapters/IntervalStatisticsAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/adapters/IntervalStatisticsAdapter.java
@@ -72,10 +72,6 @@ public class IntervalStatisticsAdapter extends RecyclerView.Adapter<RecyclerView
     }
 
     public List<IntervalStatistics.Interval> swapData(List<IntervalStatistics.Interval> data, boolean metricUnits, boolean isReportSpeed) {
-        if (intervalList == data && this.metricUnits == metricUnits && this.isReportSpeed == isReportSpeed) {
-            return null;
-        }
-
         this.metricUnits = metricUnits;
         this.isReportSpeed = isReportSpeed;
         intervalList = data;

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -745,6 +745,16 @@ public class ContentProviderUtils {
         return new TrackPointIterator(this, trackId, startTrackPointId);
     }
 
+    public List<TrackPoint> getTrackPoints(final Track.Id trackId, final TrackPoint.Id startTrackPointId) {
+        List<TrackPoint> trackPoints = new ArrayList<>();
+        try (TrackPointIterator trackPointIterator = getTrackPointLocationIterator(trackId, startTrackPointId)) {
+            while (trackPointIterator.hasNext()) {
+                trackPoints.add(trackPointIterator.next());
+            }
+        }
+        return trackPoints;
+    }
+
     @Deprecated
     private TrackPoint findTrackPointBy(String selection, String[] selectionArgs) {
         try (Cursor cursor = getTrackPointCursor(null, selection, selectionArgs, TrackPointsColumns._ID)) {

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.StreamSupport;
 
 import de.dennisguse.opentracks.BuildConfig;
 import de.dennisguse.opentracks.content.data.Altitude;
@@ -743,16 +744,6 @@ public class ContentProviderUtils {
      */
     public TrackPointIterator getTrackPointLocationIterator(final Track.Id trackId, final TrackPoint.Id startTrackPointId) {
         return new TrackPointIterator(this, trackId, startTrackPointId);
-    }
-
-    public List<TrackPoint> getTrackPoints(final Track.Id trackId, final TrackPoint.Id startTrackPointId) {
-        List<TrackPoint> trackPoints = new ArrayList<>();
-        try (TrackPointIterator trackPointIterator = getTrackPointLocationIterator(trackId, startTrackPointId)) {
-            while (trackPointIterator.hasNext()) {
-                trackPoints.add(trackPointIterator.next());
-            }
-        }
-        return trackPoints;
     }
 
     @Deprecated

--- a/src/main/java/de/dennisguse/opentracks/fragments/IntervalsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/IntervalsFragment.java
@@ -140,11 +140,14 @@ public class IntervalsFragment extends Fragment implements TrackDataListener {
     @Override
     public void onResume() {
         super.onResume();
+
+        resumeTrackDataHub();
+
         sharedPreferences.registerOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
         sharedPreferenceChangeListener.onSharedPreferenceChanged(sharedPreferences, null);
+
         viewModel = new ViewModelProvider(getActivity()).get(IntervalStatisticsModel.class);
         loadIntervals();
-        resumeTrackDataHub();
     }
 
     @Override
@@ -224,28 +227,28 @@ public class IntervalsFragment extends Fragment implements TrackDataListener {
 
     @Override
     public void clearTrackPoints() {
-        if (isResumed()) {
+        if (isResumed() && viewModel != null) {
             viewModel.clear();
         }
     }
 
     @Override
     public void onSampledInTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics unused, Speed unused2, double unused3) {
-        if (isResumed()) {
+        if (isResumed() && viewModel != null) {
             viewModel.add(trackPoint);
         }
     }
 
     @Override
     public void onSampledOutTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics unused) {
-        if (isResumed()) {
+        if (isResumed() && viewModel != null) {
             viewModel.add(trackPoint);
         }
     }
 
     @Override
     public void onNewTrackPointsDone() {
-        if (isResumed()) {
+        if (isResumed() && viewModel != null) {
             runOnUiThread(viewModel::onNewTrackPoints);
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/fragments/IntervalsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/IntervalsFragment.java
@@ -64,7 +64,7 @@ public class IntervalsFragment extends Fragment {
     /**
      * Creates an instance of this class.
      *
-     * @param trackId          track's id.
+     * @param trackId
      * @param  fromTopToBottom If true then the intervals are shown from top to bottom (the first interval on top). Otherwise the intervals are shown from bottom to top.
      * @return IntervalsFragment instance.
      */
@@ -185,7 +185,7 @@ public class IntervalsFragment extends Fragment {
     }
 
     private synchronized void updateIntervals(boolean metricUnits, IntervalStatisticsModel.IntervalOption selectedInterval) {
-        boolean update = metricUnits != this.metricUnits || !selectedInterval.equals(this.selectedInterval);
+        boolean update = metricUnits != this.metricUnits || !selectedInterval.sameMultiplier(this.selectedInterval);
         this.metricUnits = metricUnits;
         this.selectedInterval = selectedInterval;
 

--- a/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
+++ b/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
@@ -187,8 +187,9 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
 
         boolean isMetricUnits = PreferencesUtils.isMetricUnits(sharedPreferences, context);
         boolean isReportSpeed = PreferencesUtils.isReportSpeed(sharedPreferences, context, category);
+        Distance minGPSDistance = PreferencesUtils.getRecordingDistanceInterval(sharedPreferences, context);
 
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.one(isMetricUnits));
+        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.one(isMetricUnits), minGPSDistance);
         IntervalStatistics.Interval lastInterval = intervalStatistics.getLastInterval();
 
         String announcement = AnnouncementUtils.getAnnouncement(context, trackStatistics, isMetricUnits, isReportSpeed, lastInterval);

--- a/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
+++ b/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
@@ -178,19 +178,13 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
         }
         String category = track.getCategory();
 
-        //TODO Querying all TrackPoints all the time is inefficient; get infos from TrackRecordingService
-        TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), null);
-        ArrayList<TrackPoint> trackPoints = new ArrayList<>();
-        while (trackPointIterator.hasNext()) {
-            trackPoints.add(trackPointIterator.next());
-        }
-
         boolean isMetricUnits = PreferencesUtils.isMetricUnits(sharedPreferences, context);
         boolean isReportSpeed = PreferencesUtils.isReportSpeed(sharedPreferences, context, category);
         Distance minGPSDistance = PreferencesUtils.getRecordingDistanceInterval(sharedPreferences, context);
 
+        TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(track.getId(), null);
         IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.one(isMetricUnits), minGPSDistance);
-        intervalStatistics.addTrackPoints(trackPoints);
+        intervalStatistics.addTrackPoints(trackPointIterator);
         IntervalStatistics.Interval lastInterval = intervalStatistics.getLastInterval();
 
         String announcement = AnnouncementUtils.getAnnouncement(context, trackStatistics, isMetricUnits, isReportSpeed, lastInterval);

--- a/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
+++ b/src/main/java/de/dennisguse/opentracks/services/tasks/AnnouncementPeriodicTask.java
@@ -189,7 +189,8 @@ public class AnnouncementPeriodicTask implements PeriodicTask {
         boolean isReportSpeed = PreferencesUtils.isReportSpeed(sharedPreferences, context, category);
         Distance minGPSDistance = PreferencesUtils.getRecordingDistanceInterval(sharedPreferences, context);
 
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, Distance.one(isMetricUnits), minGPSDistance);
+        IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.one(isMetricUnits), minGPSDistance);
+        intervalStatistics.addTrackPoints(trackPoints);
         IntervalStatistics.Interval lastInterval = intervalStatistics.getLastInterval();
 
         String announcement = AnnouncementUtils.getAnnouncement(context, trackStatistics, isMetricUnits, isReportSpeed, lastInterval);

--- a/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsModel.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsModel.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.TrackPoint;
+import de.dennisguse.opentracks.util.PreferencesUtils;
+import de.dennisguse.opentracks.util.UnitConversions;
 
 /**
  * This model is used to load intervals for a track.
@@ -22,9 +24,11 @@ public class IntervalStatisticsModel extends AndroidViewModel {
     private final List<TrackPoint> trackPoints = new ArrayList<>();
     private MutableLiveData<List<IntervalStatistics.Interval>> intervalsLiveData;
     private Distance distanceInterval;
+    private Distance minGPSDistance;
 
     public IntervalStatisticsModel(@NonNull Application application) {
         super(application);
+        minGPSDistance = PreferencesUtils.getRecordingDistanceInterval(PreferencesUtils.getSharedPreferences(application), application);
     }
 
     public MutableLiveData<List<IntervalStatistics.Interval>> getIntervalStats(boolean metricUnits, @Nullable IntervalOption interval) {
@@ -43,7 +47,7 @@ public class IntervalStatisticsModel extends AndroidViewModel {
     }
 
     private void loadIntervalStatistics() {
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, distanceInterval);
+        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, distanceInterval, minGPSDistance);
         intervalsLiveData.postValue(intervalStatistics.getIntervalList());
     }
 

--- a/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsModel.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatisticsModel.java
@@ -1,19 +1,27 @@
 package de.dennisguse.opentracks.viewmodels;
 
 import android.app.Application;
+import android.content.ContentResolver;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.HandlerThread;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.MutableLiveData;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import de.dennisguse.opentracks.content.data.Distance;
+import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
+import de.dennisguse.opentracks.content.data.TrackPointsColumns;
+import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 import de.dennisguse.opentracks.util.PreferencesUtils;
-import de.dennisguse.opentracks.util.UnitConversions;
 
 /**
  * This model is used to load intervals for a track.
@@ -21,65 +29,95 @@ import de.dennisguse.opentracks.util.UnitConversions;
  */
 public class IntervalStatisticsModel extends AndroidViewModel {
 
-    private final List<TrackPoint> trackPoints = new ArrayList<>();
+    private static final String TAG = IntervalStatisticsModel.class.getSimpleName();
+
     private MutableLiveData<List<IntervalStatistics.Interval>> intervalsLiveData;
+    private IntervalStatistics intervalStatistics;
     private Distance distanceInterval;
-    private Distance minGPSDistance;
+    private final Distance minGPSDistance;
+    private final ContentResolver contentResolver;
+    private ContentObserver trackPointsTableObserver;
+    private TrackPoint.Id lastTrackPointId;
+
+    private final Executor executor = Executors.newSingleThreadExecutor();
+    private HandlerThread handlerThread;
+    private Handler handler;
 
     public IntervalStatisticsModel(@NonNull Application application) {
         super(application);
         minGPSDistance = PreferencesUtils.getRecordingDistanceInterval(PreferencesUtils.getSharedPreferences(application), application);
+        contentResolver = getApplication().getContentResolver();
     }
 
-    public MutableLiveData<List<IntervalStatistics.Interval>> getIntervalStats(boolean metricUnits, @Nullable IntervalOption interval) {
-        synchronized (trackPoints) {
-            if (intervalsLiveData == null) {
-                if (interval == null) {
-                    interval = IntervalOption.OPTION_1;
-                }
-
-                intervalsLiveData = new MutableLiveData<>();
-                distanceInterval = interval.getDistance(metricUnits);
-                loadIntervalStatistics();
-            }
-            return intervalsLiveData;
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        if (trackPointsTableObserver != null) {
+            contentResolver.unregisterContentObserver(trackPointsTableObserver);
         }
-    }
-
-    private void loadIntervalStatistics() {
-        IntervalStatistics intervalStatistics = new IntervalStatistics(trackPoints, distanceInterval, minGPSDistance);
-        intervalsLiveData.postValue(intervalStatistics.getIntervalList());
-    }
-
-    public void add(TrackPoint trackPoint) {
-        synchronized (trackPoints) {
-            trackPoints.add(trackPoint);
+        if (handlerThread != null) {
+            handlerThread.getLooper().quit();
+            handlerThread = null;
         }
+        handler = null;
     }
 
-    public void onNewTrackPoints() {
-        synchronized (trackPoints) {
-            if (intervalsLiveData != null) {
-                loadIntervalStatistics();
-            }
-        }
-    }
-
-    public void clear() {
-        synchronized (trackPoints) {
-            trackPoints.clear();
-        }
-    }
-
-    public void upload(boolean metricUnits, @Nullable IntervalOption interval) {
-        synchronized (trackPoints) {
+    public MutableLiveData<List<IntervalStatistics.Interval>> getIntervalStats(Track.Id trackId, boolean metricUnits, @Nullable IntervalOption interval) {
+        if (intervalsLiveData == null) {
             if (interval == null) {
                 interval = IntervalOption.OPTION_1;
             }
 
+            intervalsLiveData = new MutableLiveData<>();
             distanceInterval = interval.getDistance(metricUnits);
-            loadIntervalStatistics();
+            intervalStatistics = new IntervalStatistics(distanceInterval, minGPSDistance);
+
+            loadIntervalStatistics(trackId);
         }
+
+        registerTrackPointsObserver(trackId);
+
+        return intervalsLiveData;
+    }
+
+    private void loadIntervalStatistics(Track.Id trackId) {
+        executor.execute(() -> {
+            ContentProviderUtils contentProviderUtils = new ContentProviderUtils(getApplication());
+            List<TrackPoint> trackPoints = contentProviderUtils.getTrackPoints(trackId, lastTrackPointId);
+            lastTrackPointId = trackPoints.size() > 0 ? trackPoints.get(trackPoints.size() - 1).getId() : lastTrackPointId;
+            intervalStatistics.addTrackPoints(trackPoints);
+            intervalsLiveData.postValue(intervalStatistics.getIntervalList());
+        });
+    }
+
+    private void registerTrackPointsObserver(Track.Id trackId) {
+        handlerThread = new HandlerThread(TAG);
+        handlerThread.start();
+        handler = new Handler(handlerThread.getLooper());
+        trackPointsTableObserver = new ContentObserver(handler) {
+            @Override
+            public void onChange(boolean selfChange, Uri uri) {
+                loadIntervalStatistics(trackId);
+            }
+        };
+        contentResolver.registerContentObserver(TrackPointsColumns.CONTENT_URI_BY_TRACKID, false, trackPointsTableObserver);
+    }
+
+    public void onPause() {
+        if (trackPointsTableObserver != null) {
+            contentResolver.unregisterContentObserver(trackPointsTableObserver);
+        }
+    }
+
+    public void update(Track.Id trackId, boolean metricUnits, @Nullable IntervalOption interval) {
+        if (interval == null) {
+            interval = IntervalOption.OPTION_1;
+        }
+
+        lastTrackPointId = null;
+        distanceInterval = interval.getDistance(metricUnits);
+        intervalStatistics = new IntervalStatistics(distanceInterval, minGPSDistance);
+        loadIntervalStatistics(trackId);
     }
 
     /**
@@ -105,6 +143,10 @@ public class IntervalStatisticsModel extends AndroidViewModel {
             return Distance
                     .one(metricUnits)
                     .multipliedBy(multiplier);
+        }
+
+        public boolean equals(IntervalOption intervalOption) {
+            return intervalOption != null && this.multiplier == intervalOption.multiplier;
         }
 
         @Override


### PR DESCRIPTION
**TrackStatisticsUpdater to compute Intervals**
#703 is fixed in this PR.

**Performance improvement**
- When recording every time a new track point were gotten the intervals were created. So intervals were built again and again. Now, intervals add new track points to complete them.
- Related to the above TrackDataHub have been removed from IntervalsFragment. With TrackDataHub every time the fragment was resumed all TrackPoints were sent to the ViewModel but ViewModel.

**Work to be done after this PR**
- Improve announcement performance (last interval).
- Review ChartFragment (maybe the same issue that with the IntervalsFragment).

**Why draft PR**
Because I want to test them in a long route (next weekend). But this can be already reviewed.

**Link to the the issue**
#703 
#808 

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
