### PR TITLE
for #1025 exportdir failed to create document

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/content/provider/ShareContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ShareContentProvider.java
@@ -29,6 +29,7 @@ import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TracksColumns;
 import de.dennisguse.opentracks.io.file.TrackFileFormat;
 import de.dennisguse.opentracks.io.file.exporter.TrackExporter;
+import de.dennisguse.opentracks.util.FileUtils;
 
 /**
  * A content provider that mimics the behavior of {@link androidx.core.content.FileProvider}, which shares virtual (non-existing) KML-files.

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportService.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportService.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.ResultReceiver;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.JobIntentService;
@@ -24,6 +25,7 @@ public class ExportService extends JobIntentService {
     private static final String EXTRA_TRACK_ID = "extra_track_id";
     private static final String EXTRA_TRACK_FILE_FORMAT = "extra_track_file_format";
     private static final String EXTRA_DIRECTORY_URI = "extra_directory_uri";
+    private static final String TAG = ExportService.class.getSimpleName();
 
     public static void enqueue(Context context, ExportServiceResultReceiver receiver, Track.Id trackId, TrackFileFormat trackFileFormat, Uri directoryUri) {
         Intent intent = new Intent(context, JobService.class);
@@ -42,17 +44,22 @@ public class ExportService extends JobIntentService {
         TrackFileFormat trackFileFormat = (TrackFileFormat) intent.getSerializableExtra(EXTRA_TRACK_FILE_FORMAT);
         Uri directoryUri = intent.getParcelableExtra(EXTRA_DIRECTORY_URI);
 
+        // Prepare resultCode and bundle to send to the receiver.
+        Bundle bundle = new Bundle();
+        bundle.putParcelable(ExportServiceResultReceiver.RESULT_EXTRA_TRACK_ID, trackId);
+
         // Build directory file.
         DocumentFile directoryFile = DocumentFile.fromTreeUri(this, directoryUri);
+        if (directoryFile == null || !directoryFile.canWrite()) {
+            Log.e(TAG, "Can't write to directory: " + directoryFile);
+            resultReceiver.send(ExportServiceResultReceiver.RESULT_CODE_ERROR, bundle);
+            return;
+        }
 
         // Export.
         ContentProviderUtils contentProviderUtils = new ContentProviderUtils(this);
         Track track = contentProviderUtils.getTrack(trackId);
         boolean success = ExportUtils.exportTrack(this, trackFileFormat, directoryFile, track);
-
-        // Prepare resultCode and bundle to send to the receiver.
-        Bundle bundle = new Bundle();
-        bundle.putParcelable(ExportServiceResultReceiver.RESULT_EXTRA_TRACK_ID, trackId);
 
         // Send result to the receiver.
         int resultCode = success ? ExportServiceResultReceiver.RESULT_CODE_SUCCESS : ExportServiceResultReceiver.RESULT_CODE_ERROR;

--- a/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
@@ -100,7 +100,7 @@ public class ExportUtils {
     }
 
     private static String getExportFileNameForTrack(Track track, String trackFileFormatExtension) {
-        return track.getUuid().toString().substring(0, 8) + "_" + track.getName() + "." + trackFileFormatExtension;
+        return track.getUuid().toString().substring(0, 8) + "_" + FileUtils.sanitizeFileName(track.getName()) + "." + trackFileFormatExtension;
     }
 
     private static Uri findFile(Context context, Uri directoryUri, String exportFileName) {

--- a/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
@@ -149,7 +149,6 @@ public class FileUtils {
      *
      * @param name name
      */
-    // TODO Check if this function is still needed.
     public static String sanitizeFileName(String name) {
         StringBuilder builder = new StringBuilder(name.length());
         for (int i = 0; i < name.length(); i++) {

--- a/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
@@ -92,8 +92,9 @@ public class IntentUtils {
                 continue;
             }
 
-            Pair<Uri, String> uriTrackFile = ShareContentProvider.createURI(trackId, track.getName(), PreferencesUtils.getExportTrackFileFormat());
-            Pair<Uri, String> uriSharePicture = ShareContentProvider.createURI(trackId, track.getName(), TrackFileFormat.SHARE_PICTURE_PNG);
+            String trackName = FileUtils.sanitizeFileName(track.getName());
+            Pair<Uri, String> uriTrackFile = ShareContentProvider.createURI(trackId, trackName, PreferencesUtils.getExportTrackFileFormat());
+            Pair<Uri, String> uriSharePicture = ShareContentProvider.createURI(trackId, trackName, TrackFileFormat.SHARE_PICTURE_PNG);
 
             uris.addAll(Arrays.asList(uriSharePicture.first, uriTrackFile.first));
         }
@@ -203,8 +204,8 @@ public class IntentUtils {
         return new Pair<>(intent, photoUri);
     }
 
-    public static void persistDirectoryAccessPermission(Context context, Uri directoryUri) {
-        int flags = Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
-        context.getContentResolver().takePersistableUriPermission(directoryUri, flags);
+    public static void persistDirectoryAccessPermission(Context context, Uri directoryUri, int existingFlags) {
+        int newFlags = existingFlags | (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        context.getContentResolver().takePersistableUriPermission(directoryUri, newFlags);
     }
 }


### PR DESCRIPTION
I found a few things to tackle the export to Nextcloud error.

One thing was that Nextclound can't handle `:` character in filename, so I need to strip them from the trackname before creating the file.

Then I found a few things with the flags and handling of cases where the directory uri might not be writable.

This is just a quick hack, not tested well. Please feel free to have a look anyway.