### PR TITLE
Storing data without GPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ _OpenTracks_ is a sport tracking application that completely respects your priva
 * __Photos and Markers:__ mark interesting locations while tracking
 * __Export:__
   * export tracks either as KMZ (incl. photos), KML, or GPX
-  * export automatically after each recording (e.g., to sync)
+  * export automatically after each recording (e.g., to sync via [Nextcloud](https://nextcloud.com/))
   * avoid duplication: each exported file contain a random unique identifier (i.e., `opentracks:trackid`)
 * __Altitude:__
   * gain/loss via barometric sensor (if present)
@@ -89,6 +89,8 @@ _OpenTracks_ is a sport tracking application that completely respects your priva
   * cycling: cadence
   * cycling: power meter
   * running: speed and cadence
+  * support for BLE sensor training only (i.e., without GPS) for indoor training
+
   An overview of tested sensors: [README_TESTED_SENSORS.md](README_TESTED_SENSORS.md)
 
 ### Gadgetbridge integration

--- a/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/provider/CustomContentProviderUtilsTest.java
@@ -15,6 +15,13 @@
  */
 package de.dennisguse.opentracks.content.provider;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
@@ -56,13 +63,6 @@ import de.dennisguse.opentracks.stats.SensorStatistics;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.util.FileUtils;
 import de.dennisguse.opentracks.util.UUIDUtils;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 /**
  * A unit test for {@link ContentProviderUtils}.
@@ -220,6 +220,8 @@ public class CustomContentProviderUtilsTest {
         assertEquals(0, tracksPointsCursor.getCount());
         markerCursor = contentResolver.query(MarkerColumns.CONTENT_URI, null, null, null, MarkerColumns._ID);
         assertEquals(0, markerCursor.getCount());
+
+        //TODO Close all cursors
     }
 
     /**

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -423,6 +423,6 @@ public class ExportImportTest {
         });
 
         trackPointCreator.setClock(Clock.fixed(time, ZoneId.of("CET")));
-        trackPointCreator.getLocationHandler().onLocationChanged(location);
+        trackPointCreator.getGpsHandler().onLocationChanged(location);
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTest.java
@@ -111,11 +111,6 @@ public class TrackRecordingServiceTest {
 
     @Before
     public void setUp() {
-        // Set up the mock content resolver
-        ContentProvider customContentProvider = new CustomContentProvider() {
-        };
-        customContentProvider.attachInfo(context, null);
-
         contentProviderUtils = new ContentProviderUtils(context);
 
         // Let's use default values.
@@ -249,6 +244,7 @@ public class TrackRecordingServiceTest {
         // when
         trackPointCreator.setClock(Clock.fixed(Instant.parse("2020-02-02T02:02:03Z"), ZoneId.of("CET")));
         service.pauseCurrentTrack();
+        service.stopUpdateRecordingData();
 
         // then
         assertEquals(2, contentProviderUtils.getTrackPointCursor(trackId, null).getCount());
@@ -256,6 +252,7 @@ public class TrackRecordingServiceTest {
         //when
         trackPointCreator.setClock(Clock.fixed(Instant.parse("2020-02-02T02:02:04Z"), ZoneId.of("CET")));
         service.resumeTrack(trackId);
+        service.stopUpdateRecordingData();
 
         // then
         assertTrue(service.isRecording());

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTest.java
@@ -211,6 +211,7 @@ public class TrackRecordingServiceTest {
 
         trackPointCreator.setClock(Clock.fixed(Instant.parse("2020-02-02T02:02:02Z"), ZoneId.of("CET")));
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         trackPointCreator.stopGPS();
         trackPointCreator.setAltitudeSumManager(altitudeSumManager);
 
@@ -241,6 +242,7 @@ public class TrackRecordingServiceTest {
 
         trackPointCreator.setClock(Clock.fixed(Instant.parse("2020-02-02T02:02:02Z"), ZoneId.of("CET")));
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         trackPointCreator.stopGPS();
         trackPointCreator.setAltitudeSumManager(altitudeSumManager);
 
@@ -280,6 +282,7 @@ public class TrackRecordingServiceTest {
 
         trackPointCreator.setClock(Clock.fixed(Instant.parse("2020-02-02T02:02:02Z"), ZoneId.of("CET")));
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         trackPointCreator.stopGPS();
         trackPointCreator.setAltitudeSumManager(altitudeSumManager);
 
@@ -322,6 +325,7 @@ public class TrackRecordingServiceTest {
 
         trackPointCreator.setClock(Clock.fixed(Instant.parse("2020-02-02T02:02:02Z"), ZoneId.of("CET")));
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         trackPointCreator.stopGPS();
         trackPointCreator.setAltitudeSumManager(altitudeSumManager);
 
@@ -352,10 +356,13 @@ public class TrackRecordingServiceTest {
         TrackRecordingService service = ((TrackRecordingService.Binder) mServiceRule.bindService(createStartIntent(context)))
                 .getService();
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
+
         assertTrue(service.isRecording());
 
         // when
         Track.Id newTrackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
 
         // then
         assertNotNull(trackId);
@@ -405,6 +412,7 @@ public class TrackRecordingServiceTest {
 
         trackPointCreator.setClock(Clock.fixed(Instant.parse("2020-02-02T02:02:02Z"), ZoneId.of("CET")));
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
 
         assertTrue(service.isRecording());
         trackPointCreator.onNewTrackPoint(

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLocation.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLocation.java
@@ -2,7 +2,6 @@ package de.dennisguse.opentracks.services;
 
 import static org.junit.Assert.assertFalse;
 
-import android.content.ContentProvider;
 import android.content.Context;
 import android.os.Looper;
 
@@ -31,7 +30,6 @@ import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
-import de.dennisguse.opentracks.content.provider.CustomContentProvider;
 import de.dennisguse.opentracks.content.sensor.SensorDataHeartRate;
 import de.dennisguse.opentracks.content.sensor.SensorDataRunning;
 import de.dennisguse.opentracks.content.sensor.SensorDataSet;
@@ -79,11 +77,6 @@ public class TrackRecordingServiceTestLocation {
 
     @Before
     public void setUp() throws TimeoutException {
-        // Set up the mock content resolver
-        ContentProvider customContentProvider = new CustomContentProvider() {
-        };
-        customContentProvider.attachInfo(context, null);
-
         contentProviderUtils = new ContentProviderUtils(context);
         tearDown();
 

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLocation.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLocation.java
@@ -36,7 +36,6 @@ import de.dennisguse.opentracks.content.sensor.SensorDataSet;
 import de.dennisguse.opentracks.io.file.importer.TrackPointAssert;
 import de.dennisguse.opentracks.services.sensors.AltitudeSumManager;
 import de.dennisguse.opentracks.services.sensors.BluetoothRemoteSensorManager;
-import de.dennisguse.opentracks.settings.PreferencesUtils;
 
 /**
  * Tests insert location.
@@ -80,16 +79,14 @@ public class TrackRecordingServiceTestLocation {
         contentProviderUtils = new ContentProviderUtils(context);
         tearDown();
 
-        // Let's use default values.
-        PreferencesUtils.clear();
-
         service = ((TrackRecordingService.Binder) mServiceRule.bindService(TrackRecordingServiceTest.createStartIntent(context)))
                 .getService();
         service.getTrackPointCreator().stopGPS();
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws TimeoutException {
+        TrackRecordingServiceTest.resetService(mServiceRule, context);
         // Ensure that the database is empty after every test
         contentProviderUtils.deleteAllTracks(context);
     }

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLocation.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLocation.java
@@ -106,6 +106,7 @@ public class TrackRecordingServiceTestLocation {
     public void testOnLocationChangedAsync_movingAccurate() {
         // given
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         service.getTrackPointCreator().setAltitudeSumManager(altitudeSumManager);
 
         // when
@@ -179,6 +180,7 @@ public class TrackRecordingServiceTestLocation {
     public void testOnLocationChangedAsync_slowMovingAccurate() {
         // given
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         service.getTrackPointCreator().setAltitudeSumManager(altitudeSumManager);
 
         // when
@@ -224,6 +226,7 @@ public class TrackRecordingServiceTestLocation {
     public void testOnLocationChangedAsync_idle() {
         // given
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         service.getTrackPointCreator().setAltitudeSumManager(altitudeSumManager);
 
         // when
@@ -269,6 +272,7 @@ public class TrackRecordingServiceTestLocation {
     public void testOnLocationChangedAsync_idle_withMovement() {
         // given
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         service.getTrackPointCreator().setAltitudeSumManager(altitudeSumManager);
         service.getTrackPointCreator().stopGPS();
 
@@ -329,6 +333,7 @@ public class TrackRecordingServiceTestLocation {
     public void testOnLocationChangedAsync_idle_withSensorData() {
         // given
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         service.getTrackPointCreator().setAltitudeSumManager(altitudeSumManager);
         service.getTrackPointCreator().setRemoteSensorManager(new BluetoothRemoteSensorManager(context) {
 
@@ -403,6 +408,7 @@ public class TrackRecordingServiceTestLocation {
 
         // given
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         service.getTrackPointCreator().setRemoteSensorManager(remoteSensorManager);
         service.getTrackPointCreator().setAltitudeSumManager(altitudeSumManager);
         altitudeSumManager.stop(service);
@@ -474,6 +480,7 @@ public class TrackRecordingServiceTestLocation {
     public void testOnLocationChangedAsync_segment() {
         // given
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         service.getTrackPointCreator().setAltitudeSumManager(altitudeSumManager);
 
         // when

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLooper.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLooper.java
@@ -44,6 +44,7 @@ import de.dennisguse.opentracks.stats.TrackStatistics;
  *
  * @author Bartlomiej Niechwiej
  */
+//TODO Check that those tests are really testing something!
 @RunWith(AndroidJUnit4.class)
 public class TrackRecordingServiceTestLooper {
 
@@ -67,11 +68,6 @@ public class TrackRecordingServiceTestLooper {
 
     @Before
     public void setUp() {
-        // Set up the mock content resolver
-        ContentProvider customContentProvider = new CustomContentProvider() {
-        };
-        customContentProvider.attachInfo(context, null);
-
         contentProviderUtils = new ContentProviderUtils(context);
 
         // Let's use default values.

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLooper.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLooper.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import android.content.ContentProvider;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Looper;
@@ -35,7 +34,6 @@ import de.dennisguse.opentracks.content.data.Speed;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
-import de.dennisguse.opentracks.content.provider.CustomContentProvider;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 
@@ -67,24 +65,15 @@ public class TrackRecordingServiceTestLooper {
     }
 
     @Before
-    public void setUp() {
+    public void setUp() throws TimeoutException {
         contentProviderUtils = new ContentProviderUtils(context);
 
-        // Let's use default values.
-        PreferencesUtils.clear();
-
-        // Ensure that the database is empty before every test
-        contentProviderUtils.deleteAllTracks(context);
+        tearDown();
     }
 
     @After
     public void tearDown() throws TimeoutException {
-        // Reset service (if some previous test failed)
-        TrackRecordingService service = ((TrackRecordingService.Binder) mServiceRule.bindService(TrackRecordingServiceTest.createStartIntent(context)))
-                .getService();
-        if (service.isRecording() || service.isPaused()) {
-            service.endCurrentTrack();
-        }
+        TrackRecordingServiceTest.resetService(mServiceRule, context);
 
         // Ensure that the database is empty after every test
         contentProviderUtils.deleteAllTracks(context);

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLooper.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestLooper.java
@@ -1,5 +1,10 @@
 package de.dennisguse.opentracks.services;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import android.content.ContentProvider;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -31,13 +36,8 @@ import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 import de.dennisguse.opentracks.content.provider.CustomContentProvider;
-import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import de.dennisguse.opentracks.stats.TrackStatistics;
 
 /**
  * Tests for the track recording service, which require a {@link Looper}.
@@ -195,6 +195,7 @@ public class TrackRecordingServiceTestLooper {
 
         // Start a track.
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         assertNotNull(trackId);
         assertTrue(service.isRecording());
         Track track = contentProviderUtils.getTrack(trackId);

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestStatistics.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestStatistics.java
@@ -118,6 +118,7 @@ public class TrackRecordingServiceTestStatistics {
         // given
         service.getTrackPointCreator().setClock(Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault()));
         Track.Id trackId = service.startNewTrack();
+        service.stopUpdateRecordingData();
         service.getTrackPointCreator().setAltitudeSumManager(altitudeSumManager);
 
         Function<Integer, Void> assertMovingTime = expected -> {

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestStatistics.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestStatistics.java
@@ -81,11 +81,6 @@ public class TrackRecordingServiceTestStatistics {
 
     @Before
     public void setUp() throws TimeoutException {
-        // Set up the mock content resolver
-        ContentProvider customContentProvider = new CustomContentProvider() {
-        };
-        customContentProvider.attachInfo(context, null);
-
         contentProviderUtils = new ContentProviderUtils(context);
         tearDown();
 

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestStatistics.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestStatistics.java
@@ -3,10 +3,7 @@ package de.dennisguse.opentracks.services;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import android.content.ContentProvider;
 import android.content.Context;
-import android.content.Intent;
-import android.os.Build;
 import android.os.Looper;
 
 import androidx.annotation.NonNull;
@@ -18,7 +15,6 @@ import androidx.test.rule.ServiceTestRule;
 
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -38,9 +34,7 @@ import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
-import de.dennisguse.opentracks.content.provider.CustomContentProvider;
 import de.dennisguse.opentracks.services.sensors.AltitudeSumManager;
-import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 
 /**
@@ -82,21 +76,14 @@ public class TrackRecordingServiceTestStatistics {
     @Before
     public void setUp() throws TimeoutException {
         contentProviderUtils = new ContentProviderUtils(context);
+
         tearDown();
-
-        // Let's use default values.
-        PreferencesUtils.clear();
-
-        service = ((TrackRecordingService.Binder) mServiceRule.bindService(TrackRecordingServiceTest.createStartIntent(context)))
-                .getService();
-        service.getTrackPointCreator().stopGPS();
     }
 
     @After
     public void tearDown() throws TimeoutException {
-        TrackRecordingService service = ((TrackRecordingService.Binder) mServiceRule.bindService(new Intent(context, TrackRecordingService.class)))
-                .getService();
-        service.getTrackPointCreator().setClock(Clock.systemUTC());
+        TrackRecordingServiceTest.resetService(mServiceRule, context);
+        contentProviderUtils.deleteAllTracks(context);
     }
 
     /**
@@ -104,13 +91,12 @@ public class TrackRecordingServiceTestStatistics {
      */
     @MediumTest
     @Test
-    public void movingtime_with_pauses() {
-        Assume.assumeTrue(
-                "Test fails on API23; reproducible on CI and some machines.",
-                Build.VERSION.SDK_INT > 23
-        );
-
+    public void movingtime_with_pauses() throws TimeoutException {
         // given
+        TrackRecordingService service = ((TrackRecordingService.Binder) mServiceRule.bindService(TrackRecordingServiceTest.createStartIntent(context)))
+                .getService();
+        service.getTrackPointCreator().stopGPS();
+
         service.getTrackPointCreator().setClock(Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault()));
         Track.Id trackId = service.startNewTrack();
         service.stopUpdateRecordingData();

--- a/src/androidTest/java/de/dennisguse/opentracks/services/handlers/GPSHandlerTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/handlers/GPSHandlerTest.java
@@ -26,7 +26,7 @@ import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
 
 @RunWith(MockitoJUnitRunner.class)
-public class LocationHandlerTest {
+public class GPSHandlerTest {
 
     private final Context context = ApplicationProvider.getApplicationContext();
 
@@ -34,7 +34,7 @@ public class LocationHandlerTest {
     private TrackPointCreator trackPointCreator;
 
     @InjectMocks
-    private LocationHandler locationHandler;
+    private GPSHandler locationHandler;
 
     @BeforeClass
     public static void preSetUp() {

--- a/src/androidTest/java/de/dennisguse/opentracks/services/handlers/TrackPointCreatorTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/handlers/TrackPointCreatorTest.java
@@ -3,7 +3,6 @@ package de.dennisguse.opentracks.services.handlers;
 import static org.mockito.Mockito.verify;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 
 import org.junit.After;
 import org.junit.Before;
@@ -27,9 +26,6 @@ public class TrackPointCreatorTest {
 
     @Mock
     private GPSHandler locationHandler;
-
-    @Mock
-    private SharedPreferences sharedPreferences;
 
     private TrackPointCreator subject;
 

--- a/src/androidTest/java/de/dennisguse/opentracks/services/handlers/TrackPointCreatorTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/handlers/TrackPointCreatorTest.java
@@ -26,7 +26,7 @@ public class TrackPointCreatorTest {
     private TrackPointCreator.Callback server;
 
     @Mock
-    private LocationHandler locationHandler;
+    private GPSHandler locationHandler;
 
     @Mock
     private SharedPreferences sharedPreferences;

--- a/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
@@ -311,7 +311,7 @@ public class TrackPoint {
     }
 
     @Nullable
-    public Distance distanceToPrevious(TrackPoint previous) {
+    public Distance distanceToPrevious(@Nullable TrackPoint previous) {
         if (hasSensorDistance()) {
             return getSensorDistance();
         }

--- a/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
@@ -63,7 +63,8 @@ public class TrackPoint {
         SEGMENT_START_MANUAL(-2), //Start of a segment due to user interaction (start, resume)
 
         SEGMENT_START_AUTOMATIC(-1), //Start of a segment due to too much distance from previous TrackPoint
-        TRACKPOINT(0), //Just GPS data.
+        TRACKPOINT(0), //Just GPS data and may contain BLE sensor data
+        SENSORPOINT(2), //Just BLE sensor data
 
         SEGMENT_END_MANUAL(1); //End of a segment
 

--- a/src/main/java/de/dennisguse/opentracks/content/data/TrackPointsColumns.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TrackPointsColumns.java
@@ -77,7 +77,7 @@ public interface TrackPointsColumns extends BaseColumns {
             + SENSOR_POWER + " FLOAT, "
             + ALTITUDE_GAIN + " FLOAT, "
             + ALTITUDE_LOSS + " FLOAT, "
-            + TYPE + " TEXT CHECK(type IN (-2, -1, 0, 1)), "
+            + TYPE + " TEXT CHECK(type IN (-2, -1, 0, 1, 2)), "
             + SENSOR_DISTANCE + " FLOAT, "
             + "FOREIGN KEY (" + TRACKID + ") REFERENCES " + TracksColumns.TABLE_NAME + "(" + TracksColumns._ID + ") ON UPDATE CASCADE ON DELETE CASCADE"
             + ")";

--- a/src/main/java/de/dennisguse/opentracks/fragments/IntervalsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/IntervalsFragment.java
@@ -182,7 +182,9 @@ public class IntervalsFragment extends Fragment {
     }
 
     private synchronized void updateIntervals(boolean metricUnits, IntervalStatisticsModel.IntervalOption selectedInterval) {
-        boolean update = metricUnits != this.metricUnits || !selectedInterval.sameMultiplier(this.selectedInterval);
+        boolean update = metricUnits != this.metricUnits
+                || selectedInterval == null
+                || !selectedInterval.sameMultiplier(this.selectedInterval);
         this.metricUnits = metricUnits;
         this.selectedInterval = selectedInterval;
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
@@ -31,6 +31,7 @@ import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.content.provider.ContentProviderUtils;
 import de.dennisguse.opentracks.content.provider.TrackPointIterator;
+import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.util.StringUtils;
 
 /**
@@ -205,6 +206,7 @@ public class GPXTrackExporter implements TrackExporter {
             printWriter.println("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"");
             printWriter.println("xmlns:opentracks=\"http://opentracksapp.com/xmlschemas/v1\"");
             printWriter.println("xmlns:gpxtpx=\"http://www.garmin.com/xmlschemas/TrackPointExtension/v2\"");
+            printWriter.println("xmlns:gpxtrkx=\"http://www.garmin.com/xmlschemas/TrackStatsExtension/v1\"");
             printWriter.println("xmlns:pwr=\"http://www.garmin.com/xmlschemas/PowerExtension/v1\"");
             printWriter.println("xsi:schemaLocation=" +
                     "\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
@@ -261,6 +263,18 @@ public class GPXTrackExporter implements TrackExporter {
             printWriter.println("<extensions>");
             printWriter.println("<topografix:color>c0c0c0</topografix:color>");
             printWriter.println("<opentracks:trackid>" + track.getUuid() + "</opentracks:trackid>");
+
+            TrackStatistics trackStatistics = track.getTrackStatistics();
+            printWriter.println("<gpxtrkx:TrackStatsExtension>");
+            printWriter.println("<gpxtrkx:Distance>" + trackStatistics.getTotalDistance().toM() + "</gpxtrkx:Distance>");
+            printWriter.println("<gpxtrkx:TimerTime>" + trackStatistics.getTotalTime().getSeconds() + "</gpxtrkx:TimerTime>");
+            printWriter.println("<gpxtrkx:MovingTime>" + trackStatistics.getMovingTime().getSeconds() + "</gpxtrkx:MovingTime>");
+            printWriter.println("<gpxtrkx:StoppedTime>" + trackStatistics.getStoppedTime().getSeconds() + "</gpxtrkx:StoppedTime>");
+            printWriter.println("<gpxtrkx:MaxSpeed>" + trackStatistics.getMaxSpeed().toMPS() + "</gpxtrkx:MaxSpeed>");
+            printWriter.println("<gpxtrkx:Ascent>" + trackStatistics.getTotalAltitudeGain() + "</gpxtrkx:Ascent>");
+            printWriter.println("<gpxtrkx:Descent>" + trackStatistics.getTotalAltitudeLoss() + "</gpxtrkx:Descent>");
+            printWriter.println("</gpxtrkx:TrackStatsExtension>");
+
             printWriter.println("</extensions>");
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
@@ -151,6 +151,9 @@ public class GPXTrackExporter implements TrackExporter {
                         wroteSegment = true;
                         writeTrackPoint(trackPoint);
                         break;
+                    case SENSORPOINT:
+                        //TODO We need somehow to compute the sensor data (mainly sensorDistance if present) and add it to the TRACKPOINT (if no segment followed in between)?
+                        break;
                     case TRACKPOINT:
                         if (!wroteSegment) {
                             // Might happen for older data (pre v3.15.0)
@@ -159,6 +162,8 @@ public class GPXTrackExporter implements TrackExporter {
                         }
                         writeTrackPoint(trackPoint);
                         break;
+                    default:
+                        throw new RuntimeException("Exporting this TrackPoint type is not implemented: " + trackPoint.getType());
                 }
             }
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
@@ -181,6 +181,7 @@ public class KMLTrackExporter implements TrackExporter {
                         writeCloseSegment();
                         wroteSegment = false;
                         break;
+                    case SENSORPOINT:
                     case TRACKPOINT:
                         if (!wroteSegment) {
                             // Might happen for older data (pre v3.15.0)
@@ -189,6 +190,8 @@ public class KMLTrackExporter implements TrackExporter {
                         }
                         writeTrackPoint(trackPoint);
                         break;
+                    default:
+                        throw new RuntimeException("Exporting this TrackPoint type is not implemented: " + trackPoint.getType());
                 }
             }
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/GpxTrackImporter.java
@@ -243,7 +243,7 @@ public class GpxTrackImporter extends DefaultHandler implements XMLImporter.Trac
 
     private void onTrackSegmentEnd() {
         if (currentSegment.isEmpty()) {
-            Log.w(TAG, "No locations in current segment.");
+            Log.w(TAG, "No TrackPoints in current segment.");
             return;
         }
 
@@ -256,7 +256,7 @@ public class GpxTrackImporter extends DefaultHandler implements XMLImporter.Trac
 
 
     private TrackPoint createTrackPoint() throws ParsingException {
-        Instant parsedTime = null;
+        Instant parsedTime;
         try {
             parsedTime = StringUtils.parseTime(time);
         } catch (Exception e) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlTrackImporter.java
@@ -295,15 +295,21 @@ public class KmlTrackImporter extends DefaultHandler implements XMLImporter.Trac
 
             TrackPoint trackPoint;
             if (i == 0) {
+                //first
                 if (location == null) {
                     trackPoint = TrackPoint.createSegmentStartManualWithTime(time);
                 } else {
                     trackPoint = new TrackPoint(TrackPoint.Type.SEGMENT_START_AUTOMATIC, location, time);
                 }
             } else if (i == locationList.size() - 1 && location == null) {
+                //last
                 trackPoint = TrackPoint.createSegmentEndWithTime(time);
             } else {
-                trackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, location, time);
+                if (location == null) {
+                    trackPoint = new TrackPoint(TrackPoint.Type.SENSORPOINT, time);
+                } else {
+                    trackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, location, time);
+                }
             }
 
             if (i < sensorSpeedList.size() && sensorSpeedList.get(i) != null) {

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
@@ -147,6 +147,9 @@ class TrackRecordingManager {
         return new Marker.Id(ContentUris.parseId(uri));
     }
 
+    /**
+     * @return TrackPoint was stored?
+     */
     boolean onNewTrackPoint(TrackPoint trackPoint) {
         //Storing trackPoint
 

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
@@ -142,7 +142,7 @@ class TrackRecordingManager {
         photoUrl = photoUrl != null ? photoUrl : "";
 
         // Insert marker
-        Marker marker = new Marker(name, description, category, icon, trackId, getTrackStatistics(), lastStoredTrackPoint, photoUrl);
+        Marker marker = new Marker(name, description, category, icon, trackId, getTrackStatistics(), lastStoredTrackPointWithLocation, photoUrl);
         Uri uri = contentProviderUtils.insertMarker(marker);
         return new Marker.Id(ContentUris.parseId(uri));
     }

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
@@ -36,9 +36,11 @@ class TrackRecordingManager {
     private Track.Id trackId;
     private TrackStatisticsUpdater trackStatisticsUpdater;
 
+    //TDOO use lastStoredTrackPoint?
     private boolean currentSegmentHasTrackPoint;
     private TrackPoint lastTrackPoint;
     private TrackPoint lastStoredTrackPoint;
+    private TrackPoint lastStoredTrackPointWithLocation;
 
     TrackRecordingManager(Context context) {
         this.context = context;
@@ -80,15 +82,20 @@ class TrackRecordingManager {
 
         trackStatisticsUpdater = new TrackStatisticsUpdater(track.getTrackStatistics());
         insertTrackPoint(trackId, segmentStartTrackPoint);
-        currentSegmentHasTrackPoint = false;
-        lastTrackPoint = null;
-        lastStoredTrackPoint = null;    }
 
-    void pause(TrackPointCreator trackPointCreator) {
-        insertTrackPoint(trackId, trackPointCreator.createSegmentEnd());
         currentSegmentHasTrackPoint = false;
         lastTrackPoint = null;
         lastStoredTrackPoint = null;
+        lastStoredTrackPointWithLocation = null;
+    }
+
+    void pause(TrackPointCreator trackPointCreator) {
+        insertTrackPoint(trackId, trackPointCreator.createSegmentEnd());
+
+        currentSegmentHasTrackPoint = false;
+        lastTrackPoint = null;
+        lastStoredTrackPoint = null;
+        lastStoredTrackPointWithLocation = null;
     }
 
     void end(TrackPointCreator trackPointCreator) {
@@ -97,9 +104,11 @@ class TrackRecordingManager {
 
         trackId = null;
         trackStatisticsUpdater = null;
+
+        currentSegmentHasTrackPoint = false;
         lastTrackPoint = null;
         lastStoredTrackPoint = null;
-        currentSegmentHasTrackPoint = false;
+        lastStoredTrackPointWithLocation = null;
     }
 
     Pair<Track, Pair<TrackPoint, SensorDataSet>> get(TrackPointCreator trackPointCreator) {
@@ -131,7 +140,7 @@ class TrackRecordingManager {
             name = context.getString(R.string.marker_name_format, nextMarkerNumber + 1);
         }
 
-        if (lastStoredTrackPoint == null) {
+        if (lastStoredTrackPointWithLocation == null) {
             Log.i(TAG, "Could not create a marker as trackPoint is unknown.");
             return null;
         }
@@ -160,17 +169,30 @@ class TrackRecordingManager {
             return true;
         }
 
-        Distance distanceToLastTrackLocation = trackPoint.distanceToPrevious(lastStoredTrackPoint);
-        if (distanceToLastTrackLocation != null) {
-            if (distanceToLastTrackLocation.greaterThan(maxRecordingDistance)) {
+        Distance distanceToLastStoredTrackPoint = trackPoint.distanceToPrevious(lastStoredTrackPoint);
+        if (distanceToLastStoredTrackPoint != null) {
+            if (distanceToLastStoredTrackPoint.greaterThan(maxRecordingDistance)) {
                 trackPoint.setType(TrackPoint.Type.SEGMENT_START_AUTOMATIC);
                 insertTrackPoint(trackId, trackPoint);
                 return true;
             }
 
-            if (distanceToLastTrackLocation.greaterOrEqualThan(recordingDistanceInterval) && trackPoint.isMoving()) {
+            if (distanceToLastStoredTrackPoint.greaterOrEqualThan(recordingDistanceInterval) && trackPoint.isMoving()) {
                 insertTrackPoint(trackId, trackPoint);
                 return true;
+            }
+
+            if (trackPoint.hasLocation()) {
+                if (lastStoredTrackPointWithLocation == null) {
+                    insertTrackPoint(trackId, trackPoint);
+                    return true;
+                }
+
+                Distance distanceToLastStoredTrackPointWithLocation = trackPoint.distanceToPrevious(lastStoredTrackPointWithLocation);
+                if (distanceToLastStoredTrackPointWithLocation != null && distanceToLastStoredTrackPointWithLocation.greaterOrEqualThan(recordingDistanceInterval)) {
+                    insertTrackPoint(trackId, trackPoint);
+                    return true;
+                }
             }
         }
 
@@ -212,6 +234,9 @@ class TrackRecordingManager {
 
             contentProviderUtils.updateTrackStatistics(trackId, trackStatisticsUpdater.getTrackStatistics());
             lastStoredTrackPoint = trackPoint;
+            if (trackPoint.hasLocation()) {
+                lastStoredTrackPointWithLocation = lastStoredTrackPoint;
+            }
         } catch (SQLiteException e) {
             /*
              * Insert failed, most likely because of SqlLite error code 5 (SQLite_BUSY).

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -87,6 +87,8 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         @Override
         public void run() {
             updateRecordingDataWhileRecording();
+            trackPointCreator.onNewTrackPointWithoutGPS(); //TODO Should not be called every second, right? + with do some duplicate computation with updateRecordingDataWhileRecording().
+
             Handler localHandler = TrackRecordingService.this.handler;
             if (localHandler == null) {
                 // when this happens, no recording is running and we should not send any notifications.

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -99,7 +99,10 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         }
     };
 
-    private final OnSharedPreferenceChangeListener sharedPreferenceChangeListener = new OnSharedPreferenceChangeListener() {
+    @Deprecated
+    //TODO Workaround as service is not stopped on API23; thus sharedpreferences are not reset between tests.
+    @VisibleForTesting
+    final OnSharedPreferenceChangeListener sharedPreferenceChangeListener = new OnSharedPreferenceChangeListener() {
         @Override
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
             if (PreferencesUtils.isKey(R.string.stats_units_key, key)) {
@@ -150,19 +153,11 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
     }
 
     @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
-        return START_STICKY;
-    }
-
-    @Override
-    public Binder onBind(Intent intent) {
-        return binder;
-    }
-
-    @Override
     public void onDestroy() {
         handler.removeCallbacksAndMessages(null); //Some tests do not finish the recording completely
         handler = null;
+
+        PreferencesUtils.unregisterOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
 
         trackPointCreator.stop();
         trackPointCreator = null;
@@ -171,8 +166,6 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         // Reverse order from onCreate
         showNotification(false); //TODO Why?
         notificationManager = null;
-
-        PreferencesUtils.unregisterOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
 
         try {
             voiceAnnouncementManager.shutdown();
@@ -433,6 +426,12 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
     @VisibleForTesting
     public TrackPointCreator getTrackPointCreator() {
         return trackPointCreator;
+    }
+
+    @Deprecated
+    @VisibleForTesting
+    public TrackRecordingManager getTrackRecordingManager() {
+        return trackRecordingManager;
     }
 
     public LiveData<GpsStatusValue> getGpsStatusObservable() {

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -161,13 +161,16 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
 
     @Override
     public void onDestroy() {
+        handler.removeCallbacksAndMessages(null); //Some tests do not finish the recording completely
         handler = null;
 
         trackPointCreator.stop();
         trackPointCreator = null;
+        trackRecordingManager = null;
 
         // Reverse order from onCreate
         showNotification(false); //TODO Why?
+        notificationManager = null;
 
         PreferencesUtils.unregisterOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
 
@@ -180,11 +183,22 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         // This should be the next to last operation
         wakeLock = SystemUtils.releaseWakeLock(wakeLock);
 
+        updateRecordingStatus(STATUS_DEFAULT);
         recordingStatusObservable = null;
         gpsStatusObservable = null;
         recordingDataObservable = null;
 
         super.onDestroy();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return START_STICKY;
+    }
+
+    @Override
+    public Binder onBind(Intent intent) {
+        return binder;
     }
 
     public boolean isRecording() {

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -18,7 +18,6 @@ package de.dennisguse.opentracks.services;
 
 import android.app.PendingIntent;
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
@@ -50,11 +49,11 @@ import de.dennisguse.opentracks.services.handlers.EGM2008CorrectionManager;
 import de.dennisguse.opentracks.services.handlers.GpsStatusValue;
 import de.dennisguse.opentracks.services.handlers.TrackPointCreator;
 import de.dennisguse.opentracks.services.tasks.VoiceAnnouncementManager;
+import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.settings.SettingsActivity;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.util.ExportUtils;
 import de.dennisguse.opentracks.util.IntentUtils;
-import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.util.SystemUtils;
 
 /**
@@ -360,8 +359,9 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
             return false;
         }
 
+        boolean stored = trackRecordingManager.onNewTrackPoint(trackPoint);
         notificationManager.updateTrackPoint(this, trackRecordingManager.getTrackStatistics(), trackPoint, thresholdHorizontalAccuracy);
-        return trackRecordingManager.onNewTrackPoint(trackPoint);
+        return stored;
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -318,7 +318,7 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
      * @param trackStopped true if track is stopped, false if track is paused
      */
     private void endRecording(boolean trackStopped) {
-        handler.removeCallbacks(updateRecordingData);
+        stopUpdateRecordingData();
         if (!trackStopped) {
             updateRecordingDataWhileRecording();
         } else {
@@ -456,6 +456,11 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         localVoiceAnnouncementManager.update(data.first);
 
         recordingDataObservable.postValue(new RecordingData(data.first, trackPoint, data.second.second));
+    }
+
+    @VisibleForTesting
+    public void stopUpdateRecordingData() {
+        handler.removeCallbacks(updateRecordingData);
     }
 
     public LiveData<RecordingStatus> getRecordingStatusObservable() {

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -72,6 +72,8 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
     public static final RecordingData NOT_RECORDING = new RecordingData(null, null, null);
     public static final GpsStatusValue STATUS_GPS_DEFAULT = GpsStatusValue.GPS_NONE;
 
+    private final Binder binder = new Binder();
+
     // The following variables are setFrequency in onCreate:
     private VoiceAnnouncementManager voiceAnnouncementManager;
     private TrackRecordingServiceNotificationManager notificationManager;
@@ -114,10 +116,8 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         }
     };
 
-    // The following variables are setFrequency when recording:
+    // The following variables are set when recording:
     private WakeLock wakeLock;
-
-    private final Binder binder = new Binder();
 
     private TrackPointCreator trackPointCreator; //TODO Move to TrackRecordingManager?
 

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/GPSHandler.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/GPSHandler.java
@@ -158,6 +158,10 @@ public class GPSHandler implements LocationListener, GpsStatus.GpsStatusListener
         return lastTrackPoint;
     }
 
+    Distance getThresholdHorizontalAccuracy() {
+        return thresholdHorizontalAccuracy;
+    }
+
     /**
      * Called from {@link GpsStatus} to inform that GPS status has changed from prevStatus to currentStatus.
      *

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/GPSHandler.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/GPSHandler.java
@@ -15,13 +15,13 @@ import java.time.Duration;
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.TrackPoint;
-import de.dennisguse.opentracks.util.LocationUtils;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
+import de.dennisguse.opentracks.util.LocationUtils;
 
 @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-public class LocationHandler implements LocationListener, GpsStatus.GpsStatusListener {
+public class GPSHandler implements LocationListener, GpsStatus.GpsStatusListener {
 
-    private final String TAG = LocationHandler.class.getSimpleName();
+    private final String TAG = GPSHandler.class.getSimpleName();
 
     private LocationManager locationManager;
     private final TrackPointCreator trackPointCreator;
@@ -30,7 +30,7 @@ public class LocationHandler implements LocationListener, GpsStatus.GpsStatusLis
     private Distance thresholdHorizontalAccuracy;
     private TrackPoint lastTrackPoint;
 
-    public LocationHandler(TrackPointCreator trackPointCreator) {
+    public GPSHandler(TrackPointCreator trackPointCreator) {
         this.trackPointCreator = trackPointCreator;
     }
 

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
@@ -152,6 +152,11 @@ public class TrackPointCreator {
         return Instant.now(clock);
     }
 
+    @VisibleForTesting
+    public AltitudeSumManager getAltitudeSumManager() {
+        return altitudeSumManager;
+    }
+
     @Deprecated
     @VisibleForTesting
     public void setAltitudeSumManager(AltitudeSumManager altitudeSumManager) {

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
@@ -101,13 +101,17 @@ public class TrackPointCreator {
         gpsHandler.onSharedPreferenceChanged(key);
     }
 
-    public void onNewTrackPoint(TrackPoint trackPoint, Distance thresholdHorizontalAccuracy) {
+    public synchronized void onNewTrackPoint(@NonNull TrackPoint trackPoint, @NonNull Distance thresholdHorizontalAccuracy) {
         fill(trackPoint);
 
         boolean stored = service.newTrackPoint(trackPoint, thresholdHorizontalAccuracy);
         if (stored) {
             resetSensorData();
         }
+    }
+
+    public void onNewTrackPointWithoutGPS() {
+        onNewTrackPoint(new TrackPoint(TrackPoint.Type.SENSORPOINT, createNow()), gpsHandler.getThresholdHorizontalAccuracy());
     }
 
     public TrackPoint createSegmentStartManual() {

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
@@ -58,6 +58,10 @@ public class TrackPointCreator {
         altitudeSumManager.start(context);
     }
 
+    private boolean isStarted() {
+        return context != null;
+    }
+
     @Deprecated
     //There should be a cooler way to do this; we want to send fake locations without getting affected by real GPS data.
     @VisibleForTesting
@@ -75,6 +79,10 @@ public class TrackPointCreator {
     }
 
     private SensorDataSet fill(TrackPoint trackPoint) {
+        if (!isStarted()) {
+            Log.w(TAG, "Not started, should not be called.");
+            return null;
+        }
         SensorDataSet sensorDataSet = remoteSensorManager.fill(trackPoint);
         altitudeSumManager.fill(trackPoint);
 

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
@@ -31,25 +31,25 @@ public class TrackPointCreator {
     @NonNull
     private Clock clock = Clock.systemUTC();
 
-    private final LocationHandler locationHandler;
+    private final GPSHandler gpsHandler;
     private BluetoothRemoteSensorManager remoteSensorManager;
     private AltitudeSumManager altitudeSumManager;
 
     public TrackPointCreator(Callback service) {
         this.service = service;
-        this.locationHandler = new LocationHandler(this);
+        this.gpsHandler = new GPSHandler(this);
     }
 
     @VisibleForTesting
-    TrackPointCreator(LocationHandler locationHandler, Callback service) {
+    TrackPointCreator(GPSHandler gpsHandler, Callback service) {
         this.service = service;
-        this.locationHandler = locationHandler;
+        this.gpsHandler = gpsHandler;
     }
 
     public void start(@NonNull Context context) {
         this.context = context;
 
-        locationHandler.onStart(context);
+        gpsHandler.onStart(context);
 
         remoteSensorManager = new BluetoothRemoteSensorManager(context);
         remoteSensorManager.start();
@@ -62,7 +62,7 @@ public class TrackPointCreator {
     //There should be a cooler way to do this; we want to send fake locations without getting affected by real GPS data.
     @VisibleForTesting
     public void stopGPS() {
-        locationHandler.onStop();
+        gpsHandler.onStop();
     }
 
     public void resetSensorData() {
@@ -82,7 +82,7 @@ public class TrackPointCreator {
     }
 
     public void stop() {
-        locationHandler.onStop();
+        gpsHandler.onStop();
 
         if (remoteSensorManager != null) {
             remoteSensorManager.stop();
@@ -98,7 +98,7 @@ public class TrackPointCreator {
     }
 
     public void onSharedPreferenceChanged(String key) {
-        locationHandler.onSharedPreferenceChanged(key);
+        gpsHandler.onSharedPreferenceChanged(key);
     }
 
     public void onNewTrackPoint(TrackPoint trackPoint, Distance thresholdHorizontalAccuracy) {
@@ -123,7 +123,7 @@ public class TrackPointCreator {
 
     public Pair<TrackPoint, SensorDataSet> createCurrentTrackPoint(@Nullable TrackPoint lastValidTrackPoint) {
         TrackPoint currentTrackPoint = new TrackPoint(TrackPoint.Type.TRACKPOINT, createNow());
-        TrackPoint lastTrackPoint = locationHandler.getLastTrackPoint();
+        TrackPoint lastTrackPoint = gpsHandler.getLastTrackPoint();
 
         if (lastTrackPoint != null && lastTrackPoint.hasLocation()) {
             currentTrackPoint.setSpeed(lastTrackPoint.getSpeed());
@@ -166,8 +166,8 @@ public class TrackPointCreator {
     }
 
     @VisibleForTesting
-    public LocationHandler getLocationHandler() {
-        return locationHandler;
+    public GPSHandler getGpsHandler() {
+        return gpsHandler;
     }
 
     void sendGpsStatus(GpsStatusValue gpsStatusValue) {

--- a/src/main/java/de/dennisguse/opentracks/services/sensors/AltitudeSumManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/sensors/AltitudeSumManager.java
@@ -65,27 +65,36 @@ public class AltitudeSumManager implements SensorEventListener {
         trackPoint.setAltitudeLoss(altitudeLoss_m);
     }
 
-    public @Nullable
-    Float getAltitudeGain_m() {
+    @Nullable
+    public Float getAltitudeGain_m() {
         return isConnected ? altitudeGain_m : null;
     }
 
+    @VisibleForTesting
+    public void setAltitudeGain_m(float altitudeGain_m) {
+        this.altitudeGain_m = altitudeGain_m;
+    }
 
     @VisibleForTesting
     public void addAltitudeGain_m(float altitudeGain_m) {
         this.altitudeGain_m = this.altitudeGain_m == null ? 0f : this.altitudeGain_m;
-        this.altitudeGain_m += altitudeGain_m ;
+        this.altitudeGain_m += altitudeGain_m;
     }
 
     @VisibleForTesting
     public void addAltitudeLoss_m(Float altitudeLoss_m) {
         this.altitudeLoss_m = this.altitudeLoss_m == null ? 0f : this.altitudeLoss_m;
-        this.altitudeLoss_m += altitudeLoss_m ;
+        this.altitudeLoss_m += altitudeLoss_m;
     }
 
-    public @Nullable
-    Float getAltitudeLoss_m() {
+    @Nullable
+    public Float getAltitudeLoss_m() {
         return isConnected ? altitudeLoss_m : null;
+    }
+
+    @VisibleForTesting
+    public void setAltitudeLoss_m(float altitudeLoss_m) {
+        this.altitudeLoss_m = altitudeLoss_m;
     }
 
     public void reset() {

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -203,6 +203,10 @@ public class TrackStatistics {
         movingTime = movingTime.plus(time);
     }
 
+    public Duration getStoppedTime() {
+        return totalTime.minus(movingTime);
+    }
+
     /**
      * Gets the average speed.
      * This calculation only takes into account the displacement until the last point that was accounted for in statistics.


### PR DESCRIPTION
OpenTracks now tries to create TrackPoints from BLE sensors (i.e., the ones that provide distance) every second.
It is a really naive implementation and works nicely if GPS is **not** used.

The current implementation has a preference of sensor-based TrackPoints as those will be triggered more often.
This will very likely result in ignoring useful GPS locations (which are expansive to get from an energy perspective).

For this, we need some more magic (aka don't try to store sensor data every second).

Fixed #500.

* [x] decide on how to implement (change type or just use lat/lng null)
* [x] create a new type for BLE sensor-based trackpoints: `SENSORPOINT`
* [x] implement OSMDashboard change: https://github.com/OpenTracksApp/OSMDashboard/pull/125
* [x] Modify ExportImport test (create senor-based Trackpoints in addition)
* [x] Check behavior for GPX exports/ imports (as TrackPoints without location cannot be exported)
* [x] Export/Import KML/KMZ
* [x] ~Upgrade OSMDashboard protocol version OR~ wait for new OSMDashboard release: https://github.com/OpenTracksApp/OSMDashboard/releases/tag/v2.13
* [x] GPX must export cumulative data from SENSORPOINTs (i.e., distance and altitude gain/loss)
* [x] Add this feature to the README
* [x] Rebase onto #1047
* [x] Wait for release of https://github.com/OpenTracksApp/OpenTracks/pull/1012 (at least a 3 days after availability on F-Droid)
