### PR TITLE
Change versionCode for nightlies to commit count

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,17 @@ def getVersionName = { ->
     }
 }
 
-def versionCodeFromDate = { ->
-    def date = new Date()
-    def formattedDate = date.format('yyyyMMdd')
-    return Integer.valueOf(formattedDate)
+def getVersionCode = { ->
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'rev-list', 'HEAD', '--count'
+            standardOutput = stdout
+        }
+        return Integer.valueOf(stdout.toString().trim())
+    } catch (ignored) {
+        return null
+    }
 }
 
 android {
@@ -105,7 +112,7 @@ android {
 
         if (variant.buildType.name == 'nightly') {
             variant.outputs.all {
-                setVersionCodeOverride(versionCodeFromDate())
+                setVersionCodeOverride(getVersionCode())
                 setVersionNameOverride(getVersionName())
                 outputFileName = "${applicationId}_${variant.versionCode}.apk"
             }


### PR DESCRIPTION
As suggested in https://github.com/OpenTracksApp/opentracksapp.github.io/pull/8#issuecomment-974642302

When this change gets merged, user who already use the nightlies from the repo need to uninstall once manually because the old versionCode scheme has a much higher number. Otherwise one would never see updates. But I guess we can communicate that, right?