### PR TITLE
UI: Remove "Sensor:" prefix from speed description.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/viewmodels/StatisticDataBuilder.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/StatisticDataBuilder.java
@@ -60,7 +60,7 @@ public class StatisticDataBuilder {
 
             if (sensorDataSet != null && sensorDataSet.getSpeed() != null) {
                 valueAndUnit = StringUtils.getSpeedParts(context, sensorDataSet.getSpeed().first, metricUnits, reportSpeed);
-                description = context.getString(R.string.description_speed_source_sensor, sensorDataSet.getSpeed().second);
+                description = sensorDataSet.getSpeed().second;
             } else {
                 Speed speed = latestTrackPoint != null && latestTrackPoint.hasSpeed() ? latestTrackPoint.getSpeed() : null;
                 valueAndUnit = StringUtils.getSpeedParts(context, speed, metricUnits, reportSpeed);

--- a/src/main/res/values-b+es+419/strings.xml
+++ b/src/main/res/values-b+es+419/strings.xml
@@ -472,7 +472,6 @@
     <string name="settings_sensor_running_speed_and_cadence">Correr: Distancia, velocidad y cadencia</string>
     <string name="stats_coordinates">Latitud/Longitud</string>
     <string name="location_coordinate">%1$s°</string>
-    <string name="description_speed_source_sensor">Sensor: %1$s</string>
     <string name="title_activity_settings_custom_layout">Personalizar distribución de grabación</string>
     <string name="generic_choose_an_option">Selecciona una opción</string>
     <string name="settings_sensor_cycling_distance_speed">Ciclismo: Distancia y velocidad</string>

--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -532,7 +532,6 @@ limitations under the License.
     <string name="settings_layout_reset_done">Všechna nastavení vzhledu byla vrácena na výchozí hodnoty</string>
     <string name="stats_coordinates">Zeměpisná šířka a délka</string>
     <string name="stats_sensors_cadence">Kadence</string>
-    <string name="description_speed_source_sensor">Senzor: %1$s</string>
     <string name="description_speed_source_gps">GPS</string>
     <string name="generic_choose_an_option">Zvolit možnost</string>
     <string name="permission_bluetooth_failed">OpenTracks vyžaduje povolení k používání Bluetoothu.</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -526,7 +526,6 @@ Si el dispositivo GPS reporta datos inexactos (por ejemplo, ubicación, velocida
     <string name="location_coordinate">%1$s°</string>
     <string name="location_latitude_longitude">%1$s, %2$s</string>
     <string name="field_remove_from_layout">Remover</string>
-    <string name="description_speed_source_sensor">Sensor: %1$s</string>
     <string name="generic_choose_an_option">Seleccione una opción</string>
     <string name="settings_layout_reset">Restabecer pantalla personalizada</string>
     <string name="stats_coordinates">Latitud/Longitud</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -514,7 +514,6 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
     <string name="stats_coordinates">Latitude/Longitude</string>
     <string name="field_set_secondary">Secondaire</string>
     <string name="field_remove_from_layout">Retirer</string>
-    <string name="description_speed_source_sensor">Capteur : %1$s</string>
     <string name="description_speed_source_gps">GPS</string>
     <string name="generic_choose_an_option">Choisissez une option</string>
     <string name="stats_sensors_heart_rate">Fréquence cardiaque</string>

--- a/src/main/res/values-gl/strings.xml
+++ b/src/main/res/values-gl/strings.xml
@@ -515,7 +515,6 @@ Se te detés ou estás en interiores, non se gardarán datos do sensor (mais ser
     <string name="settings_sensor_cycling_distance_speed">Distancia e Velocidade</string>
     <string name="settings_sensor_cycling_cadence">Cadencia</string>
     <string name="settings_sensor_running_speed_and_cadence">Distancia, Velocidade e Cadencia</string>
-    <string name="description_speed_source_sensor">Sensor: %1$s</string>
     <string name="settings_recording_customize_layout_title">Personaliza a disposición da gravación</string>
     <string name="settings_layout_reset_confirm_message">Os axustes da disposición volverán aos valores por defecto. Esto non eliminará as rutas no dispositivo.</string>
     <string name="stats_coordinates">Latitude/Lonxitude</string>

--- a/src/main/res/values-nb/strings.xml
+++ b/src/main/res/values-nb/strings.xml
@@ -503,7 +503,6 @@ limitations under the License.
     <string name="settings_sensor_cycling_cadence">Kadens</string>
     <string name="settings_sensor_cycling_distance_speed">Distanse og hastighet</string>
     <string name="settings_sensor_running_speed_and_cadence">Distanse, hastighet og kadens</string>
-    <string name="description_speed_source_sensor">Sensor: %1$s</string>
     <string name="settings_recording_customize_layout_title">Tilpass opptakslayouten</string>
     <string name="settings_layout_reset_confirm_message">Alle layoutinnstillinger blir tilbakestilt til standardverdiene. Dette vil ikke slette spor på enheten.</string>
     <string name="stats_coordinates">Breddegrad/Lengdegrad</string>

--- a/src/main/res/values-pt-rBR/strings.xml
+++ b/src/main/res/values-pt-rBR/strings.xml
@@ -455,7 +455,6 @@
     <string name="settings_sensor_cycling_distance_speed">Distância e velocidade</string>
     <string name="settings_sensor_running_speed_and_cadence">Distância, velocidade e cadência</string>
     <string name="stats_sensors_cadence">Cadência</string>
-    <string name="description_speed_source_sensor">Sensores: %1$s</string>
     <string name="description_speed_source_gps">GPS</string>
     <string name="settings_recording_customize_layout_title">Personalize seu layout de gravação</string>
     <string name="settings_recording_customize_layout_select_columns">Campos de dados por linha</string>

--- a/src/main/res/values-vi/strings.xml
+++ b/src/main/res/values-vi/strings.xml
@@ -510,7 +510,6 @@ limitations under the License.
     <string name="track_delete_progress">%1$d/%2$d</string>
     <string name="settings_recording_keep_screen_on_while_recording_title">Giữ trên màn hình</string>
     <string name="bluetooth_disabled">Xin vui lòng cho phép Bluetooth.</string>
-    <string name="description_speed_source_sensor">Cảm biến: %1$s</string>
     <string name="sensor_state_cadence_avg">Nhịp trung bình</string>
     <string name="sensor_state_cadence_max">Nhịp tối đa</string>
     <string name="sensor_state_heart_rate_avg">Nhịp tim trung bình</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -196,7 +196,6 @@ limitations under the License.
     <string name="description_time">Time</string>
     <string name="description_total_distance">Total distance: %1$.2f km (%2$.1f mi)</string>
     <string name="description_total_time">Total time: %1$s</string>
-    <string name="description_speed_source_sensor">Sensor: %1$s</string>
     <string name="description_speed_source_gps">GPS</string>
     <!-- Export -->
     <string name="export_with_photos">with photos</string>


### PR DESCRIPTION
While working on the sensor stuff, I noticed that for speed, we put "Sensor: " in front of the name while for the other sensors, we don't do this.