### PR TITLE
For charts: consider altitude and speed of being optional

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/chart/ChartPointTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/chart/ChartPointTest.java
@@ -1,5 +1,8 @@
 package de.dennisguse.opentracks.chart;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
@@ -7,14 +10,12 @@ import org.junit.runner.RunWith;
 
 import java.time.Duration;
 
+import de.dennisguse.opentracks.content.data.Altitude;
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Speed;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.fragments.TrackStubUtils;
 import de.dennisguse.opentracks.stats.TrackStatistics;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 @RunWith(AndroidJUnit4.class)
 public class ChartPointTest {
@@ -26,7 +27,7 @@ public class ChartPointTest {
         statistics.setTotalTime(Duration.ofSeconds(1000));
 
         // when
-        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(0), 0, false, false);
+        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(0), Altitude.EGM2008.of(0), false, false);
 
         // then
         assertEquals(1000000, (long) point.getTimeOrDistance());
@@ -39,7 +40,7 @@ public class ChartPointTest {
         statistics.setTotalDistance(Distance.of(1000));
 
         // when
-        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(0), 0, true, true);
+        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(0), Altitude.EGM2008.of(0), true, true);
 
         // then
         assertEquals(1, (long) point.getTimeOrDistance());
@@ -51,7 +52,7 @@ public class ChartPointTest {
         TrackStatistics statistics = new TrackStatistics();
 
         // when
-        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(10), 50, false, true);
+        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(10), Altitude.EGM2008.of(50), false, true);
 
         // then
         assertEquals(50, point.getAltitude(), 0.01);
@@ -65,7 +66,7 @@ public class ChartPointTest {
         TrackStatistics statistics = new TrackStatistics();
 
         // when
-        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(10), 50, false, true);
+        ChartPoint point = new ChartPoint(statistics, TrackStubUtils.createDefaultTrackPoint(), Speed.of(10), Altitude.EGM2008.of(50), false, true);
 
         // then
         assertNull(point.getHeartRate());
@@ -84,7 +85,7 @@ public class ChartPointTest {
         TrackStatistics statistics = new TrackStatistics();
 
         // when
-        ChartPoint point = new ChartPoint(statistics, trackPoint, Speed.of(10), 50, false, true);
+        ChartPoint point = new ChartPoint(statistics, trackPoint, Speed.of(10), Altitude.EGM2008.of(50), false, true);
 
         // then
         assertEquals(100.0, point.getHeartRate(), 0.01);

--- a/src/main/java/de/dennisguse/opentracks/chart/ChartPoint.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartPoint.java
@@ -3,6 +3,7 @@ package de.dennisguse.opentracks.chart;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
+import de.dennisguse.opentracks.content.data.Altitude;
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Speed;
 import de.dennisguse.opentracks.content.data.TrackPoint;
@@ -14,7 +15,7 @@ public class ChartPoint {
     private double timeOrDistance;
 
     //Y-axis
-    private final double altitude;
+    private Double altitude;
     private Double speed;
     private Double pace;
     private Double heartRate;
@@ -27,17 +28,21 @@ public class ChartPoint {
         this.altitude = altitude;
     }
 
-    public ChartPoint(@NonNull TrackStatistics trackStatistics, @NonNull TrackPoint trackPoint, Speed smoothedSpeed, double smoothedAltitude_m, boolean chartByDistance, boolean metricUnits) {
+    public ChartPoint(@NonNull TrackStatistics trackStatistics, @NonNull TrackPoint trackPoint, Speed smoothedSpeed, Altitude smoothedAltitude, boolean chartByDistance, boolean metricUnits) {
         if (chartByDistance) {
             timeOrDistance = trackStatistics.getTotalDistance().toKM_Miles(metricUnits);
         } else {
             timeOrDistance = trackStatistics.getTotalTime().toMillis();
         }
 
-        altitude = Distance.of(smoothedAltitude_m).toM_FT(metricUnits);
+        if (smoothedAltitude != null) {
+            altitude = Distance.of(smoothedAltitude.toM()).toM_FT(metricUnits);
+        }
 
-        speed = smoothedSpeed.to(metricUnits);
-        pace = smoothedSpeed.toPace(metricUnits).toMillis() * UnitConversions.MS_TO_S * UnitConversions.S_TO_MIN;
+        if (smoothedSpeed != null) {
+            speed = smoothedSpeed.to(metricUnits);
+            pace = smoothedSpeed.toPace(metricUnits).toMillis() * UnitConversions.MS_TO_S * UnitConversions.S_TO_MIN;
+        }
         if (trackPoint.hasHeartRate()) {
             heartRate = (double) trackPoint.getHeartRate_bpm();
         }

--- a/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
@@ -213,7 +213,7 @@ public class ChartView extends View {
 
             @Override
             protected boolean drawIfChartPointHasNoData() {
-                return true;
+                return false;
             }
         });
 

--- a/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
@@ -41,7 +41,6 @@ import androidx.core.view.GestureDetectorCompat;
 import java.text.NumberFormat;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import de.dennisguse.opentracks.MarkerDetailActivity;
@@ -873,9 +872,9 @@ public class ChartView extends View {
         boolean drawFirstPoint = false;
         path.rewind();
 
-        Iterator<ChartPoint> iterator = chartPoints.iterator();
-        while (iterator.hasNext()) {
-            ChartPoint point = iterator.next();
+        Integer finalX = null;
+
+        for (ChartPoint point : chartPoints) {
             if (!series.isChartPointValid(point)) {
                 continue;
             }
@@ -893,10 +892,12 @@ public class ChartView extends View {
             // draw graph
             path.lineTo(x, y);
 
-            // last point: move to lower right
-            if (!iterator.hasNext()) {
-                path.lineTo(x, yCorner);
-            }
+            finalX = x;
+        }
+
+        // last point: move to lower right
+        if (finalX != null) {
+            path.lineTo(finalX, yCorner);
         }
 
         // back to lower left corner

--- a/src/main/java/de/dennisguse/opentracks/content/TrackDataListener.java
+++ b/src/main/java/de/dennisguse/opentracks/content/TrackDataListener.java
@@ -17,7 +17,9 @@
 package de.dennisguse.opentracks.content;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
+import de.dennisguse.opentracks.content.data.Altitude;
 import de.dennisguse.opentracks.content.data.Marker;
 import de.dennisguse.opentracks.content.data.Speed;
 import de.dennisguse.opentracks.content.data.Track;
@@ -49,7 +51,7 @@ public interface TrackDataListener {
      *
      * @param trackPoint the trackPoint
      */
-    default void onSampledInTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics trackStatistics, Speed smoothedSpeed, double smoothedAltitude_m) {
+    default void onSampledInTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics trackStatistics, Speed smoothedSpeed, @Nullable Altitude smoothedAltitude_m) {
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/content/data/Altitude.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/Altitude.java
@@ -14,6 +14,8 @@ public abstract class Altitude {
         return altitude_m;
     }
 
+    public abstract Altitude replace(double altitude_m);
+
     public abstract int getLabelId();
 
     public static class WGS84 extends Altitude {
@@ -30,6 +32,11 @@ public abstract class Altitude {
         public static Altitude of(double altitude_m) {
             return new WGS84(altitude_m);
         }
+
+        @Override
+        public Altitude replace(double altitude_m) {
+            return new WGS84(altitude_m);
+        }
     }
 
     public static class EGM2008 extends Altitude {
@@ -44,6 +51,11 @@ public abstract class Altitude {
         }
 
         public static Altitude of(double altitude_m) {
+            return new EGM2008(altitude_m);
+        }
+
+        @Override
+        public Altitude replace(double altitude_m) {
             return new EGM2008(altitude_m);
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/fragments/ChartFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/ChartFragment.java
@@ -35,14 +35,15 @@ import de.dennisguse.opentracks.TrackActivityDataHubInterface;
 import de.dennisguse.opentracks.chart.ChartPoint;
 import de.dennisguse.opentracks.content.TrackDataHub;
 import de.dennisguse.opentracks.content.TrackDataListener;
+import de.dennisguse.opentracks.content.data.Altitude;
 import de.dennisguse.opentracks.content.data.Marker;
 import de.dennisguse.opentracks.content.data.Speed;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.content.data.TrackPoint;
 import de.dennisguse.opentracks.databinding.ChartBinding;
+import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.stats.TrackStatisticsUpdater;
-import de.dennisguse.opentracks.settings.PreferencesUtils;
 
 /**
  * A fragment to display track chart to the user.
@@ -189,9 +190,9 @@ public class ChartFragment extends Fragment implements TrackDataListener {
         }
     }
 
-    public void onSampledInTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics trackStatistics, Speed smoothedSpeed, double smoothedAltitude_m) {
+    public void onSampledInTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics trackStatistics, Speed smoothedSpeed, Altitude smoothedAltitude) {
         if (isResumed()) {
-            ChartPoint point = new ChartPoint(trackStatistics, trackPoint, smoothedSpeed, smoothedAltitude_m, chartByDistance, viewBinding.chartView.getMetricUnits());
+            ChartPoint point = new ChartPoint(trackStatistics, trackPoint, smoothedSpeed, smoothedAltitude, chartByDistance, viewBinding.chartView.getMetricUnits());
             pendingPoints.add(point);
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/stats/AltitudeRingBuffer.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/AltitudeRingBuffer.java
@@ -1,0 +1,32 @@
+package de.dennisguse.opentracks.stats;
+
+import androidx.annotation.Nullable;
+
+import de.dennisguse.opentracks.content.data.Altitude;
+
+public class AltitudeRingBuffer extends RingBuffer<Altitude> {
+
+    private Altitude firstAltitude;
+
+    AltitudeRingBuffer(int size) {
+        super(size);
+    }
+
+    AltitudeRingBuffer(RingBuffer<Altitude> toCopy) {
+        super(toCopy);
+    }
+
+    @Nullable
+    @Override
+    protected Number from(Altitude object) {
+        if (firstAltitude == null) {
+            firstAltitude = object;
+        }
+        return object.toM();
+    }
+
+    @Override
+    protected Altitude to(double object) {
+        return firstAltitude.replace(object);
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/stats/SpeedRingBuffer.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/SpeedRingBuffer.java
@@ -1,0 +1,27 @@
+package de.dennisguse.opentracks.stats;
+
+import androidx.annotation.Nullable;
+
+import de.dennisguse.opentracks.content.data.Speed;
+
+public class SpeedRingBuffer extends RingBuffer<Speed> {
+
+    SpeedRingBuffer(int size) {
+        super(size);
+    }
+
+    SpeedRingBuffer(RingBuffer<Speed> toCopy) {
+        super(toCopy);
+    }
+
+    @Nullable
+    @Override
+    protected Number from(Speed object) {
+        return object.toMPS();
+    }
+
+    @Override
+    protected Speed to(double object) {
+        return Speed.of(object);
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -23,6 +23,7 @@ import androidx.annotation.VisibleForTesting;
 import java.time.Duration;
 import java.time.Instant;
 
+import de.dennisguse.opentracks.content.data.Altitude;
 import de.dennisguse.opentracks.content.data.Distance;
 import de.dennisguse.opentracks.content.data.Speed;
 
@@ -258,8 +259,10 @@ public class TrackStatistics {
         altitudeExtremities.setMax(altitude_m);
     }
 
-    public void updateAltitudeExtremities(double altitude_m) {
-        altitudeExtremities.update(altitude_m);
+    public void updateAltitudeExtremities(Altitude altitude) {
+        if (altitude != null) {
+            altitudeExtremities.update(altitude.toM());
+        }
     }
 
     public boolean hasTotalAltitudeGain() {


### PR DESCRIPTION
Considering altitude and speed as optional (i.e., null vs 0), enables the charts to scale the y-axis according to the min/max value instead of 0/max.
This is nice on higher altitudes.