### PR TITLE
Bugfix: running sensor data total is distance is UINT_32.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/util/BluetoothUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/BluetoothUtilsTest.java
@@ -93,8 +93,8 @@ public class BluetoothUtilsTest {
 
     @Test
     public void parseRunningSpeedAndCadence_with_distance() {
-        BluetoothGattCharacteristic characteristic = new BluetoothGattCharacteristic(BluetoothUtils.CYCLING_SPEED_CADENCE_MEASUREMENT_CHAR_UUID, 0, 0);
-        characteristic.setValue(new byte[]{2, 0, 5, 80, 12, 1});
+        BluetoothGattCharacteristic characteristic = new BluetoothGattCharacteristic(BluetoothUtils.RUNNING_RUNNING_SPEED_CADENCE_CHAR_UUID, 0, 0);
+        characteristic.setValue(new byte[]{2, 0, 5, 80, (byte) 0xFF, (byte) 0xFF, 0, 1});
 
         // when
         SensorDataRunning sensor = BluetoothUtils.parseRunningSpeedAndCadence("address", "sensorName", characteristic);
@@ -102,6 +102,6 @@ public class BluetoothUtilsTest {
         // then
         assertEquals(Speed.of(5), sensor.getSpeed());
         assertEquals(80, sensor.getCadence(), 0.01);
-        assertEquals(Distance.of(26.8), sensor.getTotalDistance());
+        assertEquals(Distance.of(6553.5 + 1677721.6), sensor.getTotalDistance());
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/util/BluetoothUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/BluetoothUtils.java
@@ -175,8 +175,8 @@ public class BluetoothUtils {
             index += 2;
         }
 
-        if (hasTotalDistance && valueLength - index >= 2) {
-            totalDistance = Distance.ofDM(characteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT16, index));
+        if (hasTotalDistance && valueLength - index >= 4) {
+            totalDistance = Distance.ofDM(characteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT32, index));
         }
 
         return new SensorDataRunning(address, sensorName, speed, cadence, totalDistance);


### PR DESCRIPTION
End of cycling season and I started running again using a shoe-based running sensor.
... and reported distance got negative happened 2 or 3 times.
And today, I checked the parsing code and is an overflow that happened every 6.5km (UINT16 in decimeter).
But it should be a UINT32 :/