### PR TITLE
Voice announcements: remove OpenTracks prefix.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/util/AnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/AnnouncementUtilsTest.java
@@ -47,7 +47,7 @@ public class AnnouncementUtilsTest {
         String announcement = AnnouncementUtils.getAnnouncement(context, stats, true, true, null);
 
         // then
-        assertEquals("OpenTracks total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 18.4 kilometers per hour", announcement);
+        assertEquals("total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 18.4 kilometers per hour", announcement);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class AnnouncementUtilsTest {
 
         // then
         assertEquals(
-                "OpenTracks total distance " +
+                "total distance " +
                         StringUtils.getDistanceParts(context, stats.getTotalDistance(), true).first +
                         " kilometers in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
                         StringUtils.getSpeedParts(context, stats.getAverageMovingSpeed(), true, true).first +
@@ -92,7 +92,7 @@ public class AnnouncementUtilsTest {
         String announcement = AnnouncementUtils.getAnnouncement(context, stats, true, false, null);
 
         // then
-        assertEquals("OpenTracks total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 3 minutes 15 seconds per kilometer", announcement);
+        assertEquals("total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 3 minutes 15 seconds per kilometer", announcement);
     }
 
     @Test
@@ -114,7 +114,7 @@ public class AnnouncementUtilsTest {
 
         // then
         assertEquals(
-                "OpenTracks total distance " +
+                "total distance " +
                         StringUtils.getDistanceParts(context, stats.getTotalDistance(), true).first +
                         " kilometers in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
                         buildAndGetTimeText(stats.getAverageMovingSpeed().toPace(true), true) +
@@ -137,7 +137,7 @@ public class AnnouncementUtilsTest {
         String announcement = AnnouncementUtils.getAnnouncement(context, stats, false, true, null);
 
         // then
-        assertEquals("OpenTracks total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 11.4 miles per hour", announcement);
+        assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 11.4 miles per hour", announcement);
     }
 
     @Test
@@ -159,7 +159,7 @@ public class AnnouncementUtilsTest {
 
         // then
         assertEquals(
-                "OpenTracks total distance " +
+                "total distance " +
                         StringUtils.getDistanceParts(context, stats.getTotalDistance(), false).first +
                         " miles in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
                         StringUtils.getSpeedParts(context, stats.getAverageMovingSpeed(), false, true).first +
@@ -182,7 +182,7 @@ public class AnnouncementUtilsTest {
         String announcement = AnnouncementUtils.getAnnouncement(context, stats, false, false, null);
 
         // then
-        assertEquals("OpenTracks total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile", announcement);
+        assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile", announcement);
     }
 
     @Test
@@ -203,9 +203,9 @@ public class AnnouncementUtilsTest {
         String announcement = AnnouncementUtils.getAnnouncement(context, stats, false, false, lastInterval);
 
         // then
-        //assertEquals("OpenTracks total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile Lap time of 1 minute 53 seconds per mile", announcement);
+        //assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile Lap time of 1 minute 53 seconds per mile", announcement);
         assertEquals(
-                "OpenTracks total distance " +
+                "total distance " +
                         StringUtils.getDistanceParts(context, stats.getTotalDistance(), false).first +
                         " miles in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
                         buildAndGetTimeText(stats.getAverageMovingSpeed().toPace(false), true) +

--- a/src/main/res/values-ar/strings.xml
+++ b/src/main/res/values-ar/strings.xml
@@ -364,7 +364,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s لكل كيلومتر</string>
     <string name="voice_pace_per_mile">%1$s لكل ميل</string>
-    <string name="voice_template">مساراتي‏ %1$s‏ في‏ %2$s‏ بسرعة‏ %3$s</string>
+    <string name="voice_template">%1$s‏ في‏ %2$s‏ بسرعة‏ %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="zero">المسافة الإجمالية 0 كيلومتر</item>
         <item quantity="one">المسافة الإجمالية كيلومتر واحد</item>

--- a/src/main/res/values-b+en+001/strings.xml
+++ b/src/main/res/values-b+en+001/strings.xml
@@ -291,7 +291,7 @@
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s per kilometer</string>
     <string name="voice_pace_per_mile">%1$s per mile</string>
-    <string name="voice_template">OpenTracks %1$s in %2$s at %3$s</string>
+    <string name="voice_template">%1$s in %2$s at %3$s</string>
     <string name="waypoint_type_atm">Cashpoint</string>
     <string name="waypoint_type_bank">bank</string>
     <string name="waypoint_type_bar">bar/pub</string>

--- a/src/main/res/values-b+es+419/strings.xml
+++ b/src/main/res/values-b+es+419/strings.xml
@@ -294,7 +294,7 @@
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s por kilómetro</string>
     <string name="voice_pace_per_mile">%1$s por milla</string>
-    <string name="voice_template">OpenTracks de %1$s en %2$s a %3$s</string>
+    <string name="voice_template">%1$s en %2$s a %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distancia total de 1 kilómetro</item>
         <item quantity="other">distancia total de %1$.2f kilómetros</item>

--- a/src/main/res/values-bg/strings.xml
+++ b/src/main/res/values-bg/strings.xml
@@ -342,7 +342,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s на километър</string>
     <string name="voice_pace_per_mile">%1$s на миля</string>
-    <string name="voice_template">Моите маршрути: %1$s за %2$s при %3$s</string>
+    <string name="voice_template">%1$s за %2$s при %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">общо разстояние 1 километър</item>
         <item quantity="other">общо разстояние %1$.2f километра</item>

--- a/src/main/res/values-ca/strings.xml
+++ b/src/main/res/values-ca/strings.xml
@@ -341,7 +341,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s per quilòmetre</string>
     <string name="voice_pace_per_mile">%1$s per milla</string>
-    <string name="voice_template">OpenTracks: %1$s en %2$s a %3$s</string>
+    <string name="voice_template">%1$s en %2$s a %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">1 quilòmetre de distància total</item>
         <item quantity="other">%1$.2f quilòmetres de distància total</item>

--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -414,7 +414,7 @@ Pokud zařízení GPS hlásí nepřesná data (např. Polohu, rychlost, nadmořs
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s na kilometr</string>
     <string name="voice_pace_per_mile">%1$s na míli</string>
-    <string name="voice_template">Moje trasy: %1$s za %2$s rychlostí %3$s</string>
+    <string name="voice_template">%1$s za %2$s rychlostí %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">celková vzdálenost 1 kilometr</item>
         <item quantity="few">celková vzdálenost %1$.2f kilometry</item>

--- a/src/main/res/values-da/strings.xml
+++ b/src/main/res/values-da/strings.xml
@@ -413,7 +413,7 @@ Hvis GPS-enheden rapporterer unøjagtige data (f.eks. Placering, hastighed, høj
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s pr. kilometer</string>
     <string name="voice_pace_per_mile">%1$s pr. mil</string>
-    <string name="voice_template">OpenTracks %1$s på %2$s ved %3$s</string>
+    <string name="voice_template">%1$s på %2$s ved %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">afstand i alt 1 kilometer</item>
         <item quantity="other">afstand i alt %1$.2f kilometer</item>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -419,7 +419,7 @@ g) das tun, was Deiner Meinung nach OpenTracks hilft.</string>
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s pro Kilometer</string>
     <string name="voice_pace_per_mile">%1$s pro Meile</string>
-    <string name="voice_template">Meine Tracks: %1$s in %2$s bei %3$s</string>
+    <string name="voice_template">%1$s in %2$s bei %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">Gesamtstrecke: 1 Kilometer</item>
         <item quantity="other">Gesamtstrecke: %1$.2f Kilometer</item>

--- a/src/main/res/values-el/strings.xml
+++ b/src/main/res/values-el/strings.xml
@@ -341,7 +341,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s ανά χιλιόμετρο</string>
     <string name="voice_pace_per_mile">%1$s ανά μίλι</string>
-    <string name="voice_template">Οι διαδρομές μου %1$s σε %2$s με ταχύτητα %3$s</string>
+    <string name="voice_template">%1$s σε %2$s με ταχύτητα %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">συνολική απόσταση 1 χιλιόμετρο</item>
         <item quantity="other">συνολική απόσταση %1$.2f χιλιόμετρα</item>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -409,7 +409,7 @@ Si el dispositivo GPS reporta datos inexactos (por ejemplo, ubicación, velocida
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s por kilómetro</string>
     <string name="voice_pace_per_mile">%1$s por milla</string>
-    <string name="voice_template">OpenTracks de %1$s en %2$s a %3$s</string>
+    <string name="voice_template">%1$s en %2$s a %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distancia total de 1 kilómetro</item>
         <item quantity="other">distancia total de %1$.2f kilómetros</item>

--- a/src/main/res/values-et/strings.xml
+++ b/src/main/res/values-et/strings.xml
@@ -408,7 +408,7 @@ Kui GPS-seade teatab ebatäpsetest andmetest (nt asukoht, kiirus, kõrgus), ei s
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s kilomeetri kohta</string>
     <string name="voice_pace_per_mile">%1$s miilis</string>
-    <string name="voice_template">Minu rajad %1$s ajaga %2$s ja kiirusega %3$s</string>
+    <string name="voice_template">%1$s ajaga %2$s ja kiirusega %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">kogupikkus 1 kilomeeter</item>
         <item quantity="other">kogupikkus %1$.2f kilomeetrit</item>

--- a/src/main/res/values-eu/strings.xml
+++ b/src/main/res/values-eu/strings.xml
@@ -409,7 +409,7 @@ GPS gailuak datu okerrak salatzen baditu (adibidez, kokapena, abiadura, kota), O
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s kilometro bakoitzeko</string>
     <string name="voice_pace_per_mile">%1$s miliako</string>
-    <string name="voice_template">OpenTracks. Distantzia: %1$s. Denbora: %2$s. Abiadura: %3$s</string>
+    <string name="voice_template">Distantzia: %1$s. Denbora: %2$s. Abiadura: %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distantzia, guztira: 1 kilometro</item>
         <item quantity="other">distantzia, guztira: %1$.2f kilometro</item>

--- a/src/main/res/values-fa/strings.xml
+++ b/src/main/res/values-fa/strings.xml
@@ -340,7 +340,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s در کیلومتر</string>
     <string name="voice_pace_per_mile">%1$s در مایل</string>
-    <string name="voice_template">مسیرهای من‏‏ %1$s در %2$s با %3$s</string>
+    <string name="voice_template">‏‏ %1$s در %2$s با %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">کل مسافت %1$.2f کیلومتر</item>
         <item quantity="other">کل مسافت %1$.2f کیلومتر</item>

--- a/src/main/res/values-fi/strings.xml
+++ b/src/main/res/values-fi/strings.xml
@@ -418,7 +418,7 @@ jotta ne voidaan tuoda kohteeseen %1$s.</string>
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s kilometriä kohti</string>
     <string name="voice_pace_per_mile">%1$s mailia kohti</string>
-    <string name="voice_template">Omat reitit: %1$s ajassa %2$s nopeudella %3$s</string>
+    <string name="voice_template">%1$s ajassa %2$s nopeudella %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">kokonaisetäisyys 1 kilometri</item>
         <item quantity="other">kokonaisetäisyys %1$.2f kilometriä</item>

--- a/src/main/res/values-fr-rCA/strings.xml
+++ b/src/main/res/values-fr-rCA/strings.xml
@@ -290,7 +290,7 @@
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s par kilomètre</string>
     <string name="voice_pace_per_mile">%1$s par mille</string>
-    <string name="voice_template">Mes parcours : %1$s en %2$s à %3$s</string>
+    <string name="voice_template">%1$s en %2$s à %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distance totale %1$.2f kilomètre</item>
         <item quantity="other">distance totale %1$.2f kilomètres</item>

--- a/src/main/res/values-fr-rCH/strings.xml
+++ b/src/main/res/values-fr-rCH/strings.xml
@@ -290,7 +290,7 @@
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s par kilomètre</string>
     <string name="voice_pace_per_mile">%1$s par mile</string>
-    <string name="voice_template">Mes parcours : %1$s en %2$s à %3$s</string>
+    <string name="voice_template">%1$s en %2$s à %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distance totale %1$.2f kilomètre</item>
         <item quantity="other">distance totale %1$.2f kilomètres</item>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -408,7 +408,7 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s par kilomètre</string>
     <string name="voice_pace_per_mile">%1$s par mile</string>
-    <string name="voice_template">Mes parcours : %1$s en %2$s à %3$s</string>
+    <string name="voice_template">%1$s en %2$s à %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distance totale %1$.2f kilomètre</item>
         <item quantity="other">distance totale %1$.2f kilomètres</item>

--- a/src/main/res/values-gl/strings.xml
+++ b/src/main/res/values-gl/strings.xml
@@ -426,7 +426,7 @@ Se te detés ou estás en interiores, non se gardarán datos do sensor (mais ser
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s por quilómetro</string>
     <string name="voice_pace_per_mile">%1$s por quilómetro</string>
-    <string name="voice_template">OpenTracks: %1$s en %2$s a %3$s</string>
+    <string name="voice_template">%1$s en %2$s a %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distancia total 1 quilómetro</item>
         <item quantity="other">distancia total %1$.2f quilómetros</item>

--- a/src/main/res/values-hi/strings.xml
+++ b/src/main/res/values-hi/strings.xml
@@ -340,7 +340,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s प्रति किलोमीटर</string>
     <string name="voice_pace_per_mile">%1$s प्रति मील</string>
-    <string name="voice_template">पदचिन्ह %3$s पर %2$s में %1$s</string>
+    <string name="voice_template">%3$s पर %2$s में %1$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">कुल दूरी %1$.2f किलोमीटर</item>
         <item quantity="other">कुल दूरी %1$.2f किलोमीटर</item>

--- a/src/main/res/values-hr/strings.xml
+++ b/src/main/res/values-hr/strings.xml
@@ -347,7 +347,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s po kilometru</string>
     <string name="voice_pace_per_mile">%1$s po milji</string>
-    <string name="voice_template">Moje staze %1$s za %2$s brzinom od %3$s</string>
+    <string name="voice_template">%1$s za %2$s brzinom od %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">ukupna udaljenost %1$.2f kilometar</item>
         <item quantity="few">ukupna udaljenost %1$.2f kilometra</item>

--- a/src/main/res/values-hu/strings.xml
+++ b/src/main/res/values-hu/strings.xml
@@ -342,7 +342,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s kilométerenként</string>
     <string name="voice_pace_per_mile">%1$s mérföldenként</string>
-    <string name="voice_template">Saját útvonalak: %1$s %2$s alatt %3$s sebességgel</string>
+    <string name="voice_template">%1$s %2$s alatt %3$s sebességgel</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">össztávolság: 1 kilométer</item>
         <item quantity="other">össztávolság: %1$.2f kilométer</item>

--- a/src/main/res/values-in/strings.xml
+++ b/src/main/res/values-in/strings.xml
@@ -284,7 +284,7 @@
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s per kilometer</string>
     <string name="voice_pace_per_mile">%1$s per mil</string>
-    <string name="voice_template">Lintasan Saya %1$s dalam %2$s pada kecepatan %3$s</string>
+    <string name="voice_template">%1$s dalam %2$s pada kecepatan %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="other">jarak total %1$.2f kilometer</item>
     </plurals>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -385,7 +385,7 @@ Infatti, un\'applicazione deve supportare <i>ACTION_VIEW</i> con MIME <i>applica
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s per chilometro</string>
     <string name="voice_pace_per_mile">%1$s per miglio</string>
-    <string name="voice_template">OpenTracks %1$s in %2$s a %3$s</string>
+    <string name="voice_template">%1$s in %2$s a %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distanza totale 1 chilometro</item>
         <item quantity="other">distanza totale 2 chilometri</item>

--- a/src/main/res/values-ja/strings.xml
+++ b/src/main/res/values-ja/strings.xml
@@ -335,7 +335,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">1キロあたり%1$s</string>
     <string name="voice_pace_per_mile">1マイルあたり%1$s</string>
-    <string name="voice_template">OpenTracksの記録距離は%1$s、所要時間は%2$s、ペースは%3$sです</string>
+    <string name="voice_template">の記録距離は%1$s、所要時間は%2$s、ペースは%3$sです</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="other">合計距離%1$.2fキロ</item>
     </plurals>

--- a/src/main/res/values-ko/strings.xml
+++ b/src/main/res/values-ko/strings.xml
@@ -334,7 +334,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">킬로미터 당 %1$s</string>
     <string name="voice_pace_per_mile">마일 당 %1$s</string>
-    <string name="voice_template">내 운동기록은 %1$s을(를) %2$s에 완료했으며 속도는 %3$s입니다.</string>
+    <string name="voice_template">%1$s을(를) %2$s에 완료했으며 속도는 %3$s입니다.</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="other">총 거리 %1$.2f킬로미터</item>
     </plurals>

--- a/src/main/res/values-lt/strings.xml
+++ b/src/main/res/values-lt/strings.xml
@@ -321,7 +321,7 @@ limitations under the License.
     <string name="value_smallest">Mažiausia</string>
     <string name="value_smallest_recommended">Mažiausia (rekomenduojama)</string>
     <!-- Voice -->
-    <string name="voice_template">Mano kelionės: %1$s per %2$s, %3$s greičiu</string>
+    <string name="voice_template">%1$s per %2$s, %3$s greičiu</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">bendras atstumas %1$.2f kilometras</item>
         <item quantity="few">bendras atstumas %1$.2f kilometrai</item>

--- a/src/main/res/values-mo/strings.xml
+++ b/src/main/res/values-mo/strings.xml
@@ -315,7 +315,7 @@
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s pe kilometru</string>
     <string name="voice_pace_per_mile">%1$s pe milă</string>
-    <string name="voice_template">Traseele mele %1$s în %2$s cu %3$s</string>
+    <string name="voice_template">%1$s în %2$s cu %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="zero">distanţa totală 0 kilometri</item>
         <item quantity="one">distanţa totală 1 kilometru</item>

--- a/src/main/res/values-ms/strings.xml
+++ b/src/main/res/values-ms/strings.xml
@@ -337,7 +337,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s sekilometer</string>
     <string name="voice_pace_per_mile">%1$s sejam</string>
-    <string name="voice_template">Laluan Saya %1$s dalam %2$s pada %3$s</string>
+    <string name="voice_template">%1$s dalam %2$s pada %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">jumlah jarak 1 kilometer</item>
         <item quantity="other">jumlah jarak %1$.2f kilometer</item>

--- a/src/main/res/values-nb/strings.xml
+++ b/src/main/res/values-nb/strings.xml
@@ -342,7 +342,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s per kilometer</string>
     <string name="voice_pace_per_mile">%1$s per engelsk mil</string>
-    <string name="voice_template">OpenTracks %1$s på %2$s med %3$s</string>
+    <string name="voice_template">%1$s på %2$s med %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">total distanse 1 kilometer</item>
         <item quantity="other">total distanse %1$.2f kilometer</item>

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -408,7 +408,7 @@ Als het GPS-apparaat onnauwkeurige gegevens rapporteert (bijv. locatie, snelheid
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s te kilometer</string>
     <string name="voice_pace_per_mile">%1$s per mijl</string>
-    <string name="voice_template">Mijn routes %1$s in %2$s bij %3$s</string>
+    <string name="voice_template">%1$s in %2$s bij %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">totale afstand 1 kilometer</item>
         <item quantity="other">totale afstand %1$.2f kilometer</item>

--- a/src/main/res/values-pl/strings.xml
+++ b/src/main/res/values-pl/strings.xml
@@ -391,7 +391,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s na kilometr</string>
     <string name="voice_pace_per_mile">%1$s na milę</string>
-    <string name="voice_template">Aktualna trasa: %1$s w czasie %2$s z prędkością %3$s</string>
+    <string name="voice_template">%1$s w czasie %2$s z prędkością %3$s</string>
     <string name="voice_speed_lap">Prędkosć w interwale %1$s</string>
     <string name="voice_pace_lap">Czas w interwale %1$s</string>
     <plurals name="voiceTotalDistanceKilometers">

--- a/src/main/res/values-pt-rBR/strings.xml
+++ b/src/main/res/values-pt-rBR/strings.xml
@@ -285,7 +285,7 @@
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s por quilômetro</string>
     <string name="voice_pace_per_mile">%1$s por milha</string>
-    <string name="voice_template">Minhas trilhas, %1$s em %2$s a %3$s</string>
+    <string name="voice_template">%1$s em %2$s a %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distância total %1$.2f quilômetro</item>
         <item quantity="other">distância total de %1$.2f quilómetros</item>

--- a/src/main/res/values-pt-rPT/strings.xml
+++ b/src/main/res/values-pt-rPT/strings.xml
@@ -290,7 +290,7 @@
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s por quilômetro</string>
     <string name="voice_pace_per_mile">%1$s por milha</string>
-    <string name="voice_template">Os Meus Percursos %1$s em %2$s a %3$s</string>
+    <string name="voice_template">%1$s em %2$s a %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distância total %1$.2f quilômetro</item>
         <item quantity="other">distância total de %1$.2f quilómetros</item>

--- a/src/main/res/values-pt/strings.xml
+++ b/src/main/res/values-pt/strings.xml
@@ -342,7 +342,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s por quilômetro</string>
     <string name="voice_pace_per_mile">%1$s por milha</string>
-    <string name="voice_template">Minhas trilhas, %1$s em %2$s a %3$s</string>
+    <string name="voice_template">%1$s em %2$s a %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distância total %1$.2f quilômetro</item>
         <item quantity="other">distância total de %1$.2f quilómetros</item>

--- a/src/main/res/values-ro/strings.xml
+++ b/src/main/res/values-ro/strings.xml
@@ -346,7 +346,7 @@ limitations under the License.
         <item quantity="other">%1$.1f (de) mile pe oră</item>
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s pe kilometru</string>
-    <string name="voice_template">Traseele mele %1$s în %2$s cu %3$s</string>
+    <string name="voice_template">%1$s în %2$s cu %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">distanţa totală 1 kilometru</item>
         <item quantity="few">distanţa totală %1$.2f kilometri</item>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -353,7 +353,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s на километр</string>
     <string name="voice_pace_per_mile">%1$s на милю</string>
-    <string name="voice_template">Длина треков: %1$s за %2$s (%3$s)</string>
+    <string name="voice_template">%1$s за %2$s (%3$s)</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">Общая длина: %1$.2f километр</item>
         <item quantity="few">Общая длина: %1$.2f километра</item>

--- a/src/main/res/values-sk/strings.xml
+++ b/src/main/res/values-sk/strings.xml
@@ -346,7 +346,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s na kilometer</string>
     <string name="voice_pace_per_mile">%1$s na míľu</string>
-    <string name="voice_template">Moje trasy %1$s, čas %2$s, rýchlosť %3$s</string>
+    <string name="voice_template">%1$s, čas %2$s, rýchlosť %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">celková vzdialenosť 1 kilometer</item>
         <item quantity="few">celková vzdialenosť %1$.2f kilometra</item>

--- a/src/main/res/values-sl/strings.xml
+++ b/src/main/res/values-sl/strings.xml
@@ -352,7 +352,7 @@ limitations under the License.
         <item quantity="other">%1$.1f milj na uro</item>
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s na kilometer</string>
-    <string name="voice_template">Moje poti %1$s v %2$s pri %3$s</string>
+    <string name="voice_template">%1$s v %2$s pri %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">skupna razdalja %1$.2f kilometer</item>
         <item quantity="two">skupna razdalja %1$.2f kilometra</item>

--- a/src/main/res/values-sv/strings.xml
+++ b/src/main/res/values-sv/strings.xml
@@ -340,7 +340,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s per kilometer</string>
     <string name="voice_pace_per_mile">%1$s per mile</string>
-    <string name="voice_template">OpenTracks %1$s på %2$s med %3$s</string>
+    <string name="voice_template">%1$s på %2$s med %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">totalt avstånd 1 kilometer</item>
         <item quantity="other">totalt avstånd %1$.2f kilometer</item>

--- a/src/main/res/values-th/strings.xml
+++ b/src/main/res/values-th/strings.xml
@@ -334,7 +334,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s ต่อกิโลเมตร</string>
     <string name="voice_pace_per_mile">%1$s ต่อไมล์</string>
-    <string name="voice_template">เส้นการเดินทางของฉันเป็นระยะ %1$s ใน %2$s ที่ความเร็ว %3$s</string>
+    <string name="voice_template">%1$s ใน %2$s ที่ความเร็ว %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="other">รวมระยะทาง %1$.2f กิโลเมตร</item>
     </plurals>

--- a/src/main/res/values-tl/strings.xml
+++ b/src/main/res/values-tl/strings.xml
@@ -340,7 +340,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s bawat kilometro</string>
     <string name="voice_pace_per_mile">%1$s bawat milya</string>
-    <string name="voice_template">OpenTracks %1$s sa %2$s sa %3$s</string>
+    <string name="voice_template">%1$s sa %2$s sa %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">kabuuang distansya %1$.2f kilometro</item>
         <item quantity="other">kabuuang distansya %1$.2f (na) kilometro</item>

--- a/src/main/res/values-tr/strings.xml
+++ b/src/main/res/values-tr/strings.xml
@@ -341,7 +341,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">kilometrede %1$s</string>
     <string name="voice_pace_per_mile">milde %1$s</string>
-    <string name="voice_template">OpenTracks %3$s hızla %2$s sürede %1$s mesafe</string>
+    <string name="voice_template">%3$s hızla %2$s sürede %1$s mesafe</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">toplam mesafe 1 kilometre</item>
         <item quantity="other">toplam mesafe %1$.2f kilometre</item>

--- a/src/main/res/values-uk/strings.xml
+++ b/src/main/res/values-uk/strings.xml
@@ -354,7 +354,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s на кілометр</string>
     <string name="voice_pace_per_mile">%1$s на милю</string>
-    <string name="voice_template">Подолано %1$s за %2$s (зі швидкістю %3$s)</string>
+    <string name="voice_template">%1$s за %2$s (зі швидкістю %3$s)</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">загальна відстань: %1$.2f кілометр</item>
         <item quantity="few">загальна відстань: %1$.2f км</item>

--- a/src/main/res/values-vi/strings.xml
+++ b/src/main/res/values-vi/strings.xml
@@ -336,7 +336,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s mỗi ki lô mét</string>
     <string name="voice_pace_per_mile">%1$s mỗi dặm</string>
-    <string name="voice_template">Tuyến đường của tôi là %1$s trong %2$s tại %3$s</string>
+    <string name="voice_template">%1$s trong %2$s tại %3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="other">tổng khoảng cách là %1$.2f ki lô mét</item>
     </plurals>

--- a/src/main/res/values-zh-rHK/strings.xml
+++ b/src/main/res/values-zh-rHK/strings.xml
@@ -285,7 +285,7 @@
     </plurals>
     <string name="voice_pace_per_kilometer">每小時 %1$s 英里</string>
     <string name="voice_pace_per_mile">每英里 %1$s</string>
-    <string name="voice_template">我的足跡：%1$s (時間：%2$s，速度：%3$s)。</string>
+    <string name="voice_template">%1$s (時間：%2$s，速度：%3$s)。</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="other">總距離 %1$.2f 公里</item>
     </plurals>

--- a/src/main/res/values-zh-rTW/strings.xml
+++ b/src/main/res/values-zh-rTW/strings.xml
@@ -285,7 +285,7 @@
     </plurals>
     <string name="voice_pace_per_kilometer">每小時 %1$s 英里</string>
     <string name="voice_pace_per_mile">每英里 %1$s</string>
-    <string name="voice_template">我的足跡：%1$s (時間：%2$s，速度：%3$s)。</string>
+    <string name="voice_template">%1$s (時間：%2$s，速度：%3$s)。</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="other">總距離 %1$.2f 公里</item>
     </plurals>

--- a/src/main/res/values-zh/strings.xml
+++ b/src/main/res/values-zh/strings.xml
@@ -353,7 +353,7 @@ limitations under the License.
         <item quantity="other">每小时 %1$.1f 英里</item>
     </plurals>
     <string name="voice_pace_per_kilometer">每公里 %1$s</string>
-    <string name="voice_template">“我的足迹”距离：%1$s；时间：%2$s；速度：%3$s</string>
+    <string name="voice_template">%1$s；时间：%2$s；速度：%3$s</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="other">总距离 %1$.2f 公里</item>
     </plurals>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -512,7 +512,7 @@ limitations under the License.
     </plurals>
     <string name="voice_pace_per_kilometer">%1$s per kilometer</string>
     <string name="voice_pace_per_mile">%1$s per mile</string>
-    <string name="voice_template">OpenTracks %1$s in %2$s at %3$s</string>
+    <string name="voice_template">%1$s in %2$s at %3$s</string>
     <string name="voice_speed_lap">Lap speed of %1$s</string>
     <string name="voice_pace_lap">Lap time of %1$s</string>
     <plurals name="voiceTotalDistanceKilometers">


### PR DESCRIPTION
The voice announcements were prefixed with OpenTracks (sometimes still the localized MyTracks name).
So, let's remove it - and it should not be that helpful.