### PR TITLE
Settings: add option to disable filter of BLE sensors.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/settings/BluetoothLeAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/BluetoothLeAdapter.java
@@ -45,7 +45,7 @@ public class BluetoothLeAdapter extends BaseAdapter {
 
         Device device = devices.get(position);
         TextView textView = currentView.findViewById(android.R.id.text1);
-        textView.setText(device.getName());
+        textView.setText(device.getNameOrAddress());
 
         return currentView;
     }
@@ -81,8 +81,8 @@ public class BluetoothLeAdapter extends BaseAdapter {
             this.address = address;
         }
 
-        public String getName() {
-            return name;
+        public String getNameOrAddress() {
+            return name != null ? name : getAddress();
         }
 
         public void setName(String name) {

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -232,6 +232,11 @@ public class PreferencesUtils {
         return getString(R.string.settings_sensor_bluetooth_running_speed_and_cadence_key, getBluetoothSensorAddressNone());
     }
 
+    public static boolean getBluetoothFilterEnabled() {
+        final boolean DEFAULT = resources.getBoolean(R.bool.settings_sensor_bluetooth_service_filter_enabled_default);
+        return getBoolean(R.string.settings_sensor_bluetooth_service_filter_enabled_key, DEFAULT);
+    }
+
     public static boolean shouldShowStatsOnLockscreen() {
         final boolean STATS_SHOW_ON_LOCKSCREEN_DEFAULT = resources.getBoolean(R.bool.stats_show_on_lockscreen_while_recording_default);
         return getBoolean(R.string.stats_show_on_lockscreen_while_recording_key, STATS_SHOW_ON_LOCKSCREEN_DEFAULT);

--- a/src/main/java/de/dennisguse/opentracks/settings/bluetooth/BluetoothLeSensorPreference.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/bluetooth/BluetoothLeSensorPreference.java
@@ -34,8 +34,8 @@ import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.settings.BluetoothLeAdapter;
-import de.dennisguse.opentracks.util.BluetoothUtils;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
+import de.dennisguse.opentracks.util.BluetoothUtils;
 
 /**
  * Preference to select a discoverable Bluetooth LE device.
@@ -109,17 +109,14 @@ public abstract class BluetoothLeSensorPreference extends DialogPreference {
         private final ScanCallback scanCallback = new ScanCallback() {
             @Override
             public void onScanResult(int callbackType, ScanResult result) {
-                super.onScanResult(callbackType, result);
                 Log.d(TAG, "Found device " + result.getDevice().getName() + " " + result);
-
                 listAdapter.add(result.getDevice());
             }
 
             @Override
             public void onBatchScanResults(List<ScanResult> results) {
                 for (ScanResult result : results) {
-                    Log.d(TAG, "Found device " + result.getDevice().getName() + " " + result);
-                    listAdapter.add(result.getDevice());
+                    onScanResult(-1, result);
                 }
             }
 
@@ -213,7 +210,12 @@ public abstract class BluetoothLeSensorPreference extends DialogPreference {
                 selectedEntryIndex = 1;
             }
 
-            List<ScanFilter> scanFilter = serviceUUIDs.stream().map(it -> new ScanFilter.Builder().setServiceUuid(it).build()).collect(Collectors.toList());
+            List<ScanFilter> scanFilter = null;
+            if (PreferencesUtils.getBluetoothFilterEnabled()) {
+                scanFilter = serviceUUIDs.stream()
+                        .map(it -> new ScanFilter.Builder().setServiceUuid(it).build())
+                        .collect(Collectors.toList());
+            }
 
             ScanSettings.Builder scanSettingsBuilder = new ScanSettings.Builder();
             scanSettingsBuilder.setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY);

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -39,6 +39,11 @@
     <string name="settings_sensor_bluetooth_cycling_speed_wheel_circumference_key" translatable="false">bluetoothCyclingSpeedWheelCircumference</string>
     <string name="settings_sensor_bluetooth_cycling_speed_wheel_circumference_default" translatable="false">2135</string>
 
+    <string name="settings_sensor_bluetooth_service_filter_enabled_key" translatable="false">bluetoothSensorFilterEnabled</string>
+    <bool name="settings_sensor_bluetooth_service_filter_enabled_default" translatable="false">
+        true
+    </bool>
+
     <string name="settings_default_export_directory_key" translatable="false">settingsDefaultExportDirectory</string>
     <string name="post_workout_export_enabled_key" translatable="false">instantExportEnabled</string>
     <bool name="post_workout_export_enabled_default" translatable="false">false</bool>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -433,6 +433,7 @@ limitations under the License.
     <string name="settings_sensor_cycling_cadence">Cadence</string>
     <string name="settings_sensor_running_speed_and_cadence">Distance, Speed, and Cadence</string>
     <string name="settings_sensor_wheel_circumference">Wheel Circumference (mm)</string>
+    <string name="settings_sensor_bluetooth_service_filter_enabled">Only show Bluetooth devices that announce required services</string>
 
     <!-- Settings Stats -->
     <string name="settings_stats_rate_title">Preferred rate</string>

--- a/src/main/res/xml/settings_sensors.xml
+++ b/src/main/res/xml/settings_sensors.xml
@@ -39,4 +39,11 @@
             android:title="@string/settings_sensor_running_speed_and_cadence" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/settings_advanced">
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/settings_sensor_bluetooth_service_filter_enabled_default"
+            android:key="@string/settings_sensor_bluetooth_service_filter_enabled_key"
+            android:title="@string/settings_sensor_bluetooth_service_filter_enabled" />
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
Fixes #1000.

Some devices do not announce supported service in their discovery package and this prevents users to use those with OpenTracks.
Affected devices are usually smartwatches that can measure heart rate.