### PR TITLE
Race condition fixed: deleting a recording track with post-execution on

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/AbstractTrackDeleteActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/AbstractTrackDeleteActivity.java
@@ -16,10 +16,14 @@
 
 package de.dennisguse.opentracks;
 
+import android.widget.Toast;
+
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.fragments.ConfirmDeleteDialogFragment;
@@ -70,23 +74,17 @@ public abstract class AbstractTrackDeleteActivity extends AbstractActivity imple
 
     @Override
     public void onConfirmDeleteDone(Track.Id... trackIds) {
-        boolean stopRecording = false;
+        ArrayList<Track.Id> trackIdList = new ArrayList<>(Arrays.asList(trackIds))
+                .stream().filter(trackId -> !trackId.equals(getRecordingTrackId())).collect(Collectors.toCollection(ArrayList::new));
 
         onDeleteConfirmed();
 
-        for (Track.Id trackId : trackIds) {
-            if (trackId.equals(getRecordingTrackId())) {
-                stopRecording = true;
-                break;
-            }
-        }
-
-        if (stopRecording) {
-            getTrackRecordingServiceConnection().stopRecording(this);
+        if (trackIds.length > trackIdList.size()) {
+            Toast.makeText(this, getString(R.string.track_delete_not_recording), Toast.LENGTH_LONG).show();
         }
 
         trackDeleteServiceConnection = new TrackDeleteServiceConnection(this);
-        trackDeleteServiceConnection.startAndBind(this, new ArrayList<>(Arrays.asList(trackIds)));
+        trackDeleteServiceConnection.startAndBind(this, trackIdList);
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -478,6 +478,7 @@ limitations under the License.
     <string name="track_delete_multiple_confirm_message">The selected tracks and their markers will be permanently deleted from the device.</string>
     <string name="track_delete_progress_message">Deleting&#8230;</string>
     <string name="track_delete_progress">%1$d/%2$d</string>
+    <string name="track_delete_not_recording">This track cannot be deleted as it is currently recorded.</string>
     <!-- Track Detail -->
     <string name="track_detail_chart_tab">Chart</string>
     <string name="track_detail_stats_tab">Stats</string>


### PR DESCRIPTION
**The problem**
#847 is a race condition because while is stopping the recording track is deleting it. Meanwhile post-export track is launching too.

I could reproduce it with some smartphones/emulators but not in others.

**My proposal**
I think the best option here is not delete the recording track but shows a Toast: "The recording track cannot be deleted. Stop it first."

**Link to the the issue**
#847 
