### PR TITLE
Recording GPS-based TrackPoints optimization (BLE sensor only)

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -169,7 +169,7 @@ public class ExportImportTest {
         track = contentProviderUtils.getTrack(trackId);
         trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         markers = contentProviderUtils.getMarkers(trackId);
-        assertEquals(10, trackPoints.size());
+        assertEquals(11, trackPoints.size());
         assertEquals(2, markers.size());
     }
 

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestRecording.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestRecording.java
@@ -742,7 +742,7 @@ public class TrackRecordingServiceTestRecording {
         // when
         String sensor2 = "2020-02-02T02:02:04Z";
         trackPointCreator.setClock(sensor2);
-        remoteSensorManager.onChanged(new SensorDataRunning("", "", Speed.of(5), null, Distance.of(2))); //TODO Should be ignored; distance should be added to the next TrackPoint
+        remoteSensorManager.onChanged(new SensorDataRunning("", "", Speed.of(5), null, Distance.of(2)));
 
         // when
         String gps1 = "2020-02-02T02:02:05Z";
@@ -765,7 +765,7 @@ public class TrackRecordingServiceTestRecording {
         // when
         String sensor5 = "2020-02-02T02:02:10Z";
         trackPointCreator.setClock(sensor5);
-        remoteSensorManager.onChanged(new SensorDataRunning("", "", Speed.of(5), null, Distance.of(16)));
+        remoteSensorManager.onChanged(new SensorDataRunning("", "", Speed.of(5), null, Distance.of(16))); //Should be ignored
 
         // when
         String gps3 = "2020-02-02T02:02:12Z";
@@ -784,7 +784,7 @@ public class TrackRecordingServiceTestRecording {
         // then
         new TrackPointAssert().assertEquals(List.of(
                 new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.parse(startTime)),
-                new TrackPoint(TrackPoint.Type.SENSORPOINT, Instant.parse(sensor2)) // TODO Should be ignored; is stored as it assumed to be first in current segment.
+                new TrackPoint(TrackPoint.Type.SENSORPOINT, Instant.parse(sensor2)) //First moving TrackPoint: store as the time might be interesting.
                         .setSpeed(Speed.of(5))
                         .setSensorDistance(Distance.of(2)),
                 new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.parse(gps1))
@@ -796,27 +796,21 @@ public class TrackRecordingServiceTestRecording {
                 new TrackPoint(TrackPoint.Type.SENSORPOINT, Instant.parse(sensor3))
                         .setSpeed(Speed.of(5))
                         .setSensorDistance(Distance.of(10)),
-/*
-//TODO BUG Should be stored, but sensorDistance is used instead of distance to previous TRACKPOINT.
+                new TrackPoint(TrackPoint.Type.SENSORPOINT, Instant.parse(sensor5)) //TODO No need to store this TrackPoint, data could be merged into the next one
+                        .setSpeed(Speed.of(5))
+                        .setSensorDistance(Distance.of(4)),
                 new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.parse(gps3))
                         .setLatitude(45.001)
                         .setLongitude(35)
                         .setHorizontalAccuracy(Distance.of(1))
                         .setSpeed(Speed.of(5))
-                        .setSensorDistance(Distance.of(2)),
+                        .setSensorDistance(Distance.of(0)),
                 new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.parse(gps4))
                         .setLatitude(45.001)
                         .setLongitude(35)
                         .setHorizontalAccuracy(Distance.of(1))
                         .setSpeed(Speed.of(5))
-                        .setSensorDistance(Distance.of(2)),
- */
-                new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.parse(gps4))
-                        .setLatitude(45.001)
-                        .setLongitude(35)
-                        .setHorizontalAccuracy(Distance.of(1))
-                        .setSpeed(Speed.of(5))
-                        .setSensorDistance(Distance.of(4)),
+                        .setSensorDistance(Distance.of(0)),
                 new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.parse(stopTime))
                         .setSensorDistance(Distance.of(11))
                         .setSpeed(Speed.of(5))

--- a/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
+++ b/src/main/java/de/dennisguse/opentracks/content/data/TrackPoint.java
@@ -324,6 +324,11 @@ public class TrackPoint {
         if (hasSensorDistance()) {
             return getSensorDistance();
         }
+        return distanceToPreviousFromLocation(previous);
+    }
+
+    @NonNull
+    public Distance distanceToPreviousFromLocation(@NonNull TrackPoint previous) {
         if (!hasLocation() || hasLocation() != previous.hasLocation()) {
             throw new RuntimeException("Cannot compute distance.");
         }

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
@@ -171,12 +171,14 @@ class TrackRecordingManager {
             Log.d(TAG, "Ignoring TrackPoint as it has no distance.");
             return false;
         }
-        TrackPoint distanceTo = lastStoredTrackPoint;
+
+        Distance distanceToLastStoredTrackPoint;
         if (trackPoint.hasLocation() && !lastStoredTrackPoint.hasLocation()) {
-            distanceTo = lastStoredTrackPointWithLocation;
+            distanceToLastStoredTrackPoint = trackPoint.distanceToPreviousFromLocation(lastStoredTrackPointWithLocation);
+        } else {
+            distanceToLastStoredTrackPoint = trackPoint.distanceToPrevious(lastStoredTrackPoint);
         }
 
-        Distance distanceToLastStoredTrackPoint = trackPoint.distanceToPrevious(distanceTo);
         if (distanceToLastStoredTrackPoint.greaterThan(maxRecordingDistance)) {
             trackPoint.setType(TrackPoint.Type.SEGMENT_START_AUTOMATIC);
             insertTrackPoint(trackPoint);


### PR DESCRIPTION
A GPS-based TrackPoint that contained distance sensor data might be ignored depending on the recording distance interval.
Assumption: The actual distance should be computed against the previous GPS-based TrackPoint.

Until now, we would just ignore some of those GPS-based TrackPoints, but they costs a lot of energy to acquire, so why not store them?

