### PR TITLE
Try to takkle down export dir issues

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/DirectoryChooserActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/DirectoryChooserActivity.java
@@ -45,7 +45,7 @@ public abstract class DirectoryChooserActivity extends AppCompatActivity {
 
     protected void onActivityResultCustom(int requestCode, int resultCode, @Nullable Intent resultData) {
         if (requestCode == DIRECTORY_PICKER_REQUEST_CODE) {
-            if (resultCode == Activity.RESULT_OK) {
+            if (resultCode == Activity.RESULT_OK && resultData != null) {
                 Uri directoryUri = resultData.getData();
 
                 int takeFlags = resultData.getFlags();
@@ -107,16 +107,21 @@ public abstract class DirectoryChooserActivity extends AppCompatActivity {
         @Override
         protected void onActivityResultCustom(int requestCode, int resultCode, @Nullable Intent resultData) {
             if (requestCode == DIRECTORY_PICKER_REQUEST_CODE) {
+                DocumentFile oldDirectoryUri = PreferencesUtils.getDefaultExportDirectoryUri(this);
                 switch (resultCode) {
                     case RESULT_OK:
-                        IntentUtils.releaseDirectoryAccessPermission(getApplicationContext(), PreferencesUtils.getDefaultExportDirectoryUri(this));
+                        if (resultData != null) {
+                            Uri newDirectoryUri = resultData.getData();
+                            if (oldDirectoryUri != null && !newDirectoryUri.equals(oldDirectoryUri.getUri())) {
+                                IntentUtils.releaseDirectoryAccessPermission(getApplicationContext(), oldDirectoryUri);
+                            }
 
-                        Uri directoryUri = resultData.getData();
-                        PreferencesUtils.setDefaultExportDirectoryUri(directoryUri);
-                        IntentUtils.persistDirectoryAccessPermission(getApplicationContext(), directoryUri, resultData.getFlags());
+                            PreferencesUtils.setDefaultExportDirectoryUri(newDirectoryUri);
+                            IntentUtils.persistDirectoryAccessPermission(getApplicationContext(), newDirectoryUri, resultData.getFlags());
+                        }
                         break;
                     case RESULT_CANCELED:
-                        IntentUtils.releaseDirectoryAccessPermission(getApplicationContext(), PreferencesUtils.getDefaultExportDirectoryUri(this));
+                        IntentUtils.releaseDirectoryAccessPermission(getApplicationContext(), oldDirectoryUri);
                         PreferencesUtils.setDefaultExportDirectoryUri(null);
                         break;
                 }

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -300,9 +300,9 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
             trackRecordingManager.end(trackPointCreator);
         }
 
-        ExportUtils.postWorkoutExport(this, trackId, new ExportServiceResultReceiver(new Handler(), this));
-
         endRecording(true);
+
+        ExportUtils.postWorkoutExport(this, trackId, new ExportServiceResultReceiver(new Handler(), this));
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)

--- a/src/main/java/de/dennisguse/opentracks/settings/ImportExportSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/ImportExportSettingsFragment.java
@@ -66,7 +66,11 @@ public class ImportExportSettingsFragment extends PreferenceFragmentCompat {
         instantExportDirectoryPreference.setSummaryProvider(preference -> {
             DocumentFile directory = PreferencesUtils.getDefaultExportDirectoryUri(getContext());
             //Use same value for not set as Androidx ListPreference and EditTextPreference
-            return directory != null ? directory.getName() : getString(R.string.not_set);
+            if (directory == null) {
+                return getString(R.string.not_set);
+            }
+
+            return directory.getUri().toString() + (directory.canWrite() ? "" : getString(R.string.export_dir_not_writable));
         });
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -531,12 +531,12 @@ public class PreferencesUtils {
     }
 
     public static DocumentFile getDefaultExportDirectoryUri(Context context) {
-        String singleExportDirectorySettingsKey = getString(R.string.settings_default_export_directory_key, null);
-        if (singleExportDirectorySettingsKey == null) {
+        String singleExportDirectory = getString(R.string.settings_default_export_directory_key, null);
+        if (singleExportDirectory == null) {
             return null;
         }
         try {
-            return DocumentFile.fromTreeUri(context, Uri.parse(singleExportDirectorySettingsKey));
+            return DocumentFile.fromTreeUri(context, Uri.parse(singleExportDirectory));
         } catch (Exception e) {
             Log.w(TAG, "Could not decode default export directory: " + e.getMessage());
         }

--- a/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
@@ -6,6 +6,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.DocumentsContract;
 import android.util.Log;
+import android.widget.Toast;
 
 import androidx.documentfile.provider.DocumentFile;
 
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.content.data.Track;
 import de.dennisguse.opentracks.io.file.TrackFileFormat;
 import de.dennisguse.opentracks.io.file.exporter.ExportService;
@@ -32,6 +34,11 @@ public class ExportUtils {
         if (PreferencesUtils.shouldInstantExportAfterWorkout(context)) {
             TrackFileFormat trackFileFormat = PreferencesUtils.getExportTrackFileFormat();
             DocumentFile directory = PreferencesUtils.getDefaultExportDirectoryUri(context);
+
+            if (directory == null || !directory.canWrite()) {
+                Toast.makeText(context, R.string.export_cannot_write_to_dir, Toast.LENGTH_LONG).show();
+                return;
+            }
 
             ExportService.enqueue(context, resultReceiver, trackId, trackFileFormat, directory.getUri());
         }

--- a/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
@@ -217,13 +217,10 @@ public class IntentUtils {
             return;
         }
         final Uri documentUri = documentFile.getUri();
-        final List<UriPermission> persistedUriPermissions = context.getContentResolver().getPersistedUriPermissions();
-        for (final UriPermission permission : persistedUriPermissions) {
-            final Uri uri = permission.getUri();
-            if (uri.equals(documentUri)) {
-                context.getContentResolver().releasePersistableUriPermission(uri, 0);
-            }
-        }
+        context.getContentResolver().getPersistedUriPermissions().stream()
+                .map(UriPermission::getUri)
+                .filter(documentUri::equals)
+                .forEach(u -> context.getContentResolver().releasePersistableUriPermission(u, 0));
     }
 
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -201,6 +201,8 @@ limitations under the License.
     <string name="export_with_photos">with photos</string>
     <string name="export_without_photos">without photos</string>
     <string name="export_error_post_workout">Post-workout export failed, please check the export directory.</string>
+    <string name="export_cannot_write_to_dir">Cannot write to export directory.</string>
+    <string name="export_dir_not_writable">" (not writable!)"</string>
     <string name="export_progress_message">Exporting to %1$s&#8230;</string>
     <string name="export_track_already_exists_msg">The track %1$s already exists at the destination directory.</string>
     <string name="export_all_do_it_for_all">do it for all conflicts</string>


### PR DESCRIPTION
I'm still having problems with a nextcloud export directory. Sometimes (after new install of a nightly), the directory vanishes. Vanishes as in the settings activity doesn't show anything, even not "not set". So I changed the display of the name to the uri and added an indicator if it is writable.
I also added a check if the post-workout export is enabled, but the directory is null or not writable. 
Additionally I only release the uri permission, if the new selected directory is different to the previous one.