### PR TITLE
Bugfix: use monotonic clock.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/handlers/MonotonicClock.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/MonotonicClock.java
@@ -1,0 +1,40 @@
+package de.dennisguse.opentracks.services.handlers;
+
+import android.os.SystemClock;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+/**
+ * A monotonic clock relative to the device's clock at time of the instantiation.
+ * Uses device time since startup.
+ * Replacement for java.time.Clock as it may not be monotonic (i.e., can jump back and forwards).
+ */
+public class MonotonicClock extends Clock {
+
+    private final long epochAtCreation;
+
+    private final long elapsedRealtimeAtCreation;
+
+    public MonotonicClock() {
+        epochAtCreation = Instant.now().toEpochMilli();
+        elapsedRealtimeAtCreation = SystemClock.elapsedRealtime();
+    }
+
+    @Override
+    public Instant instant() {
+        long current = (SystemClock.elapsedRealtime() - elapsedRealtimeAtCreation);
+        return Instant.ofEpochMilli(epochAtCreation + current);
+    }
+
+    @Override
+    public ZoneId getZone() {
+        throw new RuntimeException("Not implemented");
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        throw new RuntimeException("Not implemented");
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
@@ -30,7 +30,7 @@ public class TrackPointCreator implements BluetoothRemoteSensorManager.SensorDat
     private final Callback service;
 
     @NonNull
-    private Clock clock = Clock.systemUTC();
+    private Clock clock = new MonotonicClock();
 
     private final GPSHandler gpsHandler;
     private BluetoothRemoteSensorManager remoteSensorManager;

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -220,9 +220,7 @@ public class TrackStatistics {
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     public void addMovingTime(Duration time) {
         if (time.isNegative()) {
-            // Needs implementation of a monotonic Clock #800
-            // throw new RuntimeException("Moving time cannot be negative");
-            return;
+            throw new RuntimeException("Moving time cannot be negative");
         }
         movingTime = movingTime.plus(time);
     }


### PR DESCRIPTION
`System.currentTimeMillis()` is not monotonic and might jump forward/backward whenever the local device time is updated.
This results in crashes while recording:
1. if the time jumps before start of a current segment
2. if the time jumps before the time of the previous trackpoint

Exceptions are nowadays created in TrackStatistics to prevent invalid data, leading to crashes.

We now use a clock that is relative to it's creation while using the time since boot of the device (guaranteed to be monotonic).

https://developer.android.com/reference/android/os/SystemClock

Fixes #800.
