### PR TITLE
Change handling of Uri and DocumentFile for #1080 and #1095

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/settings/ImportExportSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/ImportExportSettingsFragment.java
@@ -1,5 +1,8 @@
 package de.dennisguse.opentracks.settings;
 
+import android.content.Intent;
+import android.content.UriPermission;
+import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.documentfile.provider.DocumentFile;
@@ -7,10 +10,12 @@ import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
+import java.util.List;
 import java.util.Locale;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.io.file.TrackFileFormat;
+import de.dennisguse.opentracks.util.IntentUtils;
 
 public class ImportExportSettingsFragment extends PreferenceFragmentCompat {
 
@@ -35,7 +40,7 @@ public class ImportExportSettingsFragment extends PreferenceFragmentCompat {
         setExportDirectorySummary();
 
         Preference instantExportEnabledPreference = findPreference(getString(R.string.post_workout_export_enabled_key));
-        instantExportEnabledPreference.setEnabled(PreferencesUtils.isDefaultExportDirectoryUri(getContext()));
+        instantExportEnabledPreference.setEnabled(PreferencesUtils.isDefaultExportDirectoryUri());
     }
 
     private void setExportTrackFileFormatOptions() {
@@ -64,13 +69,14 @@ public class ImportExportSettingsFragment extends PreferenceFragmentCompat {
     private void setExportDirectorySummary() {
         Preference instantExportDirectoryPreference = findPreference(getString(R.string.settings_default_export_directory_key));
         instantExportDirectoryPreference.setSummaryProvider(preference -> {
-            DocumentFile directory = PreferencesUtils.getDefaultExportDirectoryUri(getContext());
+            Uri directoryUri = PreferencesUtils.getDefaultExportDirectoryUri();
+            DocumentFile directory = IntentUtils.toDocumentFile(getContext(), directoryUri);
             //Use same value for not set as Androidx ListPreference and EditTextPreference
             if (directory == null) {
                 return getString(R.string.not_set);
             }
 
-            return directory.getUri().toString() + (directory.canWrite() ? "" : getString(R.string.export_dir_not_writable));
+            return directoryUri.toString() + (directory.canWrite() ? "" : getString(R.string.export_dir_not_writable));
         });
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -497,9 +497,9 @@ public class PreferencesUtils {
     }
 
 
-    public static boolean shouldInstantExportAfterWorkout(Context context) {
+    public static boolean shouldInstantExportAfterWorkout() {
         final boolean INSTANT_POST_WORKOUT_EXPORT_DEFAULT = resources.getBoolean(R.bool.post_workout_export_enabled_default);
-        return getBoolean(R.string.post_workout_export_enabled_key, INSTANT_POST_WORKOUT_EXPORT_DEFAULT) && isDefaultExportDirectoryUri(context);
+        return getBoolean(R.string.post_workout_export_enabled_key, INSTANT_POST_WORKOUT_EXPORT_DEFAULT) && isDefaultExportDirectoryUri();
     }
 
     public static TrackFileFormat getExportTrackFileFormat() {
@@ -535,26 +535,29 @@ public class PreferencesUtils {
         PreferenceManager.setDefaultValues(context, R.xml.settings, readAgain);
     }
 
-    public static DocumentFile getDefaultExportDirectoryUri(Context context) {
+    public static Uri getDefaultExportDirectoryUri() {
         String singleExportDirectory = getString(R.string.settings_default_export_directory_key, null);
         if (singleExportDirectory == null) {
             return null;
         }
         try {
-            return DocumentFile.fromTreeUri(context, Uri.parse(singleExportDirectory));
+            Log.d(TAG, "DefaultExportDirectoryUri: " + singleExportDirectory);
+            return Uri.parse(singleExportDirectory);
         } catch (Exception e) {
-            Log.w(TAG, "Could not decode default export directory: " + e.getMessage());
+            Log.w(TAG, "Could not parse default export directory Uri: " + e.getMessage());
         }
         return null;
     }
 
     public static void setDefaultExportDirectoryUri(Uri directoryUri) {
         String value = directoryUri != null ? directoryUri.toString() : null;
+        Log.d(TAG, "Set ExportDirectoryUri: " + directoryUri);
+
         setString(R.string.settings_default_export_directory_key, value);
     }
 
-    public static boolean isDefaultExportDirectoryUri(Context context) {
-        return getDefaultExportDirectoryUri(context) != null;
+    public static boolean isDefaultExportDirectoryUri() {
+        return getDefaultExportDirectoryUri() != null;
     }
 
     public static int getLayoutColumnsByDefault() {

--- a/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
@@ -31,9 +31,9 @@ public class ExportUtils {
     private static final String TAG = ExportUtils.class.getSimpleName();
 
     public static void postWorkoutExport(Context context, Track.Id trackId, ExportServiceResultReceiver resultReceiver) {
-        if (PreferencesUtils.shouldInstantExportAfterWorkout(context)) {
+        if (PreferencesUtils.shouldInstantExportAfterWorkout()) {
             TrackFileFormat trackFileFormat = PreferencesUtils.getExportTrackFileFormat();
-            DocumentFile directory = PreferencesUtils.getDefaultExportDirectoryUri(context);
+            DocumentFile directory = IntentUtils.toDocumentFile(context, PreferencesUtils.getDefaultExportDirectoryUri());
 
             if (directory == null || !directory.canWrite()) {
                 Toast.makeText(context, R.string.export_cannot_write_to_dir, Toast.LENGTH_LONG).show();

--- a/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.UriPermission;
 import android.net.Uri;
+import android.util.Log;
 
 import androidx.documentfile.provider.DocumentFile;
 
@@ -79,15 +80,27 @@ public class IntentUtils {
         context.getContentResolver().takePersistableUriPermission(directoryUri, newFlags);
     }
 
-    public static void releaseDirectoryAccessPermission(Context context, final DocumentFile documentFile) {
-        if (documentFile == null) {
+    public static void releaseDirectoryAccessPermission(Context context, final Uri documentUri) {
+        if (documentUri == null) {
             return;
         }
-        final Uri documentUri = documentFile.getUri();
+
         context.getContentResolver().getPersistedUriPermissions().stream()
                 .map(UriPermission::getUri)
                 .filter(documentUri::equals)
                 .forEach(u -> context.getContentResolver().releasePersistableUriPermission(u, 0));
+    }
+
+    public static DocumentFile toDocumentFile(Context context, Uri directoryUri) {
+        if (directoryUri == null) {
+            return null;
+        }
+        try {
+            return DocumentFile.fromTreeUri(context, directoryUri);
+        } catch (Exception e) {
+            Log.w(TAG, "Could not decode directory: " + e.getMessage());
+        }
+        return null;
     }
 
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -639,4 +639,5 @@ limitations under the License.
     <string name="field_set_primary">Primary</string>
     <string name="field_set_secondary">Secondary</string>
     <string name="field_remove_from_layout">Remove</string>
+    <string name="no_compatible_file_manager_installed">No compatible file manager installed</string>
 </resources>


### PR DESCRIPTION
The Uris from Intent.getData() and DocumentFile.getUri() seems to be different. I think PreferencesUtils should only work with the original Uri as well as the permission handling logic.

IntentUtils.toDocumentFile can be used to convert it to a DocumentFile later on to actually work with.

Adds "No file manager found" message if no activity with OPEN_DOCUMENT_TREE is found. #1095

Removed deprecation of `startActivityForResult`.

I'm not sure if `IntentUtils.toDocumentFile(getContext(), directoryUri);` is at the right place. Maybe `FileUtils` is a better place.


This PR improves the situation a bit, but still doesn't solve the lost write permission on the next cloud folders. I'm still investigating.