### PR TITLE
Bugfix: TrackRecordingService needs to send data from lastTrackPoint …

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/content/data/Altitude.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Altitude.java
@@ -1,5 +1,7 @@
 package de.dennisguse.opentracks.content.data;
 
+import de.dennisguse.opentracks.R;
+
 public abstract class Altitude {
 
     private final double altitude_m;
@@ -12,12 +14,18 @@ public abstract class Altitude {
         return altitude_m;
     }
 
+    public abstract int getLabelId();
+
     public static class WGS84 extends Altitude {
 
         private WGS84(double altitude_m) {
             super(altitude_m);
         }
 
+        @Override
+        public int getLabelId() {
+            return R.string.wgs84;
+        }
 
         public static Altitude of(double altitude_m) {
             return new WGS84(altitude_m);
@@ -30,6 +38,10 @@ public abstract class Altitude {
             super(altitude_m);
         }
 
+        @Override
+        public int getLabelId() {
+            return R.string.egm2008;
+        }
 
         public static Altitude of(double altitude_m) {
             return new EGM2008(altitude_m);

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
@@ -276,10 +276,18 @@ public class StatisticsRecordingFragment extends Fragment {
 
         if (preferenceShowAltitude) {
             // Current altitude
-            Float altitude = latestTrackPoint != null && latestTrackPoint.hasAltitude() ? (float) latestTrackPoint.getAltitude().toM() : null;
+            Float altitude = null;
+            int labelId = R.string.value_unknown;
+            if (latestTrackPoint != null && latestTrackPoint.hasAltitude()) {
+                altitude = (float) latestTrackPoint.getAltitude().toM();
+                labelId = latestTrackPoint.getAltitude().getLabelId();
+            }
+
             Pair<String, String> parts = StringUtils.formatAltitude(getContext(), altitude, preferenceMetricUnits);
             viewBinding.statsAltitudeCurrentValue.setText(parts.first);
             viewBinding.statsAltitudeCurrentUnit.setText(parts.second);
+
+            viewBinding.statsAltitudeCurrentLabelEgm.setText(labelId);
         }
 
         // Set coordinate
@@ -313,7 +321,7 @@ public class StatisticsRecordingFragment extends Fragment {
             sharedPreferenceChangeListener.onSharedPreferenceChanged(sharedPreferences, getString(R.string.stats_rate_key));
         }
 
-        this.latestTrackPoint = recordingData.getLatestTrackPoint();
+        latestTrackPoint = recordingData.getLatestTrackPoint();
         if (latestTrackPoint != null && latestTrackPoint.hasLocation() && !latestTrackPoint.isRecent()) {
             latestTrackPoint = null;
         }

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -652,8 +652,6 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
             trackStatisticsUpdater.addTrackPoint(trackPoint, recordingDistanceInterval);
             track.setTrackStatistics(trackStatisticsUpdater.getTrackStatistics());
 
-            recordingDataObservable.postValue(new RecordingData(track, trackPoint, sensorDataSet));
-
             contentProviderUtils.updateTrack(track);
         } catch (SQLiteException e) {
             /*
@@ -761,11 +759,18 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
         //TODO This somehow should happen in the HandlerServer as we create a new TrackPoint.
         TrackStatisticsUpdater tmpTrackStatisticsUpdater = new TrackStatisticsUpdater(trackStatisticsUpdater);
         TrackPoint tmpLastTrackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT);
+
+        if (lastTrackPoint != null && lastTrackPoint.hasLocation()) {
+            //TODO Should happen in TrackPoint? via constructor
+            tmpLastTrackPoint.setAltitude(lastTrackPoint.getAltitude());
+            tmpLastTrackPoint.setLongitude(lastTrackPoint.getLongitude());
+            tmpLastTrackPoint.setLatitude(lastTrackPoint.getLatitude());
+        }
+
         SensorDataSet sensorDataSet = fillWithSensorDataSet(tmpLastTrackPoint);
 
         tmpTrackStatisticsUpdater.addTrackPoint(tmpLastTrackPoint, recordingDistanceInterval);
         track.setTrackStatistics(tmpTrackStatisticsUpdater.getTrackStatistics());
-
 
         recordingDataObservable.postValue(new RecordingData(track, tmpLastTrackPoint, sensorDataSet));
     }

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -788,6 +788,7 @@ public class TrackRecordingService extends Service implements HandlerServer.Hand
 
         if (lastTrackPoint != null && lastTrackPoint.hasLocation()) {
             //TODO Should happen in TrackPoint? via constructor
+            tmpLastTrackPoint.setSpeed(lastTrackPoint.getSpeed());
             tmpLastTrackPoint.setAltitude(lastTrackPoint.getAltitude());
             tmpLastTrackPoint.setLongitude(lastTrackPoint.getLongitude());
             tmpLastTrackPoint.setLatitude(lastTrackPoint.getLatitude());

--- a/src/main/res/layout/statistics_recording.xml
+++ b/src/main/res/layout/statistics_recording.xml
@@ -269,7 +269,7 @@
             android:id="@+id/stats_altitude_group"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:constraint_referenced_ids="stats_altitude_horizontal_line,stats_altitude_current_label,stats_altitude_current_value,stats_altitude_current_unit,stats_altitude_gain_label,stats_altitude_gain_value,stats_altitude_gain_unit,stats_altitude_loss_label,stats_altitude_loss_value,stats_altitude_loss_unit,stats_elevation_current_label_egm" />
+            app:constraint_referenced_ids="stats_altitude_horizontal_line,stats_altitude_current_label,stats_altitude_current_value,stats_altitude_current_unit,stats_altitude_gain_label,stats_altitude_gain_value,stats_altitude_gain_unit,stats_altitude_loss_label,stats_altitude_loss_value,stats_altitude_loss_unit,@+id/stats_altitude_current_label_egm" />
 
         <!-- altitude -->
         <TextView
@@ -282,7 +282,7 @@
             app:layout_constraintTop_toBottomOf="@id/stats_altitude_horizontal_line" />
 
         <TextView
-            android:id="@+id/stats_elevation_current_label_egm"
+            android:id="@+id/stats_altitude_current_label_egm"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="0dp"

--- a/src/main/res/values/do_not_translate.xml
+++ b/src/main/res/values/do_not_translate.xml
@@ -18,6 +18,7 @@ limitations under the License.
     <string name="app_name" translatable="false">OpenTracks</string>
 
     <string name="egm2008" translatable="false">EGM2008</string>
+    <string name="wgs84" translatable="false">WGS84</string>
 
     <string name="third_party_data" translatable="false">
         <a href="https://earth-info.nga.mil/">National Geospatial-Intelligence Agency (NGA)\'s EGM2008 model</a> 5\' minute resolution.


### PR DESCRIPTION
…in it's 1s updates.

This also removes UI updates if a GPS measurement is received as 1s update should be sufficient.

Fixes #828.

BUT: elevation is shown in WGS84 as the EGM2008 transformation is happening in the TrackDataHub.
TrackRecordingService needs to do the same.