### PR TITLE
Add option to set required distance before recording a trackpoint to 0m.

### DIFF
--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -109,6 +109,7 @@
     <string name="recording_distance_interval_key" translatable="false">recordingDistanceInterval</string>
     <string name="recording_distance_interval_default" translatable="false">10</string>
     <string-array name="recording_distance_interval_values">
+        <item>0</item>
         <item>1</item>
         <item>2</item>
         <item>5</item>


### PR DESCRIPTION
Useful for testing like attitude at a static position (for EGM2008 verification).
The same behavior can actually be achieved by using a BLE sensor.

PS: The whole concept of this setting must be reworked; especially regarding altitude one might be interested in the most recent and not only the one that was stored in the db (or just store it). TrackStatistics might be different.

Used for: https://github.com/OpenTracksApp/OpenTracks/issues/850