### PR TITLE
Set FLAG_IMMUTABLE for PendingIntents

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -384,10 +384,15 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         if (isRecording()) {
             Intent intent = IntentUtils.newIntent(this, TrackRecordingActivity.class)
                     .putExtra(TrackRecordingActivity.EXTRA_TRACK_ID, recordingStatus.getTrackId());
+
+            int pendingIntentFlags = PendingIntent.FLAG_UPDATE_CURRENT;
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                pendingIntentFlags |= PendingIntent.FLAG_IMMUTABLE;
+            }
             PendingIntent pendingIntent = TaskStackBuilder.create(this)
                     .addParentStack(TrackRecordingActivity.class)
                     .addNextIntent(intent)
-                    .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+                    .getPendingIntent(0, pendingIntentFlags);
 
             notificationManager.updatePendingIntent(pendingIntent);
             notificationManager.updateContent(getString(R.string.gps_starting));
@@ -395,9 +400,14 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         }
         if (!isRecording() && isGpsStarted) {
             Intent intent = IntentUtils.newIntent(this, TrackListActivity.class);
+
+            int pendingIntentFlags = 0;
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                pendingIntentFlags = PendingIntent.FLAG_IMMUTABLE;
+            }
             PendingIntent pendingIntent = TaskStackBuilder.create(this)
                     .addNextIntent(intent)
-                    .getPendingIntent(0, 0);
+                    .getPendingIntent(0, pendingIntentFlags);
 
             notificationManager.updatePendingIntent(pendingIntent);
             notificationManager.updateContent(getString(R.string.gps_starting));


### PR DESCRIPTION
**Describe the pull request**
This PR fixes a crash on Android 12, since it explicitly requires setting either FLAG_MUTABLE or FLAG_IMMUTABLE. This requirement is documented here: https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability

(Tested in an Android 12 AVD and on a Pixel 4a running Android 12)

**Link to the the issue**
(If available): N/A

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
