### PR TITLE
Bugfix: emojis cannot be used as filenames.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/util/FileUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/FileUtilsTest.java
@@ -15,14 +15,14 @@
  */
 package de.dennisguse.opentracks.util;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.File;
 import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link FileUtils}.
@@ -98,6 +98,13 @@ public class FileUtilsTest {
     public void testSanitizeFileName_collapse() {
         String name = "hello//there";
         String expected = "hello_there";
+        assertEquals(expected, FileUtils.sanitizeFileName(name));
+    }
+
+    @Test
+    public void testSanitizeFileName_emoji() {
+        String name = "\uD83C\uDF5B-Food";
+        String expected = "_-Food";
         assertEquals(expected, FileUtils.sanitizeFileName(name));
     }
 

--- a/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/FileUtils.java
@@ -146,7 +146,7 @@ public class FileUtils {
         for (int i = 0; i < name.length(); i++) {
             int codePoint = name.codePointAt(i);
             char character = name.charAt(i);
-            if (Character.isLetterOrDigit(character) || codePoint > 127 || isSpecialFat32(character) || character == '.') {
+            if (Character.isLetterOrDigit(character) || isSpecialFat32(character) || character == '.') {
                 builder.appendCodePoint(codePoint);
             } else {
                 builder.append("_");


### PR DESCRIPTION
Fixes #1129.

This PR has the side affect that only ASCII characters can be used for filenames.
Before that all UTF characters > 127 could be used - I just don't know why somebody would want this.