### PR TITLE
Store timezone offset when starting a recording

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackExporterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackExporterTest.java
@@ -1,5 +1,7 @@
 package de.dennisguse.opentracks.io.file.exporter;
 
+import static org.junit.Assert.assertEquals;
+
 import android.content.Context;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -10,11 +12,10 @@ import org.junit.runners.JUnit4;
 
 import java.io.ByteArrayOutputStream;
 import java.time.Instant;
+import java.time.ZoneOffset;
 
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.io.file.TrackFileFormat;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(JUnit4.class)
 public class KmlTrackExporterTest {
@@ -27,6 +28,8 @@ public class KmlTrackExporterTest {
     @Test
     public void writeCloseSegment_only_write_sensordata_if_present() {
         String expected = "<when>1970-01-01T00:00:00Z</when>\n" +
+                "<gx:coord/>\n" +
+                "<when>1970-01-01T01:00:00+01:00</when>\n" +
                 "<gx:coord/>\n" +
                 "<ExtendedData>\n" +
                 "<SchemaData schemaUrl=\"#schema\">\n" +
@@ -41,7 +44,8 @@ public class KmlTrackExporterTest {
         KMLTrackExporter kmlTrackWriter = (KMLTrackExporter) TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA.createTrackExporter(context);
         kmlTrackWriter.prepare(outputStream);
 
-        kmlTrackWriter.writeTrackPoint(trackPoint);
+        kmlTrackWriter.writeTrackPoint(ZoneOffset.UTC, trackPoint);
+        kmlTrackWriter.writeTrackPoint(ZoneOffset.ofTotalSeconds(3600), trackPoint);
 
         // when
         kmlTrackWriter.writeCloseSegment();

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -219,6 +219,7 @@ public class ExportImportTest {
         TrackStatistics importedTrackStatistics = importedTrack.getTrackStatistics();
 
         // Time
+        assertEquals(track.getZoneOffset(), importedTrack.getZoneOffset());
         assertEquals(Instant.parse("2020-02-02T02:02:02Z"), importedTrackStatistics.getStartTime());
         assertEquals(Instant.parse("2020-02-02T02:02:24Z"), importedTrackStatistics.getStopTime());
 
@@ -338,6 +339,7 @@ public class ExportImportTest {
         TrackStatistics importedTrackStatistics = importedTrack.getTrackStatistics();
 
         // Time
+        assertEquals(track.getZoneOffset(), importedTrack.getZoneOffset());
         assertEquals(Instant.parse("2020-02-02T02:02:03Z"), importedTrackStatistics.getStartTime());
         assertEquals(Instant.parse("2020-02-02T02:02:23Z"), importedTrackStatistics.getStopTime());
 

--- a/src/androidTest/java/de/dennisguse/opentracks/util/StringUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/StringUtilsTest.java
@@ -16,6 +16,9 @@
 
 package de.dennisguse.opentracks.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import android.content.Context;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -30,9 +33,6 @@ import java.util.TimeZone;
 
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Speed;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link StringUtils}.
@@ -141,7 +141,7 @@ public class StringUtilsTest {
 
         // This comparision tends to be flaky (difference of 1ms)
         // Assert.assertEquals(calendar.getTimeInMillis(), StringUtils.parseTime(xmlDateTime));
-        assertTrue(calendar.getTimeInMillis() + " vs. " + StringUtils.parseTime(xmlDateTime), Math.abs(calendar.getTimeInMillis() - StringUtils.parseTime(xmlDateTime).toEpochMilli()) <= 1);
+        assertTrue(calendar.getTimeInMillis() + " vs. " + StringUtils.parseTime(xmlDateTime), Math.abs(calendar.getTimeInMillis() - StringUtils.parseTime(xmlDateTime).toInstant().toEpochMilli()) <= 1);
     }
 
     @Test

--- a/src/main/java/de/dennisguse/opentracks/content/data/Track.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Track.java
@@ -21,7 +21,10 @@ import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -45,7 +48,18 @@ public class Track {
 
     private String icon = "";
 
+    private final ZoneOffset zoneOffset;
+
     private TrackStatistics trackStatistics = new TrackStatistics();
+
+    @VisibleForTesting
+    public Track() {
+        this.zoneOffset = ZoneOffset.UTC;
+    }
+
+    public Track(@NonNull ZoneOffset zoneOffset) {
+        this.zoneOffset = zoneOffset;
+    }
 
     /**
      * May be null if the track was not loaded from the database.
@@ -97,6 +111,14 @@ public class Track {
 
     public void setIcon(String icon) {
         this.icon = icon;
+    }
+
+    public ZoneOffset getZoneOffset() {
+        return zoneOffset;
+    }
+
+    public OffsetDateTime getStartTime() {
+        return trackStatistics.getStartTime().atOffset(zoneOffset);
     }
 
     @NonNull

--- a/src/main/java/de/dennisguse/opentracks/content/data/TracksColumns.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TracksColumns.java
@@ -41,6 +41,7 @@ public interface TracksColumns extends BaseColumns {
     String DESCRIPTION = "description"; // track description
     String CATEGORY = "category"; // track activity type
     String STARTTIME = "starttime"; // track start time
+    String STARTTIME_OFFSET = "starttime_offset"; // in plus/minus in seconds
     String STOPTIME = "stoptime"; // track stop time
     String MARKER_COUNT = "markerCount"; // the numbers of markers (virtual column)
     @Deprecated
@@ -77,7 +78,8 @@ public interface TracksColumns extends BaseColumns {
             + ALTITUDE_GAIN + " FLOAT, "
             + ICON + " TEXT, "
             + UUID + " BLOB, "
-            + ALTITUDE_LOSS + " FLOAT)";
+            + ALTITUDE_LOSS + " FLOAT, "
+            + STARTTIME_OFFSET + " INTEGER)";
 
     String CREATE_TABLE_INDEX = "CREATE UNIQUE INDEX " + TABLE_NAME + "_" + UUID + "_index ON " + TABLE_NAME + "(" + UUID + ")";
 

--- a/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/content/provider/ContentProviderUtils.java
@@ -32,6 +32,7 @@ import androidx.annotation.VisibleForTesting;
 import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -98,6 +99,7 @@ public class ContentProviderUtils {
         int descriptionIndex = cursor.getColumnIndexOrThrow(TracksColumns.DESCRIPTION);
         int categoryIndex = cursor.getColumnIndexOrThrow(TracksColumns.CATEGORY);
         int startTimeIndex = cursor.getColumnIndexOrThrow(TracksColumns.STARTTIME);
+        int startTimeOffsetIndex = cursor.getColumnIndexOrThrow(TracksColumns.STARTTIME_OFFSET);
         int stopTimeIndex = cursor.getColumnIndexOrThrow(TracksColumns.STOPTIME);
         int totalDistanceIndex = cursor.getColumnIndexOrThrow(TracksColumns.TOTALDISTANCE);
         int totalTimeIndex = cursor.getColumnIndexOrThrow(TracksColumns.TOTALTIME);
@@ -109,7 +111,7 @@ public class ContentProviderUtils {
         int altitudeLossIndex = cursor.getColumnIndexOrThrow(TracksColumns.ALTITUDE_LOSS);
         int iconIndex = cursor.getColumnIndexOrThrow(TracksColumns.ICON);
 
-        Track track = new Track();
+        Track track = new Track(ZoneOffset.ofTotalSeconds(cursor.getInt(startTimeOffsetIndex)));
         TrackStatistics trackStatistics = track.getTrackStatistics();
         if (!cursor.isNull(idIndex)) {
             track.setId(new Track.Id(cursor.getLong(idIndex)));
@@ -126,6 +128,7 @@ public class ContentProviderUtils {
         if (!cursor.isNull(categoryIndex)) {
             track.setCategory(cursor.getString(categoryIndex));
         }
+
         if (!cursor.isNull(startTimeIndex)) {
             trackStatistics.setStartTime(Instant.ofEpochMilli(cursor.getLong(startTimeIndex)));
         }
@@ -288,6 +291,7 @@ public class ContentProviderUtils {
         values.put(TracksColumns.NAME, track.getName());
         values.put(TracksColumns.DESCRIPTION, track.getDescription());
         values.put(TracksColumns.CATEGORY, track.getCategory());
+        values.put(TracksColumns.STARTTIME_OFFSET, track.getZoneOffset().getTotalSeconds());
         if (trackStatistics.getStartTime() != null) {
             values.put(TracksColumns.STARTTIME, trackStatistics.getStartTime().toEpochMilli());
         }

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
@@ -24,6 +24,7 @@ import androidx.annotation.NonNull;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.text.NumberFormat;
+import java.time.ZoneOffset;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -158,7 +159,7 @@ public class GPXTrackExporter implements TrackExporter {
                         writeOpenSegment();
                         wroteSegment = true;
 
-                        writeTrackPoint(trackPoint, sensorPoints);
+                        writeTrackPoint(track.getZoneOffset(), trackPoint, sensorPoints);
                         sensorPoints.clear();
                         break;
                     case SENSORPOINT:
@@ -171,7 +172,7 @@ public class GPXTrackExporter implements TrackExporter {
                             wroteSegment = true;
                         }
 
-                        writeTrackPoint(trackPoint, sensorPoints);
+                        writeTrackPoint(track.getZoneOffset(), trackPoint, sensorPoints);
                         sensorPoints.clear();
                         break;
                     default:
@@ -230,6 +231,7 @@ public class GPXTrackExporter implements TrackExporter {
                     + " http://www.topografix.com/GPX/Private/TopoGrafix/0/1 http://www.topografix.com/GPX/Private/TopoGrafix/0/1/topografix.xsd"
                     + " http://www.garmin.com/xmlschemas/TrackPointExtension/v2 https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd"
                     + " http://www.garmin.com/xmlschemas/PowerExtension/v1 https://www8.garmin.com/xmlschemas/PowerExtensionv1.xsd"
+                    + " http://www.garmin.com/xmlschemas/TrackStatsExtension/v1"
                     + " http://opentracksapp.com/xmlschemas/v1 http://opentracksapp.com/xmlschemas/OpenTracks_v1.xsd\">");
         }
     }
@@ -248,7 +250,7 @@ public class GPXTrackExporter implements TrackExporter {
                         throw new InterruptedException();
                     }
                     Marker marker = contentProviderUtils.createMarker(cursor);
-                    writeMarker(marker);
+                    writeMarker(track.getZoneOffset(), marker);
 
                     cursor.moveToNext();
                 }
@@ -256,13 +258,13 @@ public class GPXTrackExporter implements TrackExporter {
         }
     }
 
-    public void writeMarker(Marker marker) {
+    public void writeMarker(ZoneOffset zoneOffset, Marker marker) {
         if (printWriter != null) {
             printWriter.println("<wpt " + formatLocation(marker.getLatitude(), marker.getLongitude()) + ">");
             if (marker.hasAltitude()) {
                 printWriter.println("<ele>" + ALTITUDE_FORMAT.format(marker.getAltitude().toM()) + "</ele>");
             }
-            printWriter.println("<time>" + StringUtils.formatDateTimeIso8601(marker.getTime()) + "</time>");
+            printWriter.println("<time>" + StringUtils.formatDateTimeIso8601(marker.getTime(), zoneOffset) + "</time>");
             printWriter.println("<name>" + StringUtils.formatCData(marker.getName()) + "</name>");
             printWriter.println("<desc>" + StringUtils.formatCData(marker.getDescription()) + "</desc>");
             printWriter.println("<type>" + StringUtils.formatCData(marker.getCategory()) + "</type>");
@@ -310,7 +312,7 @@ public class GPXTrackExporter implements TrackExporter {
         printWriter.println("</trkseg>");
     }
 
-    public void writeTrackPoint(TrackPoint trackPoint, List<TrackPoint> sensorPoints) {
+    public void writeTrackPoint(ZoneOffset zoneOffset, TrackPoint trackPoint, List<TrackPoint> sensorPoints) {
         if (printWriter != null) {
 
             printWriter.println("<trkpt " + formatLocation(trackPoint.getLatitude(), trackPoint.getLongitude()) + ">");
@@ -319,7 +321,7 @@ public class GPXTrackExporter implements TrackExporter {
                 printWriter.println("<ele>" + ALTITUDE_FORMAT.format(trackPoint.getAltitude().toM()) + "</ele>");
             }
 
-            printWriter.println("<time>" + StringUtils.formatDateTimeIso8601(trackPoint.getTime()) + "</time>");
+            printWriter.println("<time>" + StringUtils.formatDateTimeIso8601(trackPoint.getTime(), zoneOffset) + "</time>");
 
             {
                 String trackPointExtensionContent = "";

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ParsingException.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ParsingException.java
@@ -4,6 +4,10 @@ import androidx.annotation.NonNull;
 
 public class ParsingException extends RuntimeException {
 
+    protected ParsingException(@NonNull String message) {
+        super(message);
+    }
+
     protected ParsingException(@NonNull String message, Exception cause) {
         super(message, cause);
     }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/TrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/TrackImporter.java
@@ -5,10 +5,12 @@ import android.net.Uri;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -89,8 +91,8 @@ public class TrackImporter {
         this.markers.addAll(markers);
     }
 
-    void setTrack(Context context, String name, String uuid, String description, String category, String icon) {
-        track = new Track();
+    void setTrack(Context context, String name, String uuid, String description, String category, String icon, @Nullable ZoneOffset zoneOffset) {
+        track = new Track(zoneOffset != null ? zoneOffset : ZoneOffset.UTC);
         track.setName(name != null ? name : "");
 
         try {

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
@@ -9,6 +9,8 @@ import android.util.Pair;
 
 import androidx.annotation.NonNull;
 
+import java.time.ZoneOffset;
+
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Marker;
@@ -47,9 +49,9 @@ class TrackRecordingManager {
         contentProviderUtils = new ContentProviderUtils(context);
     }
 
-    Track.Id start(TrackPoint segmentStartTrackPoint) {
+    Track.Id start(TrackPoint segmentStartTrackPoint, ZoneOffset zoneOffset) {
         // Create new track
-        Track track = new Track();
+        Track track = new Track(zoneOffset);
         trackId = contentProviderUtils.insertTrack(track);
         track.setId(trackId);
 

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -34,6 +34,7 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
 import java.time.Duration;
+import java.time.ZoneOffset;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.TrackListActivity;
@@ -222,7 +223,9 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         }
 
         // Set recording status
-        Track.Id trackId = trackRecordingManager.start(trackPointCreator.createSegmentStartManual());
+        TrackPoint segmentStartManual = trackPointCreator.createSegmentStartManual();
+        ZoneOffset zoneOffset = ZoneOffset.systemDefault().getRules().getOffset(segmentStartManual.getTime());
+        Track.Id trackId = trackRecordingManager.start(segmentStartManual, zoneOffset);
         updateRecordingStatus(RecordingStatus.record(trackId));
 
         startRecording();

--- a/src/main/java/de/dennisguse/opentracks/util/StringUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/StringUtils.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -48,8 +49,6 @@ import de.dennisguse.opentracks.content.data.Speed;
 public class StringUtils {
 
     private static final String TAG = StringUtils.class.getSimpleName();
-
-    private static final String COORDINATE_DEGREE = "\u00B0";
 
     private StringUtils() {
     }
@@ -70,10 +69,12 @@ public class StringUtils {
     }
 
     /**
-     * Formats the time using the ISO 8601 date time format with fractional seconds in UTC time zone.
+     * Formats the time using the ISO 8601 date time format with fractional seconds.
      */
-    public static String formatDateTimeIso8601(@NonNull Instant time) {
-        return time.toString();
+    public static String formatDateTimeIso8601(@NonNull Instant time, ZoneOffset zoneOffset) {
+        return time
+                .atOffset(zoneOffset)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 
     /**
@@ -286,14 +287,14 @@ public class StringUtils {
      *
      * @param xmlDateTime the XML date time string
      */
-    public static Instant parseTime(String xmlDateTime) {
+    public static OffsetDateTime parseTime(String xmlDateTime) {
         try {
             TemporalAccessor t = DateTimeFormatter.ISO_DATE_TIME.parseBest(xmlDateTime, ZonedDateTime::from, LocalDateTime::from);
             if (t instanceof LocalDateTime) {
                 Log.w(TAG, "Date does not contain timezone information: using UTC.");
                 t = ((LocalDateTime) t).atZone(ZoneOffset.UTC);
             }
-            return Instant.from(t);
+            return OffsetDateTime.from(t);
         } catch (Exception e) {
             Log.e(TAG, "Invalid XML dateTime value");
             throw e;


### PR DESCRIPTION
This PR adds a time offset to the tracks; all times remain stored as Instant (i.e., UTC).

Data migration: existing Track will use current time offset of the phone.
Import: use the time offset from the KML/GPX

Note: time offset is stored in seconds and denotes the difference from UTC.

Note: PR is based upon #1033.

Fixes #301.

* [x] add offset column to Track table
* [x] add field to Track
* [x] add check in ExportImportTest (export/import for GPX and KML)
* [ ] use offset for UI renderings: StatisticsRecordedFragment
* [ ] use offset for naming tracks (default name option)
* [ ] use offset for UI renderings: TrackListActivity
* [ ] use offset for UI renderings: MarkerListActivity
* [x] rebase onto main after merging #1033