### PR TITLE
Intervals crashed when gain != null and loss == null

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/IntervalStatistics.java
@@ -163,8 +163,13 @@ public class IntervalStatistics {
             time = time.plus(trackStatistics.getTotalTime());
             gain_m = trackStatistics.hasTotalAltitudeGain() ? trackStatistics.getTotalAltitudeGain() : gain_m;
             loss_m = trackStatistics.hasTotalAltitudeLoss() ? trackStatistics.getTotalAltitudeLoss() : loss_m;
-            if (hasGain() && lastTrackPoint != null && lastTrackPoint.hasAltitudeGain()) {
+            if (lastTrackPoint == null) {
+                return;
+            }
+            if (hasGain() && lastTrackPoint.hasAltitudeGain()) {
                 gain_m = gain_m - lastTrackPoint.getAltitudeGain();
+            }
+            if (hasLoss() && lastTrackPoint.hasAltitudeLoss()) {
                 loss_m = loss_m - lastTrackPoint.getAltitudeLoss();
             }
         }


### PR DESCRIPTION
The changes explain themself.

I also changed tests so I hope this bug won't appear again.

PD/ This crash is only launch for old imported tracks where there are not loss information (when we only calculated gain but not loss).

PD1/ Special mention to @FTno who discovered it.