### PR TITLE
Workaround for no barometric sensor: intervals shows dashes (-) for gain and loss.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/adapters/IntervalStatisticsAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/adapters/IntervalStatisticsAdapter.java
@@ -59,8 +59,9 @@ public class IntervalStatisticsAdapter extends RecyclerView.Adapter<RecyclerView
 
         viewHolder.rate.setText(StringUtils.formatSpeed(context, interval.getSpeed(), metricUnits, isReportSpeed));
 
-        viewHolder.gain.setText(StringUtils.formatDistance(context, Distance.of(interval.getGain_m()), metricUnits));
-        viewHolder.loss.setText(StringUtils.formatDistance(context, Distance.of(interval.getLoss_m()), metricUnits));
+        viewHolder.gain.setText(interval.hasGain() ? StringUtils.formatDistance(context, Distance.of(interval.getGain_m()), metricUnits) : context.getString(R.string.value_unknown));
+        viewHolder.loss.setText(interval.hasLoss() ? StringUtils.formatDistance(context, Distance.of(interval.getLoss_m()), metricUnits) : context.getString(R.string.value_unknown));
+
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatistics.java
@@ -104,8 +104,8 @@ public class IntervalStatistics {
     public static class Interval {
         private Distance distance = Distance.of(0);
         private Duration time = Duration.ofSeconds(0);
-        private float gain_m;
-        private float loss_m;
+        private Float gain_m;
+        private Float loss_m;
 
         public Interval() {
         }
@@ -143,8 +143,16 @@ public class IntervalStatistics {
             return Speed.of(distance, time);
         }
 
+        public boolean hasGain() {
+            return gain_m != null;
+        }
+
         public float getGain_m() {
             return gain_m;
+        }
+
+        public boolean hasLoss() {
+            return loss_m != null;
         }
 
         public float getLoss_m() {


### PR DESCRIPTION
**Describe the pull request**
The simple solution: show dashes.
Hiding data require some communication strategy between Intervals Adapter and Interval Fragment because IntervalFragment have to hide the header and Adapter the values... Does it worth? I don't think so.

**Link to the the issue**
#791 

