### PR TITLE
Remove KML/KMZ lvariants

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/provider/ShareContentProviderTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/provider/ShareContentProviderTest.java
@@ -29,7 +29,7 @@ public class ShareContentProviderTest {
         trackIds.add(new Track.Id(3));
         trackIds.add(new Track.Id(5));
 
-        Pair<Uri, String> shareURIandMIME = ShareContentProvider.createURI(trackIds, "TrackName", TrackFileFormat.KML_ONLY_TRACK);
+        Pair<Uri, String> shareURIandMIME = ShareContentProvider.createURI(trackIds, "TrackName", TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA);
 
         assertEquals(trackIds, ShareContentProvider.parseURI(shareURIandMIME.first));
     }
@@ -38,8 +38,8 @@ public class ShareContentProviderTest {
     public void testCreateURIescapeFilename() {
         Set<Track.Id> trackIds = new HashSet<>();
         trackIds.add(new Track.Id(1));
-        Pair<Uri, String> shareURIandMIME = ShareContentProvider.createURI(trackIds, "../../&1=1", TrackFileFormat.KML_ONLY_TRACK);
+        Pair<Uri, String> shareURIandMIME = ShareContentProvider.createURI(trackIds, "../../&1=1", TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA);
 
-        assertEquals(Uri.parse("content://de.dennisguse.opentracks.debug.content/tracks/kml_only_track/1/..%2F..%2F%261%3D1.kml"), shareURIandMIME.first);
+        assertEquals(Uri.parse("content://de.dennisguse.opentracks.debug.content/tracks/kml_with_trackdetail_and_sensordata/1/..%2F..%2F%261%3D1.kml"), shareURIandMIME.first);
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -158,46 +158,6 @@ public class ExportImportTest {
 
     @LargeTest
     @Test
-    public void kml_with_trackdetail() throws TimeoutException, IOException {
-        setUp(false);
-
-        // given
-        Track track = contentProviderUtils.getTrack(trackId);
-
-        TrackExporter trackExporter = TrackFileFormat.KML_WITH_TRACKDETAIL.createTrackExporter(context);
-
-        // when
-        // 1. export
-        trackExporter.writeTrack(track, context.getContentResolver().openOutputStream(tmpFileUri));
-        contentProviderUtils.deleteTrack(context, trackId);
-
-        // 2. import
-        InputStream inputStream = context.getContentResolver().openInputStream(tmpFileUri);
-        XMLImporter importer = new XMLImporter(new KmlTrackImporter(context, trackImporter));
-        importTrackId = importer.importFile(inputStream).get(0);
-
-        // then
-        // 1. track
-        Track importedTrack = contentProviderUtils.getTrack(importTrackId);
-        assertNotNull(importedTrack);
-        assertEquals(track.getCategory(), importedTrack.getCategory());
-        assertEquals(track.getDescription(), importedTrack.getDescription());
-        assertEquals(track.getName(), importedTrack.getName());
-        assertEquals(track.getIcon(), importedTrack.getIcon());
-        assertEquals(track.getUuid(), importedTrack.getUuid());
-
-        // 2. trackpoints
-        assertTrackpoints(trackPoints, false, false, false, false, false, false);
-
-        // 3. trackstatistics
-        assertTrackStatistics(false, false, true);
-
-        // 4. markers
-        assertMarkers();
-    }
-
-    @LargeTest
-    @Test
     public void kml_with_trackdetail_and_sensordata() throws TimeoutException, IOException {
         setUp(true);
 

--- a/src/androidTest/java/de/dennisguse/opentracks/util/PreferencesUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/PreferencesUtilsTest.java
@@ -25,14 +25,14 @@ public class PreferencesUtilsTest {
         SharedPreferences sharedPreferences = PreferencesUtils.getSharedPreferences(context);
         SharedPreferences.Editor editor = sharedPreferences.edit();
 
-        editor.putString(context.getString(R.string.export_trackfileformat_key), TrackFileFormat.KMZ_WITH_TRACKDETAIL.name());
+        editor.putString(context.getString(R.string.export_trackfileformat_key), TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA.name());
         editor.commit();
 
         // when
         TrackFileFormat trackFileFormat = PreferencesUtils.getExportTrackFileFormat(sharedPreferences, context);
 
         // then
-        assertEquals(TrackFileFormat.KMZ_WITH_TRACKDETAIL, trackFileFormat);
+        assertEquals(TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA, trackFileFormat);
     }
 
     @Test

--- a/src/main/java/de/dennisguse/opentracks/ShowOnMapProxyActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/ShowOnMapProxyActivity.java
@@ -57,10 +57,9 @@ public abstract class ShowOnMapProxyActivity extends AppCompatActivity {
         context.startActivity(Intent.createChooser(intent, context.getString(R.string.open_track_as_trackfileformat, trackFileFormat.getExtension())));
     }
 
-    @Deprecated //TODO I guess we should send KML; zipping should not really improve the situation.
-    public static class KMZ extends ShowOnMapProxyActivity {
-        public KMZ() {
-            super(TrackFileFormat.KMZ_WITH_TRACKDETAIL_AND_SENSORDATA);
+    public static class KML extends ShowOnMapProxyActivity {
+        public KML() {
+            super(TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA);
         }
     }
 

--- a/src/main/java/de/dennisguse/opentracks/ShowOnMapProxyActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/ShowOnMapProxyActivity.java
@@ -57,9 +57,10 @@ public abstract class ShowOnMapProxyActivity extends AppCompatActivity {
         context.startActivity(Intent.createChooser(intent, context.getString(R.string.open_track_as_trackfileformat, trackFileFormat.getExtension())));
     }
 
+    @Deprecated //TODO I guess we should send KML; zipping should not really improve the situation.
     public static class KMZ extends ShowOnMapProxyActivity {
         public KMZ() {
-            super(TrackFileFormat.KMZ_WITH_TRACKDETAIL);
+            super(TrackFileFormat.KMZ_WITH_TRACKDETAIL_AND_SENSORDATA);
         }
     }
 

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ShareContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ShareContentProvider.java
@@ -64,12 +64,8 @@ public class ShareContentProvider extends CustomContentProvider {
     static {
         uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, TracksColumns.TABLE_NAME + "/" + TrackFileFormat.GPX.getName() + "/*/*", URI_GPX);
 
-        uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, TracksColumns.TABLE_NAME + "/" + TrackFileFormat.KML_ONLY_TRACK.getName() + "/*/*", URI_KML_ONLY);
-        uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, TracksColumns.TABLE_NAME + "/" + TrackFileFormat.KML_WITH_TRACKDETAIL.getName() + "/*/*", URI_KML_WITH_TRACKDETAIL);
         uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, TracksColumns.TABLE_NAME + "/" + TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA.getName() + "/*/*", URI_KML_WITH_TRACKDETAIL_SENSORDATA);
-        uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, TracksColumns.TABLE_NAME + "/" + TrackFileFormat.KMZ_ONLY_TRACK.getName() + "/*/*", URI_KMZ_ONLY_TRACK);
 
-        uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, TracksColumns.TABLE_NAME + "/" + TrackFileFormat.KMZ_WITH_TRACKDETAIL.getName() + "/*/*", URI_KMZ_WITH_TRACKDETAIL);
         uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, TracksColumns.TABLE_NAME + "/" + TrackFileFormat.KMZ_WITH_TRACKDETAIL_AND_SENSORDATA.getName() + "/*/*", URI_KMZ_WITH_TRACKDETAIL_AND_SENSORDATA);
         uriMatcher.addURI(ContentProviderUtils.AUTHORITY_PACKAGE, TracksColumns.TABLE_NAME + "/" + TrackFileFormat.KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES.getName() + "/*/*", URI_KMZ_WITH_TRACKDETAIL_SENSORDATA_AND_PICTURES);
     }
@@ -138,17 +134,9 @@ public class ShareContentProvider extends CustomContentProvider {
             case URI_GPX:
                 return TrackFileFormat.GPX;
 
-            case URI_KML_ONLY:
-                return TrackFileFormat.KML_ONLY_TRACK;
-            case URI_KML_WITH_TRACKDETAIL:
-                return TrackFileFormat.KML_WITH_TRACKDETAIL;
             case URI_KML_WITH_TRACKDETAIL_SENSORDATA:
                 return TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA;
 
-            case URI_KMZ_ONLY_TRACK:
-                return TrackFileFormat.KMZ_ONLY_TRACK;
-            case URI_KMZ_WITH_TRACKDETAIL:
-                return TrackFileFormat.KMZ_WITH_TRACKDETAIL;
             case URI_KMZ_WITH_TRACKDETAIL_AND_SENSORDATA:
                 return TrackFileFormat.KMZ_WITH_TRACKDETAIL_AND_SENSORDATA;
             case URI_KMZ_WITH_TRACKDETAIL_SENSORDATA_AND_PICTURES:

--- a/src/main/java/de/dennisguse/opentracks/io/file/TrackFileFormat.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/TrackFileFormat.java
@@ -13,6 +13,8 @@ import de.dennisguse.opentracks.io.file.exporter.TrackExporter;
 
 /**
  * Definition of all possible track formats.
+ * <p>
+ * NOTE: The names of the entries are used in the user's settings.
  */
 public enum TrackFileFormat {
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/TrackFileFormat.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/TrackFileFormat.java
@@ -16,41 +16,10 @@ import de.dennisguse.opentracks.io.file.exporter.TrackExporter;
  */
 public enum TrackFileFormat {
 
-    @Deprecated //Not needed anymore; we now have OSMDashboard; was only used to share with other applications
-    KML_ONLY_TRACK {
-        @Override
-        public TrackExporter createTrackExporter(Context context) {
-            return new KMLTrackExporter(context, false, false, false);
-        }
-
-        @Override
-        public String getMimeType() {
-            return MIME_KML;
-        }
-
-        public String getExtension() {
-            return "kml";
-        }
-    },
-    KML_WITH_TRACKDETAIL {
-        @Override
-        public TrackExporter createTrackExporter(Context context) {
-            return new KMLTrackExporter(context, true, false, false);
-        }
-
-        @Override
-        public String getMimeType() {
-            return MIME_KML;
-        }
-
-        public String getExtension() {
-            return "kml";
-        }
-    },
     KML_WITH_TRACKDETAIL_AND_SENSORDATA {
         @Override
         public TrackExporter createTrackExporter(Context context) {
-            return new KMLTrackExporter(context, true, true, false);
+            return new KMLTrackExporter(context, false);
         }
 
         @Override
@@ -62,61 +31,15 @@ public enum TrackFileFormat {
             return "kml";
         }
     },
-    KMZ_ONLY_TRACK {
-        private static final boolean exportPhotos = false;
 
-        @Override
-        public TrackExporter createTrackExporter(Context context) {
-            KMLTrackExporter exporter = new KMLTrackExporter(context, false, false, exportPhotos);
-            return new KmzTrackExporter(context, new ContentProviderUtils(context), exporter, exportPhotos);
-        }
-
-        @Override
-        public String getMimeType() {
-            return MIME_KMZ;
-        }
-
-        public String getExtension() {
-            return "kmz";
-        }
-
-        @Override
-        public boolean includesPhotos() {
-            return exportPhotos;
-        }
-    },
-    KMZ_WITH_TRACKDETAIL {
-
-        private static final boolean exportPhotos = false;
-
-        @Override
-        public TrackExporter createTrackExporter(Context context) {
-            KMLTrackExporter exporter = new KMLTrackExporter(context, true, false, exportPhotos);
-            return new KmzTrackExporter(context, new ContentProviderUtils(context), exporter, exportPhotos);
-        }
-
-        @Override
-        public String getMimeType() {
-            return MIME_KMZ;
-        }
-
-        public String getExtension() {
-            return "kmz";
-        }
-
-        @Override
-        public boolean includesPhotos() {
-            return exportPhotos;
-        }
-
-    },
+    @Deprecated //TODO Check if we really need this
     KMZ_WITH_TRACKDETAIL_AND_SENSORDATA {
 
         private static final boolean exportPhotos = false;
 
         @Override
         public TrackExporter createTrackExporter(Context context) {
-            KMLTrackExporter exporter = new KMLTrackExporter(context, true, true, exportPhotos);
+            KMLTrackExporter exporter = new KMLTrackExporter(context, exportPhotos);
             return new KmzTrackExporter(context, new ContentProviderUtils(context), exporter, exportPhotos);
         }
 
@@ -133,16 +56,15 @@ public enum TrackFileFormat {
         public boolean includesPhotos() {
             return exportPhotos;
         }
-
-
     },
+
     KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES {
 
         private static final boolean exportPhotos = true;
 
         @Override
         public TrackExporter createTrackExporter(Context context) {
-            KMLTrackExporter exporter = new KMLTrackExporter(context, true, true, exportPhotos);
+            KMLTrackExporter exporter = new KMLTrackExporter(context, exportPhotos);
             return new KmzTrackExporter(context, new ContentProviderUtils(context), exporter, exportPhotos);
         }
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
@@ -69,8 +69,6 @@ public class KMLTrackExporter implements TrackExporter {
 
     private final Context context;
     private final boolean exportPhotos;
-    private final boolean exportTrackDetail;
-    private final boolean exportSensorData;
     private final ContentProviderUtils contentProviderUtils;
 
     private PrintWriter printWriter;
@@ -82,13 +80,8 @@ public class KMLTrackExporter implements TrackExporter {
     private final List<Float> altitudeGainList = new ArrayList<>();
     private final List<Float> altitudeLossList = new ArrayList<>();
 
-    @Deprecated // Figure out a better way to do this! (if needed)
-    private TrackPoint startTrackPoint;
-
-    public KMLTrackExporter(Context context, boolean exportTrackDetail, boolean exportSensorData, boolean exportPhotos) {
+    public KMLTrackExporter(Context context, boolean exportPhotos) {
         this.context = context;
-        this.exportTrackDetail = exportTrackDetail;
-        this.exportSensorData = exportSensorData;
         this.exportPhotos = exportPhotos;
         this.contentProviderUtils = new ContentProviderUtils(context);
     }
@@ -160,11 +153,6 @@ public class KMLTrackExporter implements TrackExporter {
                 if (Thread.interrupted()) throw new InterruptedException();
 
                 TrackPoint trackPoint = trackPointIterator.next();
-                setLocationTime(trackPoint, offset);
-                if (startTrackPoint == null) {
-                    startTrackPoint = trackPoint;
-                }
-
                 if (!wroteTrack) {
                     writeBeginTrack(track);
                     wroteTrack = true;
@@ -207,8 +195,6 @@ public class KMLTrackExporter implements TrackExporter {
             }
 
             writeEndTrack();
-
-            startTrackPoint = null;
         }
     }
 
@@ -238,23 +224,19 @@ public class KMLTrackExporter implements TrackExporter {
             printWriter.println("<open>1</open>");
             printWriter.println("<visibility>1</visibility>");
 
-            if (exportTrackDetail) {
-                Track track = tracks[0];
-                printWriter.println("<name>" + StringUtils.formatCData(track.getName()) + "</name>");
-                printWriter.println("<atom:generator>" + StringUtils.formatCData(context.getString(R.string.app_name)) + "</atom:generator>");
-            }
+            Track track = tracks[0];
+            printWriter.println("<name>" + StringUtils.formatCData(track.getName()) + "</name>");
+            printWriter.println("<atom:generator>" + StringUtils.formatCData(context.getString(R.string.app_name)) + "</atom:generator>");
 
             writeTrackStyle();
             writePlacemarkerStyle(MARKER_STYLE, MARKER_ICON, 20, 2);
             printWriter.println("<Schema id=\"" + SCHEMA_ID + "\">");
 
             writeSimpleArrayStyle(EXTENDED_DATA_TYPE_SPEED, context.getString(R.string.description_speed_ms));
+            writeSimpleArrayStyle(EXTENDED_DATA_TYPE_POWER, context.getString(R.string.description_sensor_power));
+            writeSimpleArrayStyle(EXTENDED_DATA_TYPE_CADENCE, context.getString(R.string.description_sensor_cadence));
+            writeSimpleArrayStyle(EXTENDED_DATA_TYPE_HEART_RATE, context.getString(R.string.description_sensor_heart_rate));
 
-            if (exportSensorData) {
-                writeSimpleArrayStyle(EXTENDED_DATA_TYPE_POWER, context.getString(R.string.description_sensor_power));
-                writeSimpleArrayStyle(EXTENDED_DATA_TYPE_CADENCE, context.getString(R.string.description_sensor_cadence));
-                writeSimpleArrayStyle(EXTENDED_DATA_TYPE_HEART_RATE, context.getString(R.string.description_sensor_heart_rate));
-            }
             printWriter.println("</Schema>");
         }
     }
@@ -269,15 +251,13 @@ public class KMLTrackExporter implements TrackExporter {
     private void writeBeginMarkers(Track track) {
         if (printWriter != null) {
             printWriter.println("<Folder>");
-            if (exportTrackDetail) {
-                printWriter.println("<name>" + StringUtils.formatCData(context.getString(R.string.track_markers, track.getName())) + "</name>");
-            }
+            printWriter.println("<name>" + StringUtils.formatCData(context.getString(R.string.track_markers, track.getName())) + "</name>");
             printWriter.println("<open>1</open>");
         }
     }
 
     private void writeMarker(Marker marker) {
-        if (printWriter != null && exportTrackDetail) {
+        if (printWriter != null) {
             boolean existsPhoto = FileUtils.buildInternalPhotoFile(context, marker.getTrackId(), marker.getPhotoURI()) != null;
             if (marker.hasPhoto() && exportPhotos && existsPhoto) {
                 float heading = getHeading(marker.getTrackId(), marker.getLocation());
@@ -312,12 +292,10 @@ public class KMLTrackExporter implements TrackExporter {
         if (printWriter != null) {
             printWriter.println("<Placemark>");
 
-            if (exportTrackDetail) {
-                printWriter.println("<name>" + StringUtils.formatCData(track.getName()) + "</name>");
-                printWriter.println("<description>" + StringUtils.formatCData(track.getDescription()) + "</description>");
-                printWriter.println("<icon>" + StringUtils.formatCData(track.getIcon()) + "</icon>");
-                printWriter.println("<opentracks:trackid>" + track.getUuid() + "</opentracks:trackid>");
-            }
+            printWriter.println("<name>" + StringUtils.formatCData(track.getName()) + "</name>");
+            printWriter.println("<description>" + StringUtils.formatCData(track.getDescription()) + "</description>");
+            printWriter.println("<icon>" + StringUtils.formatCData(track.getIcon()) + "</icon>");
+            printWriter.println("<opentracks:trackid>" + track.getUuid() + "</opentracks:trackid>");
 
             printWriter.println("<styleUrl>#" + TRACK_STYLE + "</styleUrl>");
             writeCategory(track.getCategory());
@@ -357,25 +335,23 @@ public class KMLTrackExporter implements TrackExporter {
             if (speedList.stream().anyMatch(Objects::nonNull)) {
                 writeSimpleArrayData(speedList, EXTENDED_DATA_TYPE_SPEED);
             }
-            if (exportSensorData) {
-                if (distanceList.stream().anyMatch(Objects::nonNull)) {
-                    writeSimpleArrayData(distanceList, EXTENDED_DATA_TYPE_DISTANCE);
-                }
-                if (powerList.stream().anyMatch(Objects::nonNull)) {
-                    writeSimpleArrayData(powerList, EXTENDED_DATA_TYPE_POWER);
-                }
-                if (cadenceList.stream().anyMatch(Objects::nonNull)) {
-                    writeSimpleArrayData(cadenceList, EXTENDED_DATA_TYPE_CADENCE);
-                }
-                if (heartRateList.stream().anyMatch(Objects::nonNull)) {
-                    writeSimpleArrayData(heartRateList, EXTENDED_DATA_TYPE_HEART_RATE);
-                }
-                if (altitudeGainList.stream().anyMatch(Objects::nonNull)) {
-                    writeSimpleArrayData(altitudeGainList, EXTENDED_DATA_TYPE_ALTITUDE_GAIN);
-                }
-                if (altitudeLossList.stream().anyMatch(Objects::nonNull)) {
-                    writeSimpleArrayData(altitudeLossList, EXTENDED_DATA_TYPE_ALTITUDE_LOSS);
-                }
+            if (distanceList.stream().anyMatch(Objects::nonNull)) {
+                writeSimpleArrayData(distanceList, EXTENDED_DATA_TYPE_DISTANCE);
+            }
+            if (powerList.stream().anyMatch(Objects::nonNull)) {
+                writeSimpleArrayData(powerList, EXTENDED_DATA_TYPE_POWER);
+            }
+            if (cadenceList.stream().anyMatch(Objects::nonNull)) {
+                writeSimpleArrayData(cadenceList, EXTENDED_DATA_TYPE_CADENCE);
+            }
+            if (heartRateList.stream().anyMatch(Objects::nonNull)) {
+                writeSimpleArrayData(heartRateList, EXTENDED_DATA_TYPE_HEART_RATE);
+            }
+            if (altitudeGainList.stream().anyMatch(Objects::nonNull)) {
+                writeSimpleArrayData(altitudeGainList, EXTENDED_DATA_TYPE_ALTITUDE_GAIN);
+            }
+            if (altitudeLossList.stream().anyMatch(Objects::nonNull)) {
+                writeSimpleArrayData(altitudeLossList, EXTENDED_DATA_TYPE_ALTITUDE_LOSS);
             }
             printWriter.println("</SchemaData>");
             printWriter.println("</ExtendedData>");
@@ -386,9 +362,7 @@ public class KMLTrackExporter implements TrackExporter {
     @VisibleForTesting
     void writeTrackPoint(TrackPoint trackPoint) {
         if (printWriter != null) {
-            if (exportTrackDetail) {
-                printWriter.println("<when>" + getTime(trackPoint.getLocation()) + "</when>");
-            }
+            printWriter.println("<when>" + getTime(trackPoint.getLocation()) + "</when>");
 
             if (trackPoint.hasLocation()) {
                 printWriter.println("<gx:coord>" + (trackPoint.hasLocation() ? getCoordinates(trackPoint.getLocation(), " ") : "") + "</gx:coord>");
@@ -397,15 +371,13 @@ public class KMLTrackExporter implements TrackExporter {
             }
             speedList.add(trackPoint.hasSpeed() ? (float) trackPoint.getSpeed().toMPS() : null);
 
-            if (exportSensorData) {
-                distanceList.add(trackPoint.hasSensorDistance() ? (float) trackPoint.getSensorDistance().toM() : null);
-                heartRateList.add(trackPoint.hasHeartRate() ? trackPoint.getHeartRate_bpm() : null);
-                cadenceList.add(trackPoint.hasCyclingCadence() ? trackPoint.getCyclingCadence_rpm() : null);
-                powerList.add(trackPoint.hasPower() ? trackPoint.getPower() : null);
+            distanceList.add(trackPoint.hasSensorDistance() ? (float) trackPoint.getSensorDistance().toM() : null);
+            heartRateList.add(trackPoint.hasHeartRate() ? trackPoint.getHeartRate_bpm() : null);
+            cadenceList.add(trackPoint.hasCyclingCadence() ? trackPoint.getCyclingCadence_rpm() : null);
+            powerList.add(trackPoint.hasPower() ? trackPoint.getPower() : null);
 
-                altitudeGainList.add(trackPoint.hasAltitudeGain() ? trackPoint.getAltitudeGain() : null);
-                altitudeLossList.add(trackPoint.hasAltitudeLoss() ? trackPoint.getAltitudeLoss() : null);
-            }
+            altitudeGainList.add(trackPoint.hasAltitudeGain() ? trackPoint.getAltitudeGain() : null);
+            altitudeLossList.add(trackPoint.hasAltitudeLoss() ? trackPoint.getAltitudeLoss() : null);
         }
     }
 
@@ -438,7 +410,7 @@ public class KMLTrackExporter implements TrackExporter {
      * @param location    the location
      */
     private void writePlacemark(String name, String category, String description, String styleName, Location location) {
-        if (location != null && exportTrackDetail) {
+        if (location != null) {
             printWriter.println("<Placemark>");
             printWriter.println("<name>" + StringUtils.formatCData(name) + "</name>");
             printWriter.println("<description>" + StringUtils.formatCData(description) + "</description>");
@@ -453,37 +425,35 @@ public class KMLTrackExporter implements TrackExporter {
     }
 
     private void writePhotoOverlay(Marker marker, float heading) {
-        if (exportTrackDetail) {
-            printWriter.println("<PhotoOverlay>");
-            printWriter.println("<name>" + StringUtils.formatCData(marker.getName()) + "</name>");
-            printWriter.println("<description>" + StringUtils.formatCData(marker.getDescription()) + "</description>");
-            printWriter.print("<Camera>");
-            printWriter.print("<longitude>" + marker.getLongitude() + "</longitude>");
-            printWriter.print("<latitude>" + marker.getLatitude() + "</latitude>");
-            printWriter.print("<altitude>20</altitude>");
-            printWriter.print("<heading>" + heading + "</heading>");
-            printWriter.print("<tilt>90</tilt>");
-            printWriter.println("</Camera>");
-            printWriter.println("<TimeStamp><when>" + getTime(marker.getLocation()) + "</when></TimeStamp>");
-            printWriter.println("<styleUrl>#" + MARKER_STYLE + "</styleUrl>");
-            writeCategory(marker.getCategory());
+        printWriter.println("<PhotoOverlay>");
+        printWriter.println("<name>" + StringUtils.formatCData(marker.getName()) + "</name>");
+        printWriter.println("<description>" + StringUtils.formatCData(marker.getDescription()) + "</description>");
+        printWriter.print("<Camera>");
+        printWriter.print("<longitude>" + marker.getLongitude() + "</longitude>");
+        printWriter.print("<latitude>" + marker.getLatitude() + "</latitude>");
+        printWriter.print("<altitude>20</altitude>");
+        printWriter.print("<heading>" + heading + "</heading>");
+        printWriter.print("<tilt>90</tilt>");
+        printWriter.println("</Camera>");
+        printWriter.println("<TimeStamp><when>" + getTime(marker.getLocation()) + "</when></TimeStamp>");
+        printWriter.println("<styleUrl>#" + MARKER_STYLE + "</styleUrl>");
+        writeCategory(marker.getCategory());
 
-            if (exportPhotos) {
-                printWriter.println("<Icon><href>" + KmzTrackExporter.buildKmzImageFilePath(marker) + "</href></Icon>");
-            }
-
-            printWriter.print("<ViewVolume>");
-            printWriter.print("<near>10</near>");
-            printWriter.print("<leftFov>-60</leftFov>");
-            printWriter.print("<rightFov>60</rightFov>");
-            printWriter.print("<bottomFov>-45</bottomFov>");
-            printWriter.print("<topFov>45</topFov>");
-            printWriter.println("</ViewVolume>");
-            printWriter.println("<Point>");
-            printWriter.println("<coordinates>" + getCoordinates(marker.getLocation(), ",") + "</coordinates>");
-            printWriter.println("</Point>");
-            printWriter.println("</PhotoOverlay>");
+        if (exportPhotos) {
+            printWriter.println("<Icon><href>" + KmzTrackExporter.buildKmzImageFilePath(marker) + "</href></Icon>");
         }
+
+        printWriter.print("<ViewVolume>");
+        printWriter.print("<near>10</near>");
+        printWriter.print("<leftFov>-60</leftFov>");
+        printWriter.print("<rightFov>60</rightFov>");
+        printWriter.print("<bottomFov>-45</bottomFov>");
+        printWriter.print("<topFov>45</topFov>");
+        printWriter.println("</ViewVolume>");
+        printWriter.println("<Point>");
+        printWriter.println("<coordinates>" + getCoordinates(marker.getLocation(), ",") + "</coordinates>");
+        printWriter.println("</Point>");
+        printWriter.println("</PhotoOverlay>");
     }
 
     /**
@@ -492,11 +462,7 @@ public class KMLTrackExporter implements TrackExporter {
      * @param location the location
      */
     private String getTime(Location location) {
-        if (exportTrackDetail) {
-            return StringUtils.formatDateTimeIso8601(Instant.ofEpochMilli(location.getTime()));
-        } else {
-            return StringUtils.formatDateTimeIso8601(Instant.ofEpochMilli(location.getTime() - startTrackPoint.getTime().toEpochMilli()));
-        }
+        return StringUtils.formatDateTimeIso8601(Instant.ofEpochMilli(location.getTime()));
     }
 
     /**
@@ -579,18 +545,5 @@ public class KMLTrackExporter implements TrackExporter {
         printWriter.println("<gx:SimpleArrayField name=\"" + name + "\" type=\"float\">");
         printWriter.println("<displayName>" + StringUtils.formatCData(extendedDataType) + "</displayName>");
         printWriter.println("</gx:SimpleArrayField>");
-    }
-
-    /**
-     * Sets a trackPoint time.
-     *
-     * @param trackPoint the trackPoint
-     * @param offset     the time offset
-     */
-    //TODO Why?
-    private void setLocationTime(TrackPoint trackPoint, Duration offset) {
-        if (trackPoint != null) {
-            trackPoint.setTime(trackPoint.getTime().minus(offset));
-        }
     }
 }


### PR DESCRIPTION
Before OSMDashboard existed, I added the functionality to only share a limited set of geo data with other applications (i.e., only coordinates; no timestamps; no markers; no track description).

All of this should not be necessary anymore (due to the existence OSMDashboard) - it is a privacy respecting map application.
No need to protect the user too much.

Thus, I propose to remove this.