### PR TITLE
Using Zulu builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: '11'
 
       - run: ./gradlew lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: '11'
 
       - name: run tests


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu OpenJDK builds gets you all the latest and greatest (TCK Tested) builds for all versions of OpenJDK.

https://adoptopenjdk.net 

"24th July 2021: AdoptOpenJDK is moving to the Eclipse Foundation and rebranding.
Our July 2021 and future releases will come from Adoptium.net"