### PR TITLE
Aggregated stats for only selected tracks.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/AggregatedStatisticsActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/AggregatedStatisticsActivity.java
@@ -5,11 +5,16 @@ import android.view.View;
 
 import androidx.lifecycle.ViewModelProvider;
 
+import java.util.List;
+
 import de.dennisguse.opentracks.adapters.AggregatedStatisticsAdapter;
+import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.databinding.AggregatedStatsBinding;
 import de.dennisguse.opentracks.viewmodels.AggregatedStatisticsModel;
 
 public class AggregatedStatisticsActivity extends AbstractActivity {
+
+    public static final String EXTRA_TRACK_IDS = "track_ids";
 
     private AggregatedStatsBinding viewBinding;
 
@@ -21,8 +26,10 @@ public class AggregatedStatisticsActivity extends AbstractActivity {
 
         viewBinding.aggregatedStatsList.setEmptyView(viewBinding.aggregatedStatsEmptyView);
 
+        List<Track.Id> trackIds = getIntent().getParcelableArrayListExtra(EXTRA_TRACK_IDS);
+
         final AggregatedStatisticsModel viewModel = new ViewModelProvider(this).get(AggregatedStatisticsModel.class);
-        viewModel.getAggregatedStats().observe(this, aggregatedStatistics -> {
+        viewModel.getAggregatedStats(trackIds).observe(this, aggregatedStatistics -> {
             if (aggregatedStatistics != null) {
                 adapter = new AggregatedStatisticsAdapter(this, aggregatedStatistics);
                 viewBinding.aggregatedStatsList.setAdapter(adapter);

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -49,6 +49,10 @@ import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Track;
@@ -460,6 +464,13 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
 
         if (itemId == R.id.list_context_menu_delete) {
             deleteTracks(trackIds);
+            return true;
+        }
+
+        if (itemId == R.id.list_context_menu_aggregated_stats) {
+            Intent intent = IntentUtils.newIntent(this, AggregatedStatisticsActivity.class)
+                    .putParcelableArrayListExtra(AggregatedStatisticsActivity.EXTRA_TRACK_IDS, new ArrayList<>(Arrays.asList(trackIds)));
+            startActivity(intent);
             return true;
         }
 

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -205,6 +205,26 @@ public class ContentProviderUtils {
         return tracks;
     }
 
+    public List<Track> getTracks(List<Track.Id> trackIds) {
+        if (trackIds == null || trackIds.isEmpty()) {
+            return getTracks();
+        }
+
+        String selection = String.format(TracksColumns._ID + " IN (%s)", TextUtils.join(",", Collections.nCopies(trackIds.size(), "?")));
+        String[] selectionArgs = trackIds.stream().map(id -> Long.toString(id.getId())).toArray(String[]::new);
+        ArrayList<Track> tracks = new ArrayList<>();
+        try (Cursor cursor = getTrackCursor(selection, selectionArgs, TracksColumns._ID)) {
+            if (cursor != null && cursor.moveToFirst()) {
+                tracks.ensureCapacity(cursor.getCount());
+                do {
+                    tracks.add(createTrack(cursor));
+                } while (cursor.moveToNext());
+            }
+        }
+
+        return tracks;
+    }
+
     public Track getTrack(@NonNull Track.Id trackId) {
         try (Cursor cursor = getTrackCursor(TracksColumns._ID + "=?", new String[]{Long.toString(trackId.getId())}, null)) {
             if (cursor != null && cursor.moveToNext()) {

--- a/src/main/java/de/dennisguse/opentracks/viewmodels/AggregatedStatisticsModel.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/AggregatedStatisticsModel.java
@@ -3,6 +3,7 @@ package de.dennisguse.opentracks.viewmodels;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
@@ -20,18 +21,18 @@ public class AggregatedStatisticsModel extends AndroidViewModel {
         super(application);
     }
 
-    public LiveData<AggregatedStatistics> getAggregatedStats() {
+    public LiveData<AggregatedStatistics> getAggregatedStats(@Nullable List<Track.Id> trackIds) {
         if (aggregatedStats == null) {
             aggregatedStats = new MutableLiveData<>();
-            loadAggregatedStats();
+            loadAggregatedStats(trackIds);
         }
         return aggregatedStats;
     }
 
-    private void loadAggregatedStats() {
+    private void loadAggregatedStats(@Nullable List<Track.Id> trackIds) {
         new Thread(() -> {
             ContentProviderUtils contentProviderUtils = new ContentProviderUtils(getApplication().getApplicationContext());
-            List<Track> tracks = contentProviderUtils.getTracks();
+            List<Track> tracks = contentProviderUtils.getTracks(trackIds);
 
             AggregatedStatistics aggregatedStatistics = new AggregatedStatistics(tracks);
 

--- a/src/main/res/menu/list_context_menu.xml
+++ b/src/main/res/menu/list_context_menu.xml
@@ -36,6 +36,11 @@ limitations under the License.
         android:title="@string/menu_delete"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/list_context_menu_aggregated_stats"
+        android:icon="@drawable/ic_statistics_24dp"
+        android:title="@string/menu_aggregated_statistics"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/list_context_menu_select_all"
         android:icon="@drawable/ic_select_all_24dp"
         android:title="@string/menu_select_all"


### PR DESCRIPTION
**Describe the pull request**
Aggregated stats has been extended to see aggregated stats only for tracks selected in the contextual menu from TrackListActivity.

Users that select tracks (open contextual menu) can see now a new item menu called "Aggregated Stats".

AggregatedStatisticsActivity expect an optional list of Track.Id and show only aggregated stats from those Track.Ids. If this list is empty or not exists then it shows aggregated stats from all tracks.

It partially fixes #1039 (see comment: https://github.com/OpenTracksApp/OpenTracks/issues/1039#issuecomment-985834549)

**Link to the the issue**
#1039

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

