### PR TITLE
for #1080: maybe the different type of Contexts are the problem

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportServiceResultReceiver.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportServiceResultReceiver.java
@@ -32,8 +32,10 @@ public class ExportServiceResultReceiver extends ResultReceiver {
         switch (resultCode) {
             case RESULT_CODE_SUCCESS:
                 receiver.onExportSuccess(trackId);
+                break;
             case RESULT_CODE_ERROR:
                 receiver.onExportError(trackId);
+                break;
             default:
                 throw new RuntimeException("Unknown resultCode.");
         }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/DirectoryChooserActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/DirectoryChooserActivity.java
@@ -54,10 +54,7 @@ public abstract class DirectoryChooserActivity extends AppCompatActivity {
 
     protected void onActivityResultCustom(@NonNull Intent resultData) {
         Uri directoryUri = resultData.getData();
-        int takeFlags = resultData.getFlags();
-        takeFlags &= (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-        getContentResolver().takePersistableUriPermission(directoryUri, takeFlags);
-
+        IntentUtils.persistDirectoryAccessPermission(this, directoryUri, resultData.getFlags());
         startActivity(createNextActivityIntent(directoryUri));
     }
 
@@ -111,11 +108,11 @@ public abstract class DirectoryChooserActivity extends AppCompatActivity {
             Uri oldDirectoryUri = PreferencesUtils.getDefaultExportDirectoryUri();
             Uri newDirectoryUri = resultData.getData();
             if (oldDirectoryUri != null && !newDirectoryUri.equals(oldDirectoryUri)) {
-                IntentUtils.releaseDirectoryAccessPermission(getApplicationContext(), oldDirectoryUri);
+                IntentUtils.releaseDirectoryAccessPermission(this, oldDirectoryUri);
             }
 
             PreferencesUtils.setDefaultExportDirectoryUri(newDirectoryUri);
-            IntentUtils.persistDirectoryAccessPermission(getApplicationContext(), newDirectoryUri, resultData.getFlags());
+            IntentUtils.persistDirectoryAccessPermission(this, newDirectoryUri, resultData.getFlags());
         }
 
         @Override

--- a/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/IntentUtils.java
@@ -77,7 +77,7 @@ public class IntentUtils {
 
     public static void persistDirectoryAccessPermission(Context context, Uri directoryUri, int existingFlags) {
         int newFlags = existingFlags & (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-        context.getContentResolver().takePersistableUriPermission(directoryUri, newFlags);
+        context.getApplicationContext().getContentResolver().takePersistableUriPermission(directoryUri, newFlags);
     }
 
     public static void releaseDirectoryAccessPermission(Context context, final Uri documentUri) {
@@ -85,7 +85,7 @@ public class IntentUtils {
             return;
         }
 
-        context.getContentResolver().getPersistedUriPermissions().stream()
+        context.getApplicationContext().getContentResolver().getPersistedUriPermissions().stream()
                 .map(UriPermission::getUri)
                 .filter(documentUri::equals)
                 .forEach(u -> context.getContentResolver().releasePersistableUriPermission(u, 0));
@@ -96,7 +96,7 @@ public class IntentUtils {
             return null;
         }
         try {
-            return DocumentFile.fromTreeUri(context, directoryUri);
+            return DocumentFile.fromTreeUri(context.getApplicationContext(), directoryUri);
         } catch (Exception e) {
             Log.w(TAG, "Could not decode directory: " + e.getMessage());
         }


### PR DESCRIPTION
Still not sure why the persisted URI permission gets lost, but I saw that we use different contexts to persist the URI and to get the DocumentFile from it. Let's use ApplicationContext everywhere because sometimes it's an Activity and sometimes a Service.

Also stumbled upon a RuntimeException after exporting because missing breaks in a switch statement.