### PR TITLE
Set distinct versionCode and name for nightlies

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -29,6 +29,6 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: OpenTracks-nightly.apk
-          path: ./build/outputs/apk/nightly/OpenTracks-nightly.apk
+          path: ./build/outputs/apk/nightly/*.apk
           retention-days: 7
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,12 @@ def getVersionName = { ->
     }
 }
 
+def versionCodeFromDate = { ->
+    def date = new Date()
+    def formattedDate = date.format('yyyyMMdd')
+    return Integer.valueOf(formattedDate)
+}
+
 android {
     compileOptions {
         coreLibraryDesugaringEnabled true
@@ -41,7 +47,7 @@ android {
     compileSdkVersion 31
 
     buildFeatures {
-        viewBinding = true
+        viewBinding true
     }
 
     aaptOptions {
@@ -82,7 +88,6 @@ android {
         nightly {
             signingConfig signingConfigs.nightly
             applicationIdSuffix ".nightly"
-            versionNameSuffix "-nightly"
         }
 
         release {
@@ -97,6 +102,14 @@ android {
 
     applicationVariants.all { variant ->
         variant.resValue "string", "applicationId", variant.applicationId
+
+        if (variant.buildType.name == 'nightly') {
+            variant.outputs.all {
+                setVersionCodeOverride(versionCodeFromDate())
+                setVersionNameOverride(getVersionName())
+                outputFileName = "${applicationId}_${variant.versionCode}.apk"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I'm experimenting with my own fdroid repository: https://fdroid.storchp.de/fdroid/repo

Currently it's all manually build and an apk only repository. But one can add it to the F-Droid client and would receive updates for nightlies. This needs to be automated and metadata be added.

What we also need is a nightly distinct versionCode and apk name. That's the reason for this PullRequest. I set the versionCode to the current date in the format YYYYMMDD and the apk filename to applicationId + _ + versionCode.

Probably the GitHub action need to be adjusted as well.

For #952 

@dennisguse what do you think?