### PR TITLE
GPX importer supports speed without namespace (compatibility with other tools)

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/GPXImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/GPXImportTest.java
@@ -158,4 +158,54 @@ public class GPXImportTest {
                         .setSpeed(Speed.of(0.7224021553993225))
         ), importedTrackPoints);
     }
+
+    @LargeTest
+    @Test
+    public void gpx_speed_no_namespace() throws IOException {
+        // given
+        XMLImporter importer = new XMLImporter(new GpxTrackImporter(context, trackImporter));
+        InputStream inputStream = InstrumentationRegistry.getInstrumentation().getContext().getResources().openRawResource(de.dennisguse.opentracks.debug.test.R.raw.gpx11_with_speed_no_namespace);
+
+        // when
+        // 1. import
+        importTrackId = importer.importFile(inputStream).get(0);
+
+        // then
+        // 2. track
+        Track importedTrack = contentProviderUtils.getTrack(importTrackId);
+        assertNotNull(importedTrack);
+        assertEquals("", importedTrack.getCategory());
+        assertEquals("", importedTrack.getDescription());
+        assertEquals("20210907_213924.gpx", importedTrack.getName());
+        assertEquals("", importedTrack.getIcon());
+
+        // 3. trackstatistics
+        TrackStatistics trackStatistics = importedTrack.getTrackStatistics();
+        assertEquals(4, trackStatistics.getMaxSpeed().toMPS(), 0.01);
+        assertEquals(Duration.ofSeconds(101), trackStatistics.getMovingTime());
+
+        // 4. trackpoints
+        List<TrackPoint> importedTrackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, importTrackId);
+        assertEquals(3, importedTrackPoints.size());
+
+        TrackPointAssert a = new TrackPointAssert();
+        a.assertEquals(List.of(
+                new TrackPoint(TrackPoint.Type.SEGMENT_START_AUTOMATIC, Instant.parse("2021-09-07T22:10:19Z"))
+                        .setLatitude(30.14185982)
+                        .setLongitude(-40.3863038)
+                        .setAltitude(-5)
+                        .setSpeed(Speed.of(5)),
+                new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.parse("2021-09-07T22:11:07Z"))
+                        .setLatitude(30.14184657)
+                        .setLongitude(-40.38670089)
+                        .setAltitude(-5)
+                        .setSpeed(Speed.of(0.7976524233818054))
+                        .setSpeed(Speed.of(4)),
+                new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.parse("2021-09-07T22:12:00Z"))
+                        .setLatitude(30.14185982)
+                        .setLongitude(-40.3863038)
+                        .setAltitude(-5)
+                        .setSpeed(Speed.of(3))
+        ), importedTrackPoints);
+    }
 }

--- a/src/androidTest/res/raw/gpx11_with_speed_no_namespace.gpx
+++ b/src/androidTest/res/raw/gpx11_with_speed_no_namespace.gpx
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="Cruiser" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+  <trk>
+    <name>20210907_213924.gpx</name>
+    <trkseg>
+      <trkpt lat="30.14185982" lon="-40.3863038">
+        <ele>-5</ele>
+        <time>2021-09-07T22:10:19Z</time>
+        <hdop>4</hdop>
+        <speed>5</speed>
+      </trkpt>
+      <trkpt lat="30.14184657" lon="-40.38670089">
+        <ele>-5</ele>
+        <time>2021-09-07T22:11:07Z</time>
+        <hdop>4</hdop>
+        <speed>4</speed>
+      </trkpt>
+      <trkpt lat="30.14185982" lon="-40.3863038">
+        <ele>-5</ele>
+        <time>2021-09-07T22:12:00Z</time>
+        <hdop>4</hdop>
+        <speed>3</speed>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxTrackImporter.java
@@ -70,6 +70,10 @@ public class GpxTrackImporter extends DefaultHandler implements XMLImporter.Trac
     private static final String ATTRIBUTE_LON = "lon";
 
     private static final String TAG_EXTENSION_SPEED = "gpxtpx:speed";
+    /**
+     * Often speed is exported without the proper namespace.
+     */
+    private static final String TAG_EXTENSION_SPEED_COMPAT = "speed";
     private static final String TAG_EXTENSION_HEARTRATE = "gpxtpx:hr";
     private static final String TAG_EXTENSION_CADENCE = "gpxtpx:cad";
     private static final String TAG_EXTENSION_POWER = "pwr:PowerInWatts";
@@ -192,6 +196,7 @@ public class GpxTrackImporter extends DefaultHandler implements XMLImporter.Trac
                 }
                 break;
             case TAG_EXTENSION_SPEED:
+            case TAG_EXTENSION_SPEED_COMPAT:
                 if (content != null) {
                     speed = content.trim();
                 }


### PR DESCRIPTION
Includes a test.

Fixed #774.
