### PR TITLE
Track recording without GPS: warn user with a Snackbar.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -2,7 +2,6 @@ package de.dennisguse.opentracks;
 
 import android.app.AlertDialog;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.os.Build;
 import android.os.Bundle;
@@ -17,6 +16,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
+import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayoutMediator;
 
 import java.util.List;
@@ -31,6 +31,7 @@ import de.dennisguse.opentracks.fragments.ChooseActivityTypeDialogFragment;
 import de.dennisguse.opentracks.fragments.StatisticsRecordingFragment;
 import de.dennisguse.opentracks.services.TrackRecordingService;
 import de.dennisguse.opentracks.services.TrackRecordingServiceConnection;
+import de.dennisguse.opentracks.services.handlers.GpsStatusValue;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.settings.SettingsActivity;
 import de.dennisguse.opentracks.ui.intervals.IntervalsFragment;
@@ -70,48 +71,44 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
 
     private TrackRecordingService.RecordingStatus recordingStatus = TrackRecordingService.STATUS_DEFAULT;
 
-    private final TrackRecordingServiceConnection.Callback bindChangedCallback = new TrackRecordingServiceConnection.Callback() {
-        @Override
-        public void onConnected(TrackRecordingService service) {
+    private final TrackRecordingServiceConnection.Callback bindChangedCallback = service -> {
+        service.getRecordingStatusObservable()
+                .observe(TrackRecordingActivity.this, this::onRecordingStatusChanged);
 
-            service.getRecordingStatusObservable()
-                    .observe(TrackRecordingActivity.this, status -> onRecordingStatusChanged(status));
+        service.getGpsStatusObservable()
+                .observe(TrackRecordingActivity.this, this::onGpsStatusChanged);
 
-            if (!service.isRecording()) {
-                if (trackId == null) {
-                    // trackId isn't initialized -> leads a new recording.
-                    trackId = service.startNewTrack();
-                } else {
-                    // trackId is initialized -> resumes the track.
-                    service.resumeTrack(trackId);
-                }
-
-                // A recording track is on.
-                trackDataHub.loadTrack(trackId);
-                trackDataHub.setRecordingStatus(recordingStatus);
+        if (!service.isRecording()) {
+            if (trackId == null) {
+                // trackId isn't initialized -> leads a new recording.
+                trackId = service.startNewTrack();
+            } else {
+                // trackId is initialized -> resumes the track.
+                service.resumeTrack(trackId);
             }
+
+            // A recording track is on.
+            trackDataHub.loadTrack(trackId);
+            trackDataHub.setRecordingStatus(recordingStatus);
         }
     };
 
-    private final OnSharedPreferenceChangeListener sharedPreferenceChangeListener = new OnSharedPreferenceChangeListener() {
-        @Override
-        public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-            if (PreferencesUtils.isKey(R.string.stats_show_on_lockscreen_while_recording_key, key)) {
-                setLockscreenPolicy();
-            }
-            if (PreferencesUtils.isKey(R.string.stats_keep_screen_on_while_recording_key, key)) {
-                setScreenOnPolicy();
-            }
-            if (PreferencesUtils.isKey(R.string.stats_fullscreen_while_recording_key, key)) {
-                setFullscreenPolicy();
-            }
-            if (PreferencesUtils.isKey(R.string.recording_distance_interval_key, key)) {
-                trackDataHub.setRecordingDistanceInterval(PreferencesUtils.getRecordingDistanceInterval());
-            }
-            if (key == null) return;
-
-            runOnUiThread(TrackRecordingActivity.this::invalidateOptionsMenu);
+    private final OnSharedPreferenceChangeListener sharedPreferenceChangeListener = (sharedPreferences, key) -> {
+        if (PreferencesUtils.isKey(R.string.stats_show_on_lockscreen_while_recording_key, key)) {
+            setLockscreenPolicy();
         }
+        if (PreferencesUtils.isKey(R.string.stats_keep_screen_on_while_recording_key, key)) {
+            setScreenOnPolicy();
+        }
+        if (PreferencesUtils.isKey(R.string.stats_fullscreen_while_recording_key, key)) {
+            setFullscreenPolicy();
+        }
+        if (PreferencesUtils.isKey(R.string.recording_distance_interval_key, key)) {
+            trackDataHub.setRecordingDistanceInterval(PreferencesUtils.getRecordingDistanceInterval());
+        }
+        if (key == null) return;
+
+        runOnUiThread(TrackRecordingActivity.this::invalidateOptionsMenu);
     };
 
     private MenuItem insertMarkerMenuItem;
@@ -405,5 +402,19 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
 
         setLockscreenPolicy();
         setScreenOnPolicy();
+    }
+
+    private void onGpsStatusChanged(GpsStatusValue gpsStatusValue) {
+        Log.e("probando", "onGpsStautsChanged: is started? " + gpsStatusValue.isGpsStarted() + " | " + gpsStatusValue);
+        var coordinatorLayout = viewBinding.trackRecordingCoordinatorLayout;
+        if (coordinatorLayout == null) {
+            return;
+        }
+        Snackbar snackbar = Snackbar
+                .make(coordinatorLayout, "GPS Status changed: " + gpsStatusValue, Snackbar.LENGTH_INDEFINITE)
+                .setAction("OK", v -> {
+
+                });
+        snackbar.show();
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -19,6 +19,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayoutMediator;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import de.dennisguse.opentracks.chart.ChartFragment;
@@ -57,6 +58,8 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
     private static final String TAG = TrackRecordingActivity.class.getSimpleName();
 
     private static final String CURRENT_TAB_TAG_KEY = "current_tab_tag_key";
+
+    private final EnumSet<GpsStatusValue> dismissedStatus = EnumSet.noneOf(GpsStatusValue.class);
 
     // The following are setFrequency in onCreate
     private ContentProviderUtils contentProviderUtils;
@@ -405,14 +408,13 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
     }
 
     private void onGpsStatusChanged(GpsStatusValue gpsStatusValue) {
-        var coordinatorLayout = viewBinding.trackRecordingCoordinatorLayout;
-        if (coordinatorLayout == null) {
+        if (viewBinding.trackRecordingCoordinatorLayout == null || dismissedStatus.contains(gpsStatusValue)) {
             return;
         }
         Snackbar snackbar = Snackbar
-                .make(coordinatorLayout, getString(gpsStatusValue.message), Snackbar.LENGTH_INDEFINITE)
-                .setAction("OK", v -> {
-
+                .make(viewBinding.trackRecordingCoordinatorLayout, getString(gpsStatusValue.message), Snackbar.LENGTH_INDEFINITE)
+                .setAction(getString(android.R.string.ok), v -> {
+                    dismissedStatus.add(gpsStatusValue);
                 });
         snackbar.show();
     }

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -405,13 +405,12 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
     }
 
     private void onGpsStatusChanged(GpsStatusValue gpsStatusValue) {
-        Log.e("probando", "onGpsStautsChanged: is started? " + gpsStatusValue.isGpsStarted() + " | " + gpsStatusValue);
         var coordinatorLayout = viewBinding.trackRecordingCoordinatorLayout;
         if (coordinatorLayout == null) {
             return;
         }
         Snackbar snackbar = Snackbar
-                .make(coordinatorLayout, "GPS Status changed: " + gpsStatusValue, Snackbar.LENGTH_INDEFINITE)
+                .make(coordinatorLayout, getString(gpsStatusValue.message), Snackbar.LENGTH_INDEFINITE)
                 .setAction("OK", v -> {
 
                 });

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -59,7 +59,7 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
 
     private static final String CURRENT_TAB_TAG_KEY = "current_tab_tag_key";
 
-    private final EnumSet<GpsStatusValue> dismissedStatus = EnumSet.noneOf(GpsStatusValue.class);
+    private boolean isDismissed = false;
 
     // The following are setFrequency in onCreate
     private ContentProviderUtils contentProviderUtils;
@@ -408,13 +408,15 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
     }
 
     private void onGpsStatusChanged(GpsStatusValue gpsStatusValue) {
-        if (viewBinding.trackRecordingCoordinatorLayout == null || dismissedStatus.contains(gpsStatusValue)) {
+        if (viewBinding.trackRecordingCoordinatorLayout == null || isDismissed || !(gpsStatusValue == GpsStatusValue.GPS_DISABLED || gpsStatusValue == GpsStatusValue.GPS_NONE)) {
             return;
         }
         Snackbar snackbar = Snackbar
-                .make(viewBinding.trackRecordingCoordinatorLayout, getString(gpsStatusValue.message), Snackbar.LENGTH_INDEFINITE)
-                .setAction(getString(android.R.string.ok), v -> {
-                    dismissedStatus.add(gpsStatusValue);
+                .make(viewBinding.trackRecordingCoordinatorLayout,
+                        getString(R.string.gps_recording_status, getString(gpsStatusValue.message), getString(R.string.gps_recording_without_signal)),
+                        Snackbar.LENGTH_INDEFINITE)
+                .setAction(getString(R.string.generic_dismiss), v -> {
+                    isDismissed = true;
                 });
         snackbar.show();
     }

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
@@ -2,7 +2,6 @@ package de.dennisguse.opentracks.fragments;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,8 +15,6 @@ import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.google.android.material.snackbar.Snackbar;
-
 import java.util.List;
 
 import de.dennisguse.opentracks.R;
@@ -26,7 +23,6 @@ import de.dennisguse.opentracks.data.models.Track;
 import de.dennisguse.opentracks.databinding.StatisticsRecordingBinding;
 import de.dennisguse.opentracks.services.TrackRecordingService;
 import de.dennisguse.opentracks.services.TrackRecordingServiceConnection;
-import de.dennisguse.opentracks.services.handlers.GpsStatusValue;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.ui.customRecordingLayout.Layout;
 import de.dennisguse.opentracks.viewmodels.StatisticData;
@@ -80,9 +76,6 @@ public class StatisticsRecordingFragment extends Fragment {
     private final TrackRecordingServiceConnection.Callback bindChangedCallback = service -> {
         service.getRecordingDataObservable()
                 .observe(StatisticsRecordingFragment.this, this::onRecordingDataChanged);
-
-        service.getGpsStatusObservable()
-                .observe(StatisticsRecordingFragment.this, this::onGpsStatusChanged);
     };
 
     @Override
@@ -175,19 +168,5 @@ public class StatisticsRecordingFragment extends Fragment {
         }
 
         updateUI();
-    }
-
-    private void onGpsStatusChanged(GpsStatusValue gpsStatusValue) {
-        Log.e("probando", "onGpsStautsChanged: is started? " + gpsStatusValue.isGpsStarted() + " | " + gpsStatusValue);
-        Snackbar snackbar = Snackbar
-                .make(viewBinding.getRoot(), "GPS Status changed: " + gpsStatusValue, Snackbar.LENGTH_INDEFINITE)
-                .setAction("OK", new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-
-                    }
-                });
-        snackbar.show();
-
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
@@ -2,6 +2,7 @@ package de.dennisguse.opentracks.fragments;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -15,15 +16,17 @@ import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.snackbar.Snackbar;
+
 import java.util.List;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.adapters.StatisticsAdapter;
 import de.dennisguse.opentracks.data.models.Track;
-import de.dennisguse.opentracks.data.models.TrackPoint;
 import de.dennisguse.opentracks.databinding.StatisticsRecordingBinding;
 import de.dennisguse.opentracks.services.TrackRecordingService;
 import de.dennisguse.opentracks.services.TrackRecordingServiceConnection;
+import de.dennisguse.opentracks.services.handlers.GpsStatusValue;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.ui.customRecordingLayout.Layout;
 import de.dennisguse.opentracks.viewmodels.StatisticData;
@@ -45,7 +48,6 @@ public class StatisticsRecordingFragment extends Fragment {
 
     private TrackRecordingServiceConnection trackRecordingServiceConnection;
     private TrackRecordingService.RecordingData recordingData = TrackRecordingService.NOT_RECORDING;
-    private TrackPoint latestTrackPoint;
     private Layout layout;
 
     private StatisticsRecordingBinding viewBinding;
@@ -75,8 +77,13 @@ public class StatisticsRecordingFragment extends Fragment {
         }
     };
 
-    private final TrackRecordingServiceConnection.Callback bindChangedCallback = service -> service.getRecordingDataObservable()
-            .observe(StatisticsRecordingFragment.this, this::onRecordingDataChanged);
+    private final TrackRecordingServiceConnection.Callback bindChangedCallback = service -> {
+        service.getRecordingDataObservable()
+                .observe(StatisticsRecordingFragment.this, this::onRecordingDataChanged);
+
+        service.getGpsStatusObservable()
+                .observe(StatisticsRecordingFragment.this, this::onGpsStatusChanged);
+    };
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -167,11 +174,20 @@ public class StatisticsRecordingFragment extends Fragment {
             sharedPreferenceChangeListener.onSharedPreferenceChanged(null, getString(R.string.stats_rate_key));
         }
 
-        latestTrackPoint = recordingData.getLatestTrackPoint();
-        if (latestTrackPoint != null && latestTrackPoint.hasLocation() && !latestTrackPoint.isRecent()) {
-            latestTrackPoint = null;
-        }
-
         updateUI();
+    }
+
+    private void onGpsStatusChanged(GpsStatusValue gpsStatusValue) {
+        Log.e("probando", "onGpsStautsChanged: is started? " + gpsStatusValue.isGpsStarted() + " | " + gpsStatusValue);
+        Snackbar snackbar = Snackbar
+                .make(viewBinding.getRoot(), "GPS Status changed: " + gpsStatusValue, Snackbar.LENGTH_INDEFINITE)
+                .setAction("OK", new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+
+                    }
+                });
+        snackbar.show();
+
     }
 }

--- a/src/main/res/layout-land/track_recording.xml
+++ b/src/main/res/layout-land/track_recording.xml
@@ -1,54 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.coordinatorlayout.widget.CoordinatorLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     android:orientation="vertical">
+
+    <include layout="@layout/toolbar" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:orientation="horizontal">
 
-        <include layout="@layout/toolbar" />
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/controller_fragment"
+            android:name="de.dennisguse.opentracks.ControllerFragment"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="horizontal">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
 
-            <androidx.fragment.app.FragmentContainerView
-                android:id="@+id/controller_fragment"
-                android:name="de.dennisguse.opentracks.ControllerFragment"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent" />
-
-                <LinearLayout
+                <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/track_detail_activity_tablayout"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical">
+                    android:layout_height="wrap_content" />
 
-                    <com.google.android.material.tabs.TabLayout
-                        android:id="@+id/track_detail_activity_tablayout"
+                <androidx.coordinatorlayout.widget.CoordinatorLayout
+                    android:id="@+id/track_recording_coordinator_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:layout_weight="1">
+
+                    <androidx.viewpager2.widget.ViewPager2
+                        android:id="@+id/track_detail_activity_view_pager"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
+                        android:layout_height="match_parent"/>
 
-                    <androidx.coordinatorlayout.widget.CoordinatorLayout
-                        android:id="@+id/track_recording_coordinator_layout"
-                        android:layout_width="match_parent"
-                        android:layout_height="0dp"
-                        android:layout_weight="1">
+                </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-                        <androidx.viewpager2.widget.ViewPager2
-                            android:id="@+id/track_detail_activity_view_pager"
-                            android:layout_width="match_parent"
-                            android:layout_height="match_parent"/>
-
-                    </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
-                </LinearLayout>
-        </LinearLayout>
+            </LinearLayout>
     </LinearLayout>
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/src/main/res/layout-land/track_recording.xml
+++ b/src/main/res/layout-land/track_recording.xml
@@ -1,38 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
-
-    <include layout="@layout/toolbar" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="horizontal">
+        android:orientation="vertical">
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/controller_fragment"
-            android:name="de.dennisguse.opentracks.ControllerFragment"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent" />
+        <include layout="@layout/toolbar" />
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical">
+            android:orientation="horizontal">
 
-            <com.google.android.material.tabs.TabLayout
-                android:id="@+id/track_detail_activity_tablayout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/controller_fragment"
+                android:name="de.dennisguse.opentracks.ControllerFragment"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent" />
 
-            <androidx.viewpager2.widget.ViewPager2
-                android:id="@+id/track_detail_activity_view_pager"
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_weight="1" />
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
 
+                    <com.google.android.material.tabs.TabLayout
+                        android:id="@+id/track_detail_activity_tablayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
+                    <androidx.coordinatorlayout.widget.CoordinatorLayout
+                        android:id="@+id/track_recording_coordinator_layout"
+                        android:layout_width="match_parent"
+                        android:layout_height="0dp"
+                        android:layout_weight="1">
+
+                        <androidx.viewpager2.widget.ViewPager2
+                            android:id="@+id/track_detail_activity_view_pager"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"/>
+
+                    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+                </LinearLayout>
         </LinearLayout>
     </LinearLayout>
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/src/main/res/layout/statistics_recording.xml
+++ b/src/main/res/layout/statistics_recording.xml
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    style="@style/StatsScrollView"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/stats_recycler_view"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        style="@style/StatsScrollView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_constraintEnd_toStartOf="parent"
-        app:layout_constraintStart_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="parent" />
+        android:layout_height="match_parent">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/stats_recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintEnd_toStartOf="parent"
+            app:layout_constraintStart_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/src/main/res/layout/statistics_recording.xml
+++ b/src/main/res/layout/statistics_recording.xml
@@ -1,23 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/StatsScrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        style="@style/StatsScrollView"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/stats_recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        app:layout_constraintEnd_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="parent" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/stats_recycler_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_constraintEnd_toStartOf="parent"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/main/res/layout/track_recording.xml
+++ b/src/main/res/layout/track_recording.xml
@@ -1,25 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
-    <include layout="@layout/toolbar" />
-
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/track_detail_activity_tablayout"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-    <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/track_detail_activity_view_pager"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
+        <include layout="@layout/toolbar" />
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/controller_fragment"
-        android:name="de.dennisguse.opentracks.ControllerFragment"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-</LinearLayout>
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/track_detail_activity_tablayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/track_recording_coordinator_layout"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/track_detail_activity_view_pager"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/controller_fragment"
+            android:name="de.dennisguse.opentracks.ControllerFragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/src/main/res/layout/track_recording.xml
+++ b/src/main/res/layout/track_recording.xml
@@ -1,41 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
+
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
-    <LinearLayout
+    <include layout="@layout/toolbar" />
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/track_detail_activity_tablayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="wrap_content" />
 
-        <include layout="@layout/toolbar" />
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/track_recording_coordinator_layout"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
 
-        <com.google.android.material.tabs.TabLayout
-            android:id="@+id/track_detail_activity_tablayout"
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/track_detail_activity_view_pager"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="match_parent" />
 
-        <androidx.coordinatorlayout.widget.CoordinatorLayout
-            android:id="@+id/track_recording_coordinator_layout"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1">
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-            <androidx.viewpager2.widget.ViewPager2
-                android:id="@+id/track_detail_activity_view_pager"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/controller_fragment"
+        android:name="de.dennisguse.opentracks.ControllerFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
-        </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/controller_fragment"
-            android:name="de.dennisguse.opentracks.ControllerFragment"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-    </LinearLayout>
-
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -42,4 +42,5 @@ limitations under the License.
     <color name="track_controller_background_activated">#3F0000</color>
 
     <color name="splashscreen_background">#272727</color>
+
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -246,12 +246,15 @@ limitations under the License.
     <string name="generic_to">To</string>
     <string name="generic_today">Today</string>
     <string name="generic_yesterday">Yesterday</string>
+    <string name="generic_dismiss">Dismiss</string>
     <!-- Gps -->
     <string name="gps_starting">Starting GPS</string>
     <string name="gps_wait_for_better_signal">Waiting for a better GPS signal</string>
     <string name="gps_wait_for_signal">Waiting for GPS signal</string>
     <string name="gps_disabled_msg">GPS disabled</string>
     <string name="gps_fixed_and_ready">GPS fixed and ready</string>
+    <string name="gps_recording_status">%1$s: %2$s</string>
+    <string name="gps_recording_without_signal">OpenTracks is recording without GPS data.</string>
     <!-- Image -->
     <string name="image_arrow">Arrow</string>
     <string name="image_marker">Marker</string>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -334,40 +334,29 @@ limitations under the License.
         <item name="cardUseCompatPadding">true</item>
     </style>
 
-
-
-
-
-
-
-
-
-
-    <style name="Widget.App.Snackbar" parent="Widget.MaterialComponents.Snackbar">
-
-        <!--this child makes changes to the background color of the snackbar-->
+    <!-- Snackbar -->
+    <style name="MaterialSnackbarTheme" parent="@style/Widget.MaterialComponents.Snackbar">
         <item name="materialThemeOverlay">@style/ThemeOverlay.App.Snackbar</item>
-        <!--if this is made 0 then the action button text color will be white-->
-        <!--if this is 1 then the custom color can be set to action button text-->
         <item name="actionTextColorAlpha">1</item>
+
+        <item name="backgroundTint">@android:color/holo_red_dark</item>
     </style>
 
-    <!--this is child is needed only when there is action button in snackbar-->
-    <!--otherwise this is not necessary-->
-    <!--in this case the action button color inside the snackbar is set to red-->
-
-
-    <style name="Widget.App.SnackbarButton" parent="@style/Widget.MaterialComponents.Button.TextButton.Snackbar">
-
-        <item name="android:textColor">#000000</item>
-
+    <style name="MaterialSnackbarTextButtonTheme" parent="@style/Widget.MaterialComponents.Button.TextButton.Snackbar">
+        <item name="backgroundTint">#7777ff</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textSize">14sp</item>
     </style>
 
+    <style name="MaterialSnackbarTextViewTheme" parent="@style/Widget.MaterialComponents.Snackbar.TextView">
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textAppearance">?textAppearanceLabelMedium</item>
+        <item name="android:textSize">14sp</item>
+    </style>
 
-
-    <!--this color inside this child is the background color of the snackbar-->
     <style name="ThemeOverlay.App.Snackbar" parent="">
         <item name="colorSurface">@android:color/holo_red_dark</item>
         <item name="colorOnSurface">@android:color/holo_red_dark</item>
     </style>
+
 </resources>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -333,4 +333,41 @@ limitations under the License.
         <item name="cardPreventCornerOverlap">true</item>
         <item name="cardUseCompatPadding">true</item>
     </style>
+
+
+
+
+
+
+
+
+
+
+    <style name="Widget.App.Snackbar" parent="Widget.MaterialComponents.Snackbar">
+
+        <!--this child makes changes to the background color of the snackbar-->
+        <item name="materialThemeOverlay">@style/ThemeOverlay.App.Snackbar</item>
+        <!--if this is made 0 then the action button text color will be white-->
+        <!--if this is 1 then the custom color can be set to action button text-->
+        <item name="actionTextColorAlpha">1</item>
+    </style>
+
+    <!--this is child is needed only when there is action button in snackbar-->
+    <!--otherwise this is not necessary-->
+    <!--in this case the action button color inside the snackbar is set to red-->
+
+
+    <style name="Widget.App.SnackbarButton" parent="@style/Widget.MaterialComponents.Button.TextButton.Snackbar">
+
+        <item name="android:textColor">#000000</item>
+
+    </style>
+
+
+
+    <!--this color inside this child is the background color of the snackbar-->
+    <style name="ThemeOverlay.App.Snackbar" parent="">
+        <item name="colorSurface">@android:color/holo_red_dark</item>
+        <item name="colorOnSurface">@android:color/holo_red_dark</item>
+    </style>
 </resources>

--- a/src/main/res/values/themes_custom.xml
+++ b/src/main/res/values/themes_custom.xml
@@ -24,11 +24,11 @@ limitations under the License.
 
         <item name="windowActionModeOverlay">true</item>
 
-        <!--this is makes changes to the entire snackbar-->
-        <item name="snackbarStyle">@style/Widget.App.Snackbar</item>
+        <!-- Snackbar -->
+        <item name="snackbarStyle">@style/MaterialSnackbarTheme</item>
+        <item name="snackbarButtonStyle">@style/MaterialSnackbarTextButtonTheme</item>
+        <item name="snackbarTextViewStyle">@style/MaterialSnackbarTextViewTheme</item>
 
-        <!--this item is optional as all the snackbar wont contain the action button-->
-        <item name="snackbarButtonStyle">@style/Widget.App.SnackbarButton</item>
     </style>
 
     <style name="SplashTheme" parent="ThemeCustom">

--- a/src/main/res/values/themes_custom.xml
+++ b/src/main/res/values/themes_custom.xml
@@ -23,6 +23,12 @@ limitations under the License.
         <item name="android:activatedBackgroundIndicator">@drawable/activated_background</item>
 
         <item name="windowActionModeOverlay">true</item>
+
+        <!--this is makes changes to the entire snackbar-->
+        <item name="snackbarStyle">@style/Widget.App.Snackbar</item>
+
+        <!--this item is optional as all the snackbar wont contain the action button-->
+        <item name="snackbarButtonStyle">@style/Widget.App.SnackbarButton</item>
     </style>
 
     <style name="SplashTheme" parent="ThemeCustom">


### PR DESCRIPTION
**Describe the pull request**
OpenTracks warns user if s-he starts recording with GPS off.

The Snackbar can be dismissed and it won't show up anymore. Anyway, It would be great to add a setting to disable this warning because some users can consider it a little invasive :thinking: 

Also, I've changed the theme for Snackbar. It took me a long time so I've decided to push this code with this theme but I'm not sure about it. I think it would be better let the default theme for the Snackbar (background color dark gray and foreground orange).

Above all, I create this draft PR to discuss about all these stuffs.

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/482

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
