### PR TITLE
Voice heart rate with comma fix

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/content/data/TestDataUtil.java
@@ -125,7 +125,7 @@ public class TestDataUtil {
         trackPoint.setAltitude(i * ALTITUDE_INTERVAL);
         trackPoint.setSpeed(Speed.of(5f + (i / 10f)));
 
-        trackPoint.setHeartRate(100f + i);
+        trackPoint.setHeartRate(100f + i % 80);
         trackPoint.setCadence(300f + i);
         trackPoint.setPower(400f + i);
         trackPoint.setAltitudeGain(ALTITUDE_GAIN);

--- a/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
@@ -1,6 +1,7 @@
 package de.dennisguse.opentracks.services.announcement;
 
 import static org.junit.Assert.assertEquals;
+import static de.dennisguse.opentracks.services.announcement.VoiceAnnouncementUtils.getLanguageLocale;
 
 import android.content.Context;
 import android.util.Pair;
@@ -13,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.time.Duration;
+import java.util.Locale;
 
 import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.data.ContentProviderUtils;
@@ -36,6 +38,15 @@ public class VoiceAnnouncementUtilsTest {
     public void setUp() {
         contentProviderUtils = new ContentProviderUtils(context);
         PreferencesUtils.setVoiceAnnounceHeartRate(false);
+    }
+
+    @Test
+    public void getLanguageLocaleStripsRegion() {
+        Locale incompatibleRegion = Locale.forLanguageTag("en-SE");
+        // This demonstrates the problem
+        assertEquals("1,23", String.format(incompatibleRegion, "%.2f", 1.234));
+        // And the solution
+        assertEquals("1.23", String.format(getLanguageLocale(incompatibleRegion), "%.2f", 1.234));
     }
 
     @Test

--- a/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
@@ -50,10 +50,10 @@ public class VoiceAnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, null, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, null, null).toString();
 
         // then
-        assertEquals("total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 18.4 kilometers per hour", announcement);
+        assertEquals("Total distance 20.00 kilometers, 1 hour 5 minutes 10 seconds, Speed 18.4 kilometers per hour,", announcement);
     }
 
     @Test
@@ -67,21 +67,22 @@ public class VoiceAnnouncementUtilsTest {
         try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(trackId, null)) {
             assertEquals(trackPointIterator.getCount(), numberOfPoints);
             IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000));
+            intervalStatistics.addTrackPoints(trackPointIterator);
             lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
         }
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval, null).toString();
 
         // then
         Assert.assertEquals(
-                "total distance " +
+                "Total distance " +
                         StringUtils.getDistanceParts(context, stats.getTotalDistance(), true).first +
-                        " kilometers in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
+                        " kilometers, " + buildAndGetTimeText(stats.getTotalTime(), false) + ", Speed " +
                         StringUtils.getSpeedParts(context, stats.getAverageMovingSpeed(), true, true).first +
-                        " kilometers per hour Lap speed of " +
+                        " kilometers per hour, Lap speed " +
                         StringUtils.getSpeedParts(context, lastInterval.getSpeed(), true, true).first +
-                        " kilometers per hour",
+                        " kilometers per hour,",
                 announcement);
     }
 
@@ -95,10 +96,10 @@ public class VoiceAnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, null, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, null, null).toString();
 
         // then
-        assertEquals("total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 3 minutes 15 seconds per kilometer", announcement);
+        assertEquals("Total distance 20.00 kilometers, 1 hour 5 minutes 10 seconds, Pace 3 minutes 15 seconds per kilometer,", announcement);
     }
 
     @Test
@@ -112,21 +113,22 @@ public class VoiceAnnouncementUtilsTest {
         try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(trackId, null)) {
             assertEquals(trackPointIterator.getCount(), numberOfPoints);
             IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000));
+            intervalStatistics.addTrackPoints(trackPointIterator);
             lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
         }
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, lastInterval, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, lastInterval, null).toString();
 
         // then
         assertEquals(
-                "total distance " +
+                "Total distance " +
                         StringUtils.getDistanceParts(context, stats.getTotalDistance(), true).first +
-                        " kilometers in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
+                        " kilometers, " + buildAndGetTimeText(stats.getTotalTime(), false) + ", Pace " +
                         buildAndGetTimeText(stats.getAverageMovingSpeed().toPace(true), true) +
-                        " per kilometer Lap time of " +
+                        " per kilometer, Lap time " +
                         buildAndGetTimeText(lastInterval.getSpeed().toPace(true), true) +
-                        " per kilometer",
+                        " per kilometer,",
                 announcement);
     }
 
@@ -140,10 +142,10 @@ public class VoiceAnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, null, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, null, null).toString();
 
         // then
-        assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 11.4 miles per hour", announcement);
+        assertEquals("Total distance 12.43 miles, 1 hour 5 minutes 10 seconds, Speed 11.4 miles per hour,", announcement);
     }
 
     @Test
@@ -157,21 +159,22 @@ public class VoiceAnnouncementUtilsTest {
         try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(trackId, null)) {
             assertEquals(trackPointIterator.getCount(), numberOfPoints);
             IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000));
+            intervalStatistics.addTrackPoints(trackPointIterator);
             lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
         }
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, lastInterval, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, lastInterval, null).toString();
 
         // then
         assertEquals(
-                "total distance " +
+                "Total distance " +
                         StringUtils.getDistanceParts(context, stats.getTotalDistance(), false).first +
-                        " miles in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
+                        " miles, " + buildAndGetTimeText(stats.getTotalTime(), false) + ", Speed " +
                         StringUtils.getSpeedParts(context, stats.getAverageMovingSpeed(), false, true).first +
-                        " miles per hour Lap speed of " +
+                        " miles per hour, Lap speed " +
                         StringUtils.getSpeedParts(context, lastInterval.getSpeed(), false, true).first +
-                        " miles per hour",
+                        " miles per hour,",
                 announcement);
     }
 
@@ -185,10 +188,10 @@ public class VoiceAnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, false, null, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, false, null, null).toString();
 
         // then
-        assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile", announcement);
+        assertEquals("Total distance 12.43 miles, 1 hour 5 minutes 10 seconds, Pace 5 minutes 15 seconds per mile,", announcement);
     }
 
     @Test
@@ -202,22 +205,23 @@ public class VoiceAnnouncementUtilsTest {
         try (TrackPointIterator trackPointIterator = contentProviderUtils.getTrackPointLocationIterator(trackId, null)) {
             assertEquals(trackPointIterator.getCount(), numberOfPoints);
             IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.of(1000));
+            intervalStatistics.addTrackPoints(trackPointIterator);
             lastInterval = intervalStatistics.getIntervalList().get(intervalStatistics.getIntervalList().size() - 1);
         }
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, false, lastInterval, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, false, lastInterval, null).toString();
 
         // then
         //assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile Lap time of 1 minute 53 seconds per mile", announcement);
         assertEquals(
-                "total distance " +
+                "Total distance " +
                         StringUtils.getDistanceParts(context, stats.getTotalDistance(), false).first +
-                        " miles in " + buildAndGetTimeText(stats.getTotalTime(), false) + " at " +
+                        " miles, " + buildAndGetTimeText(stats.getTotalTime(), false) + ", Pace " +
                         buildAndGetTimeText(stats.getAverageMovingSpeed().toPace(false), true) +
-                        " per mile Lap time of " +
+                        " per mile, Lap time " +
                         buildAndGetTimeText(lastInterval.getSpeed().toPace(false), true) +
-                        " per mile",
+                        " per mile,",
                 announcement);
     }
 
@@ -240,10 +244,10 @@ public class VoiceAnnouncementUtilsTest {
         SensorStatistics sensorStatistics = new SensorStatistics(HeartRate.of(180f), HeartRate.of(180f), null, null, null);
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval, sensorStatistics);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval, sensorStatistics).toString();
 
         // then
-        assertEquals("total distance 14.21 kilometers in 16 minutes 39 seconds at 51.2 kilometers per hour Lap speed of 51.2 kilometers per hour Average heart rate 180 BPM Current heart rate 132 BPM", announcement);
+        assertEquals("Total distance 14.21 kilometers, 16 minutes 39 seconds, Speed 51.2 kilometers per hour, Lap speed 51.2 kilometers per hour, Average heart rate 180 bpm, Current heart rate 132 bpm,", announcement);
     }
 
     /**

--- a/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
@@ -247,7 +247,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval, sensorStatistics).toString();
 
         // then
-        assertEquals("Total distance 14.21 kilometers, 16 minutes 39 seconds, Speed 51.2 kilometers per hour, Lap speed 51.2 kilometers per hour, Average heart rate 180 bpm, Current heart rate 132 bpm,", announcement);
+        assertEquals("Total distance 14.21 kilometers, 16 minutes 39 seconds, Speed 51.2 kilometers per hour, Lap speed 51.2 kilometers per hour, Average heart rate 180 bpm, Current heart rate 133 bpm,", announcement);
     }
 
     /**

--- a/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
@@ -8,7 +8,6 @@ import android.util.Pair;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +25,6 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.stats.SensorStatistics;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.ui.intervals.IntervalStatistics;
-import de.dennisguse.opentracks.util.StringUtils;
 
 @RunWith(AndroidJUnit4.class)
 public class VoiceAnnouncementUtilsTest {
@@ -53,7 +51,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 20.00 kilometers, 1 hour 5 minutes 10 seconds, Speed 18.4 kilometers per hour,", announcement);
+        assertEquals("Total distance 20.00 kilometers. 1 hour 5 minutes 10 seconds. Speed 18.4 kilometers per hour.", announcement);
     }
 
     @Test
@@ -75,7 +73,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval, null).toString();
 
         // then
-        assertEquals("Total distance 14.21 kilometers, 16 minutes 39 seconds, Speed 51.2 kilometers per hour, Lap speed 51.2 kilometers per hour,", announcement);
+        assertEquals("Total distance 14.21 kilometers. 16 minutes 39 seconds. Speed 51.2 kilometers per hour. Lap speed 51.2 kilometers per hour.", announcement);
     }
 
     @Test
@@ -91,7 +89,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, null, null).toString();
 
         // then
-        assertEquals("Total distance 20.00 kilometers, 1 hour 5 minutes 10 seconds, Pace 3 minutes 15 seconds per kilometer,", announcement);
+        assertEquals("Total distance 20.00 kilometers. 1 hour 5 minutes 10 seconds. Pace 3 minutes 15 seconds per kilometer.", announcement);
     }
 
     @Test
@@ -113,7 +111,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, lastInterval, null).toString();
 
         // then
-        assertEquals("Total distance 14.21 kilometers, 16 minutes 39 seconds, Pace 1 minute 10 seconds per kilometer, Lap time 1 minute 10 seconds per kilometer,", announcement);
+        assertEquals("Total distance 14.21 kilometers. 16 minutes 39 seconds. Pace 1 minute 10 seconds per kilometer. Lap time 1 minute 10 seconds per kilometer.", announcement);
     }
 
     @Test
@@ -129,7 +127,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 12.43 miles, 1 hour 5 minutes 10 seconds, Speed 11.4 miles per hour,", announcement);
+        assertEquals("Total distance 12.43 miles. 1 hour 5 minutes 10 seconds. Speed 11.4 miles per hour.", announcement);
     }
 
     @Test
@@ -151,7 +149,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, lastInterval, null).toString();
 
         // then
-        assertEquals("Total distance 8.83 miles, 16 minutes 39 seconds, Speed 31.8 miles per hour, Lap speed 31.8 miles per hour,", announcement);
+        assertEquals("Total distance 8.83 miles. 16 minutes 39 seconds. Speed 31.8 miles per hour. Lap speed 31.8 miles per hour.", announcement);
     }
 
     @Test
@@ -167,7 +165,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, false, null, null).toString();
 
         // then
-        assertEquals("Total distance 12.43 miles, 1 hour 5 minutes 10 seconds, Pace 5 minutes 15 seconds per mile,", announcement);
+        assertEquals("Total distance 12.43 miles. 1 hour 5 minutes 10 seconds. Pace 5 minutes 15 seconds per mile.", announcement);
     }
 
     @Test
@@ -189,8 +187,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, false, lastInterval, null).toString();
 
         // then
-        //assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile Lap time of 1 minute 53 seconds per mile", announcement);
-        assertEquals("Total distance 8.83 miles, 16 minutes 39 seconds, Pace 1 minute 53 seconds per mile, Lap time 1 minute 53 seconds per mile,", announcement);
+        assertEquals("Total distance 8.83 miles. 16 minutes 39 seconds. Pace 1 minute 53 seconds per mile. Lap time 1 minute 53 seconds per mile.", announcement);
     }
 
     @Test
@@ -215,35 +212,6 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval, sensorStatistics).toString();
 
         // then
-        assertEquals("Total distance 14.21 kilometers, 16 minutes 39 seconds, Speed 51.2 kilometers per hour, Lap speed 51.2 kilometers per hour, Average heart rate 180 bpm, Current heart rate 133 bpm,", announcement);
-    }
-
-    /**
-     * Builds an returns the text representing the duration's time.
-     *
-     * @param duration        Duration object.
-     * @param showFromMinutes show minutes tough it's 0.
-     * @return                text representing the duratin's time.
-     */
-    private String buildAndGetTimeText(Duration duration, boolean showFromMinutes) {
-        long hours = Math.abs(duration.getSeconds()) / 3600;
-        long minutes = (Math.abs(duration.getSeconds()) % 3600) / 60;
-        long seconds = Math.abs(duration.getSeconds()) % 60;
-        String hUnit = hours > 1 || hours == 0 ? "hours" : "hour";
-        String mUnit = minutes > 1 || minutes == 0 ? "minutes" : "minute";
-        String sUnit = seconds > 1 || seconds == 0 ? "seconds" : "second";
-
-        String res = hours > 0 ? hours + " " + hUnit : "";
-        if (hours > 0) {
-            res += minutes > 0 || showFromMinutes ? " " + minutes + " " + mUnit : "";
-        } else {
-            res += minutes > 0 || showFromMinutes ? minutes + " " + mUnit : "";
-        }
-        if (hours > 0 || minutes > 0 || showFromMinutes) {
-            res += " " + seconds + " " + sUnit;
-        } else {
-            res += seconds + " " + sUnit;
-        }
-        return res;
+        assertEquals("Total distance 14.21 kilometers. 16 minutes 39 seconds. Speed 51.2 kilometers per hour. Lap speed 51.2 kilometers per hour. Average heart rate 180 bpm. Current heart rate 133 bpm.", announcement);
     }
 }

--- a/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
@@ -19,8 +19,10 @@ import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.data.ContentProviderUtils;
 import de.dennisguse.opentracks.data.TrackPointIterator;
 import de.dennisguse.opentracks.data.models.Distance;
+import de.dennisguse.opentracks.data.models.HeartRate;
 import de.dennisguse.opentracks.data.models.Speed;
 import de.dennisguse.opentracks.data.models.Track;
+import de.dennisguse.opentracks.stats.SensorStatistics;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.ui.intervals.IntervalStatistics;
 import de.dennisguse.opentracks.util.StringUtils;
@@ -46,7 +48,7 @@ public class VoiceAnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, null, null);
 
         // then
         assertEquals("total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 18.4 kilometers per hour", announcement);
@@ -67,7 +69,7 @@ public class VoiceAnnouncementUtilsTest {
         }
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval, null);
 
         // then
         Assert.assertEquals(
@@ -91,7 +93,7 @@ public class VoiceAnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, null, null);
 
         // then
         assertEquals("total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 3 minutes 15 seconds per kilometer", announcement);
@@ -112,7 +114,7 @@ public class VoiceAnnouncementUtilsTest {
         }
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, lastInterval);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, lastInterval, null);
 
         // then
         assertEquals(
@@ -136,7 +138,7 @@ public class VoiceAnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, null, null);
 
         // then
         assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 11.4 miles per hour", announcement);
@@ -157,7 +159,7 @@ public class VoiceAnnouncementUtilsTest {
         }
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, lastInterval);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, lastInterval, null);
 
         // then
         assertEquals(
@@ -181,7 +183,7 @@ public class VoiceAnnouncementUtilsTest {
         stats.setTotalAltitudeGain(6000f);
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, false, null);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, false, null, null);
 
         // then
         assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile", announcement);
@@ -202,7 +204,7 @@ public class VoiceAnnouncementUtilsTest {
         }
 
         // when
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, false, lastInterval);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, false, lastInterval, null);
 
         // then
         //assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile Lap time of 1 minute 53 seconds per mile", announcement);
@@ -215,6 +217,25 @@ public class VoiceAnnouncementUtilsTest {
                         buildAndGetTimeText(lastInterval.getSpeed().toPace(false), true) +
                         " per mile",
                 announcement);
+    }
+
+    @Test
+    public void getAnnouncement_heart_rate_and_sensor_statistics() {
+        TrackStatistics stats = new TrackStatistics();
+        stats.setTotalDistance(Distance.of(20000));
+        stats.setTotalTime(Duration.ofHours(2).plusMinutes(5).plusSeconds(10));
+        stats.setMovingTime(Duration.ofHours(1).plusMinutes(5).plusSeconds(10));
+        stats.setMaxSpeed(Speed.of(100));
+        stats.setTotalAltitudeGain(6000f);
+        stats.setAverageHeartRate(HeartRate.of(139f));
+
+        SensorStatistics sensorStatistics = new SensorStatistics(null, HeartRate.of(180f), null, null, null);
+
+        // when
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, null, sensorStatistics);
+
+        // then
+        assertEquals("total distance 20.00 kilometers in 1 hour 5 minutes 10 seconds at 18.4 kilometers per hour Average heart rate 180 BPM Current heart rate 139 BPM", announcement);
     }
 
     /**

--- a/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
@@ -75,15 +75,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, true, lastInterval, null).toString();
 
         // then
-        Assert.assertEquals(
-                "Total distance " +
-                        StringUtils.getDistanceParts(context, stats.getTotalDistance(), true).first +
-                        " kilometers, " + buildAndGetTimeText(stats.getTotalTime(), false) + ", Speed " +
-                        StringUtils.getSpeedParts(context, stats.getAverageMovingSpeed(), true, true).first +
-                        " kilometers per hour, Lap speed " +
-                        StringUtils.getSpeedParts(context, lastInterval.getSpeed(), true, true).first +
-                        " kilometers per hour,",
-                announcement);
+        assertEquals("Total distance 14.21 kilometers, 16 minutes 39 seconds, Speed 51.2 kilometers per hour, Lap speed 51.2 kilometers per hour,", announcement);
     }
 
     @Test
@@ -121,15 +113,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, true, false, lastInterval, null).toString();
 
         // then
-        assertEquals(
-                "Total distance " +
-                        StringUtils.getDistanceParts(context, stats.getTotalDistance(), true).first +
-                        " kilometers, " + buildAndGetTimeText(stats.getTotalTime(), false) + ", Pace " +
-                        buildAndGetTimeText(stats.getAverageMovingSpeed().toPace(true), true) +
-                        " per kilometer, Lap time " +
-                        buildAndGetTimeText(lastInterval.getSpeed().toPace(true), true) +
-                        " per kilometer,",
-                announcement);
+        assertEquals("Total distance 14.21 kilometers, 16 minutes 39 seconds, Pace 1 minute 10 seconds per kilometer, Lap time 1 minute 10 seconds per kilometer,", announcement);
     }
 
     @Test
@@ -167,15 +151,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, false, true, lastInterval, null).toString();
 
         // then
-        assertEquals(
-                "Total distance " +
-                        StringUtils.getDistanceParts(context, stats.getTotalDistance(), false).first +
-                        " miles, " + buildAndGetTimeText(stats.getTotalTime(), false) + ", Speed " +
-                        StringUtils.getSpeedParts(context, stats.getAverageMovingSpeed(), false, true).first +
-                        " miles per hour, Lap speed " +
-                        StringUtils.getSpeedParts(context, lastInterval.getSpeed(), false, true).first +
-                        " miles per hour,",
-                announcement);
+        assertEquals("Total distance 8.83 miles, 16 minutes 39 seconds, Speed 31.8 miles per hour, Lap speed 31.8 miles per hour,", announcement);
     }
 
     @Test
@@ -214,15 +190,7 @@ public class VoiceAnnouncementUtilsTest {
 
         // then
         //assertEquals("total distance 12.43 miles in 1 hour 5 minutes 10 seconds at 5 minutes 15 seconds per mile Lap time of 1 minute 53 seconds per mile", announcement);
-        assertEquals(
-                "Total distance " +
-                        StringUtils.getDistanceParts(context, stats.getTotalDistance(), false).first +
-                        " miles, " + buildAndGetTimeText(stats.getTotalTime(), false) + ", Pace " +
-                        buildAndGetTimeText(stats.getAverageMovingSpeed().toPace(false), true) +
-                        " per mile, Lap time " +
-                        buildAndGetTimeText(lastInterval.getSpeed().toPace(false), true) +
-                        " per mile,",
-                announcement);
+        assertEquals("Total distance 8.83 miles, 16 minutes 39 seconds, Pace 1 minute 53 seconds per mile, Lap time 1 minute 53 seconds per mile,", announcement);
     }
 
     @Test

--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsTest.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 import de.dennisguse.opentracks.data.models.Distance;
+import de.dennisguse.opentracks.data.models.HeartRate;
 import de.dennisguse.opentracks.data.models.Speed;
 
 /**
@@ -67,6 +68,7 @@ public class TrackStatisticsTest {
         assertEquals(0.0, statistics.getMaxSpeed().toMPS(), 0.0);
         assertEquals(0.0, statistics.getAverageSpeed().toMPS(), 0.0);
         assertEquals(0.0, statistics.getAverageMovingSpeed().toMPS(), 0.0);
+        assertNull(statistics.getAverageHeartRate());
     }
 
     @Test
@@ -91,6 +93,8 @@ public class TrackStatisticsTest {
         statistics.setMinAltitude(1200.0);  // Resulting min altitude
         statistics2.setMaxAltitude(3575.0);  // Resulting max altitude
         statistics2.setMinAltitude(2800.0);
+        statistics.setAverageHeartRate(HeartRate.of(100f));
+        statistics2.setAverageHeartRate(HeartRate.of(200f));
 
         // when
         statistics.merge(statistics2);
@@ -105,6 +109,7 @@ public class TrackStatisticsTest {
         assertEquals(Speed.of(statistics.getTotalDistance(), statistics.getMovingTime()).toMPS(), statistics.getMaxSpeed().toMPS(), 0.001);
         assertEquals(1200.0, statistics.getMinAltitude(), 0.001);
         assertEquals(3575.0, statistics.getMaxAltitude(), 0.001);
+        assertEquals(140.0, statistics.getAverageHeartRate().getBPM(), 0.001);
     }
 
     @Test

--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsTest.java
@@ -109,7 +109,7 @@ public class TrackStatisticsTest {
         assertEquals(Speed.of(statistics.getTotalDistance(), statistics.getMovingTime()).toMPS(), statistics.getMaxSpeed().toMPS(), 0.001);
         assertEquals(1200.0, statistics.getMinAltitude(), 0.001);
         assertEquals(3575.0, statistics.getMaxAltitude(), 0.001);
-        assertEquals(140.0, statistics.getAverageHeartRate().getBPM(), 0.001);
+        assertEquals(150.0, statistics.getAverageHeartRate().getBPM(), 0.001);
     }
 
     @Test

--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
@@ -40,6 +40,7 @@ public class TrackStatisticsUpdaterTest {
 
         assertNull(statistics.getTotalAltitudeGain());
         assertNull(statistics.getTotalAltitudeLoss());
+        assertNull(statistics.getAverageHeartRate());
     }
 
     @Test
@@ -66,6 +67,7 @@ public class TrackStatisticsUpdaterTest {
 
         assertNull(statistics.getTotalAltitudeGain());
         assertNull(statistics.getTotalAltitudeLoss());
+        assertNull(statistics.getAverageHeartRate());
     }
 
     @Test
@@ -91,6 +93,8 @@ public class TrackStatisticsUpdaterTest {
         assertEquals(14.226, statistics.getMaxSpeed().toMPS(), 0.01);
         assertEquals(14.226, statistics.getAverageMovingSpeed().toMPS(), 0.01);
         assertEquals(9.84, statistics.getAverageSpeed().toMPS(), 0.01);
+        // Fix this once test is run
+        assertEquals(100f, statistics.getAverageHeartRate().getBPM(), 0.01);
     }
 
     @Test

--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
@@ -93,7 +93,7 @@ public class TrackStatisticsUpdaterTest {
         assertEquals(14.226, statistics.getMaxSpeed().toMPS(), 0.01);
         assertEquals(14.226, statistics.getAverageMovingSpeed().toMPS(), 0.01);
         assertEquals(9.84, statistics.getAverageSpeed().toMPS(), 0.01);
-        assertEquals(106.88f, statistics.getAverageHeartRate().getBPM(), 0.01);
+        assertEquals(106.85f, statistics.getAverageHeartRate().getBPM(), 0.01);
     }
 
     @Test

--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
@@ -93,8 +93,7 @@ public class TrackStatisticsUpdaterTest {
         assertEquals(14.226, statistics.getMaxSpeed().toMPS(), 0.01);
         assertEquals(14.226, statistics.getAverageMovingSpeed().toMPS(), 0.01);
         assertEquals(9.84, statistics.getAverageSpeed().toMPS(), 0.01);
-        // Fix this once test is run
-        assertEquals(100f, statistics.getAverageHeartRate().getBPM(), 0.01);
+        assertEquals(106.88f, statistics.getAverageHeartRate().getBPM(), 0.01);
     }
 
     @Test

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncement.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncement.java
@@ -34,6 +34,7 @@ import de.dennisguse.opentracks.data.TrackPointIterator;
 import de.dennisguse.opentracks.data.models.Distance;
 import de.dennisguse.opentracks.data.models.Track;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
+import de.dennisguse.opentracks.stats.SensorStatistics;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.ui.intervals.IntervalStatistics;
 
@@ -171,8 +172,12 @@ public class VoiceAnnouncement {
         IntervalStatistics intervalStatistics = new IntervalStatistics(Distance.one(isMetricUnits));
         intervalStatistics.addTrackPoints(trackPointIterator);
         IntervalStatistics.Interval lastInterval = intervalStatistics.getLastInterval();
+        SensorStatistics sensorStatistics = null;
+        if (track.getId() != null) {
+            sensorStatistics = contentProviderUtils.getSensorStats(track.getId());
+        }
 
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, track.getTrackStatistics(), isMetricUnits, isReportSpeed, lastInterval);
+        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, track.getTrackStatistics(), isMetricUnits, isReportSpeed, lastInterval, sensorStatistics);
 
         // We don't care about the utterance id. It is supplied here to force onUtteranceCompleted to be called.
         tts.speak(announcement, TextToSpeech.QUEUE_FLUSH, null, "not used");

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncement.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncement.java
@@ -21,6 +21,7 @@ import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.speech.tts.TextToSpeech;
 import android.speech.tts.UtteranceProgressListener;
+import android.text.Spannable;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -177,7 +178,7 @@ public class VoiceAnnouncement {
             sensorStatistics = contentProviderUtils.getSensorStats(track.getId());
         }
 
-        String announcement = VoiceAnnouncementUtils.getAnnouncement(context, track.getTrackStatistics(), isMetricUnits, isReportSpeed, lastInterval, sensorStatistics);
+        Spannable announcement = VoiceAnnouncementUtils.getAnnouncement(context, track.getTrackStatistics(), isMetricUnits, isReportSpeed, lastInterval, sensorStatistics);
 
         // We don't care about the utterance id. It is supplied here to force onUtteranceCompleted to be called.
         tts.speak(announcement, TextToSpeech.QUEUE_FLUSH, null, "not used");

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -1,8 +1,12 @@
 package de.dennisguse.opentracks.services.announcement;
 
+import static android.text.Spanned.SPAN_INCLUSIVE_EXCLUSIVE;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceHeartRate;
 
 import android.content.Context;
+import android.text.Spannable;
+import android.text.SpannableStringBuilder;
+import android.text.style.TtsSpan;
 
 import androidx.annotation.Nullable;
 
@@ -20,7 +24,7 @@ class VoiceAnnouncementUtils {
     private VoiceAnnouncementUtils() {
     }
 
-    static String getAnnouncement(
+    static Spannable getAnnouncement(
             Context context,
             TrackStatistics trackStatistics,
             boolean isMetricUnits,
@@ -28,82 +32,209 @@ class VoiceAnnouncementUtils {
             @Nullable IntervalStatistics.Interval currentInterval,
             @Nullable SensorStatistics sensorStatistics
     ) {
+        SpannableStringBuilder builder = new SpannableStringBuilder();
         Distance distance = trackStatistics.getTotalDistance();
         Speed distancePerTime = trackStatistics.getAverageMovingSpeed();
         Speed currentDistancePerTime = currentInterval != null ? currentInterval.getSpeed() : null;
+        int perUnitStringId = isMetricUnits ? R.string.voice_per_kilometer : R.string.voice_per_mile;
 
-        int totalDistanceId = isMetricUnits ? R.plurals.voiceTotalDistanceKilometers : R.plurals.voiceTotalDistanceMiles;
         double distanceInUnit = distance.toKM_Miles(isMetricUnits);
-        String totalDistance = context.getResources().getQuantityString(totalDistanceId, getQuantityCount(distanceInUnit), distanceInUnit);
+        int distanceId = isMetricUnits ? R.plurals.voiceDistanceKilometers : R.plurals.voiceDistanceMiles;
+
+        builder.append(context.getString(R.string.total_distance));
+        appendDecimalUnit(
+                builder,
+                // This string is not actually spoken
+                context.getResources().getQuantityString(distanceId, getQuantityCount(distanceInUnit), distanceInUnit),
+                String.format("%.2f", distanceInUnit),
+                // Units should always be english singular
+                isMetricUnits ? "kilometer" : "mile"
+        );
+        // Punctuation helps introduce natural pauses in TTS
+        builder.append(",");
         if (distance.isZero()) {
-            return totalDistance;
+            return builder;
         }
 
-        String rate;
-        String currentRate;
-        String currentRateMsg;
-        String heartRateMsg = "";
+        // Announce time
+        Duration movingTime = trackStatistics.getMovingTime();
+        if (!movingTime.isZero()) {
+            appendDuration(
+                    context,
+                    builder,
+                    movingTime
+            );
+            builder.append(",");
+        }
+
         if (isReportSpeed) {
             int speedId = isMetricUnits ? R.plurals.voiceSpeedKilometersPerHour : R.plurals.voiceSpeedMilesPerHour;
             double speedInUnit = distancePerTime.to(isMetricUnits);
-            rate = context.getResources().getQuantityString(speedId, getQuantityCount(speedInUnit), speedInUnit);
 
-            double currentDistancePerTimeInUnit = currentDistancePerTime != null ? currentDistancePerTime.to(isMetricUnits) : 0;
-            currentRate = context.getResources().getQuantityString(speedId, getQuantityCount(currentDistancePerTimeInUnit), currentDistancePerTimeInUnit);
-            currentRateMsg = context.getString(R.string.voice_speed_lap, currentRate);
+            builder.append(" ").append(context.getString(R.string.speed));
+            appendDecimalUnit(
+                    builder,
+                    context.getResources().getQuantityString(speedId, getQuantityCount(speedInUnit), speedInUnit),
+                    String.format("%.1f", speedInUnit),
+                    isMetricUnits ? "kilometer per hour" : "mile per hour"
+            );
+            builder.append(",");
+
+            if (currentDistancePerTime != null) {
+                double currentDistancePerTimeInUnit = currentDistancePerTime.to(isMetricUnits);
+
+                if (currentDistancePerTimeInUnit > 0) {
+
+                    builder.append(" ").append(context.getString(R.string.lap_speed));
+                    appendDecimalUnit(
+                            builder,
+                            context.getResources().getQuantityString(speedId, getQuantityCount(currentDistancePerTimeInUnit), currentDistancePerTimeInUnit),
+                            String.format("%.1f", currentDistancePerTimeInUnit),
+                            isMetricUnits ? "kilometer per hour" : "mile per hour"
+                    );
+                    builder.append(",");
+                }
+            }
         } else {
             Duration time = distancePerTime.toPace(isMetricUnits);
-
-            int paceId = isMetricUnits ? R.string.voice_pace_per_kilometer : R.string.voice_pace_per_mile;
-            rate = context.getString(paceId, getAnnounceTime(context, time));
+            builder.append(" ").append(context.getString(R.string.pace));
+            appendDuration(
+                    context,
+                    builder,
+                    time
+            );
+            builder.append(" ").append(context.getString(perUnitStringId))
+                    .append(",");
 
             Duration currentTime = currentDistancePerTime != null ? currentDistancePerTime.toPace(isMetricUnits) : Duration.ofMillis(0);
-            currentRate = context.getString(paceId, getAnnounceTime(context, currentTime));
-            currentRateMsg = context.getString(R.string.voice_pace_lap, currentRate);
+            if (!currentTime.isZero()) {
+                builder.append(" ").append(context.getString(R.string.lap_time));
+                appendDuration(
+                        context,
+                        builder,
+                        currentTime
+                );
+                builder.append(" ").append(context.getString(perUnitStringId))
+                        .append(",");
+            }
         }
-
-        currentRateMsg = currentInterval == null ? "" : " " + currentRateMsg;
 
         if (shouldVoiceAnnounceHeartRate()) {
             if (sensorStatistics != null && sensorStatistics.hasHeartRate()) {
-                heartRateMsg = context.getString(R.string.average_heart_rate, Math.round(sensorStatistics.getAvgHeartRate().getBPM()));
+                int averageHeartRate = Math.round(sensorStatistics.getAvgHeartRate().getBPM());
+
+                builder.append(" ").append(context.getString(R.string.average_heart_rate));
+                appendCardinal(
+                        builder,
+                        context.getString(R.string.sensor_state_heart_rate_value, averageHeartRate),
+                        averageHeartRate
+                );
+                builder.append(",");
             }
 
             if (currentInterval != null && currentInterval.hasAverageHeartRate()) {
-                if (!heartRateMsg.isEmpty()) {
-                    heartRateMsg += " ";
-                }
-                heartRateMsg += context.getString(R.string.current_heart_rate, Math.round(currentInterval.getAverageHeartRate().getBPM()));
+                int currentHeartRate = Math.round(currentInterval.getAverageHeartRate().getBPM());
+
+                builder.append(" ").append(context.getString(R.string.current_heart_rate));
+                appendCardinal(
+                        builder,
+                        context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate),
+                        currentHeartRate
+                );
+                builder.append(",");
             }
         }
-        heartRateMsg = heartRateMsg.isEmpty() ? "" : " " + heartRateMsg;
 
-        return context.getString(R.string.voice_template, totalDistance, getAnnounceTime(context, trackStatistics.getMovingTime()), rate) + currentRateMsg + heartRateMsg;
-    }
-
-    //TODO We might need to localize this using strings.xml if order is relevant.
-    private static String getAnnounceTime(Context context, Duration duration) {
-        String result = "";
-
-        int hours = (int) (duration.toHours());
-        int minutes = (int) (duration.toMinutes() % 60);
-        int seconds = (int) (duration.getSeconds() % 60);
-
-        if (hours != 0) {
-            String hoursText = context.getResources()
-                    .getQuantityString(R.plurals.voiceHours, hours, hours);
-            result += hoursText + " ";
-        }
-        String minutesText = context.getResources()
-                .getQuantityString(R.plurals.voiceMinutes, minutes, minutes);
-        String secondsText = context.getResources()
-                .getQuantityString(R.plurals.voiceSeconds, seconds, seconds);
-
-        return result + minutesText + " " + secondsText;
+        return builder;
     }
 
     static int getQuantityCount(double d) {
         return (int) d;
+    }
+
+    private static void appendDuration(
+            Context context,
+            SpannableStringBuilder builder,
+            Duration duration
+    ) {
+        int hours = (int) (duration.toHours());
+        int minutes = (int) (duration.toMinutes() % 60);
+        int seconds = (int) (duration.getSeconds() % 60);
+
+        if (hours > 0) {
+            appendDecimalUnit(
+                    builder,
+                    context.getResources()
+                            .getQuantityString(R.plurals.voiceHours, hours, hours),
+                    String.format("%1$d", hours),
+                    "hour"
+            );
+        }
+        if (minutes > 0) {
+            appendDecimalUnit(
+                    builder,
+                    context.getResources()
+                            .getQuantityString(R.plurals.voiceMinutes, minutes, minutes),
+                    String.format("%1$d", minutes),
+                    "minute"
+            );
+        }
+        if (seconds > 0 || duration.isZero()) {
+            appendDecimalUnit(
+                    builder,
+                    context.getResources()
+                            .getQuantityString(R.plurals.voiceSeconds, seconds, seconds),
+                    String.format("%1$d", seconds),
+                    "second"
+            );
+        }
+    }
+
+    /**
+     * Speaks as: 98.14 [UNIT] - ninety eight point one four [UNIT with correct plural form]
+     */
+    private static void appendDecimalUnit(
+            SpannableStringBuilder builder,
+            String localizedText,
+            String decimalValue,
+            String unit
+    ) {
+        int decimalPoint = decimalValue.indexOf(".");
+
+        TtsSpan.MeasureBuilder measureBuilder = new TtsSpan.MeasureBuilder()
+                .setUnit(unit);
+
+        if (decimalPoint == -1) {
+            measureBuilder.setNumber(decimalValue);
+        } else {
+            measureBuilder.setIntegerPart(decimalValue.substring(0, decimalPoint))
+                    .setFractionalPart(decimalValue.substring(decimalPoint + 1));
+        }
+
+        builder.append(" ")
+                .append(
+                        localizedText,
+                        measureBuilder.build(),
+                        SPAN_INCLUSIVE_EXCLUSIVE
+                );
+    }
+
+    /**
+     * Speaks as: 98 - ninety eight
+     */
+    private static void appendCardinal(
+            SpannableStringBuilder builder,
+            String localizedText,
+            long number
+    ) {
+        builder.append(" ")
+                .append(
+                        localizedText,
+                        new TtsSpan.CardinalBuilder()
+                                .setNumber(number)
+                                .build(),
+                        SPAN_INCLUSIVE_EXCLUSIVE
+                );
     }
 }
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -51,7 +51,7 @@ class VoiceAnnouncementUtils {
                 isMetricUnits ? "kilometer" : "mile"
         );
         // Punctuation helps introduce natural pauses in TTS
-        builder.append(",");
+        builder.append(".");
         if (distance.isZero()) {
             return builder;
         }
@@ -64,7 +64,7 @@ class VoiceAnnouncementUtils {
                     builder,
                     movingTime
             );
-            builder.append(",");
+            builder.append(".");
         }
 
         if (isReportSpeed) {
@@ -78,7 +78,7 @@ class VoiceAnnouncementUtils {
                     String.format("%.1f", speedInUnit),
                     isMetricUnits ? "kilometer per hour" : "mile per hour"
             );
-            builder.append(",");
+            builder.append(".");
 
             if (currentDistancePerTime != null) {
                 double currentDistancePerTimeInUnit = currentDistancePerTime.to(isMetricUnits);
@@ -92,7 +92,7 @@ class VoiceAnnouncementUtils {
                             String.format("%.1f", currentDistancePerTimeInUnit),
                             isMetricUnits ? "kilometer per hour" : "mile per hour"
                     );
-                    builder.append(",");
+                    builder.append(".");
                 }
             }
         } else {
@@ -103,8 +103,7 @@ class VoiceAnnouncementUtils {
                     builder,
                     time
             );
-            builder.append(" ").append(context.getString(perUnitStringId))
-                    .append(",");
+            builder.append(" ").append(context.getString(perUnitStringId)).append(".");
 
             Duration currentTime = currentDistancePerTime != null ? currentDistancePerTime.toPace(isMetricUnits) : Duration.ofMillis(0);
             if (!currentTime.isZero()) {
@@ -114,8 +113,7 @@ class VoiceAnnouncementUtils {
                         builder,
                         currentTime
                 );
-                builder.append(" ").append(context.getString(perUnitStringId))
-                        .append(",");
+                builder.append(" ").append(context.getString(perUnitStringId)).append(".");
             }
         }
 
@@ -129,7 +127,7 @@ class VoiceAnnouncementUtils {
                         context.getString(R.string.sensor_state_heart_rate_value, averageHeartRate),
                         averageHeartRate
                 );
-                builder.append(",");
+                builder.append(".");
             }
 
             if (currentInterval != null && currentInterval.hasAverageHeartRate()) {
@@ -141,7 +139,7 @@ class VoiceAnnouncementUtils {
                         context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate),
                         currentHeartRate
                 );
-                builder.append(",");
+                builder.append(".");
             }
         }
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -1,5 +1,7 @@
 package de.dennisguse.opentracks.services.announcement;
 
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceHeartRate;
+
 import android.content.Context;
 
 import androidx.annotation.Nullable;
@@ -62,18 +64,19 @@ class VoiceAnnouncementUtils {
 
         currentRateMsg = currentInterval == null ? "" : " " + currentRateMsg;
 
-        if (sensorStatistics != null && sensorStatistics.hasHeartRate()) {
-            heartRateMsg = context.getString(R.string.average_heart_rate, Math.round(sensorStatistics.getAvgHeartRate().getBPM()));
-        }
-
-        if (currentInterval != null && currentInterval.hasAverageHeartRate()) {
-            if (!heartRateMsg.isEmpty()) {
-                heartRateMsg += " ";
+        if (shouldVoiceAnnounceHeartRate()) {
+            if (sensorStatistics != null && sensorStatistics.hasHeartRate()) {
+                heartRateMsg = context.getString(R.string.average_heart_rate, Math.round(sensorStatistics.getAvgHeartRate().getBPM()));
             }
-            heartRateMsg += context.getString(R.string.current_heart_rate, Math.round(currentInterval.getAverageHeartRate().getBPM()));
-        }
 
-        heartRateMsg = heartRateMsg.isEmpty() ? "": " " + heartRateMsg;
+            if (currentInterval != null && currentInterval.hasAverageHeartRate()) {
+                if (!heartRateMsg.isEmpty()) {
+                    heartRateMsg += " ";
+                }
+                heartRateMsg += context.getString(R.string.current_heart_rate, Math.round(currentInterval.getAverageHeartRate().getBPM()));
+            }
+        }
+        heartRateMsg = heartRateMsg.isEmpty() ? "" : " " + heartRateMsg;
 
         return context.getString(R.string.voice_template, totalDistance, getAnnounceTime(context, trackStatistics.getMovingTime()), rate) + currentRateMsg + heartRateMsg;
     }

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -9,6 +9,7 @@ import java.time.Duration;
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.models.Distance;
 import de.dennisguse.opentracks.data.models.Speed;
+import de.dennisguse.opentracks.stats.SensorStatistics;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.ui.intervals.IntervalStatistics;
 
@@ -17,7 +18,14 @@ class VoiceAnnouncementUtils {
     private VoiceAnnouncementUtils() {
     }
 
-    static String getAnnouncement(Context context, TrackStatistics trackStatistics, boolean isMetricUnits, boolean isReportSpeed, @Nullable IntervalStatistics.Interval currentInterval) {
+    static String getAnnouncement(
+            Context context,
+            TrackStatistics trackStatistics,
+            boolean isMetricUnits,
+            boolean isReportSpeed,
+            @Nullable IntervalStatistics.Interval currentInterval,
+            @Nullable SensorStatistics sensorStatistics
+    ) {
         Distance distance = trackStatistics.getTotalDistance();
         Speed distancePerTime = trackStatistics.getAverageMovingSpeed();
         Speed currentDistancePerTime = currentInterval != null ? currentInterval.getSpeed() : null;
@@ -32,6 +40,7 @@ class VoiceAnnouncementUtils {
         String rate;
         String currentRate;
         String currentRateMsg;
+        String heartRateMsg = "";
         if (isReportSpeed) {
             int speedId = isMetricUnits ? R.plurals.voiceSpeedKilometersPerHour : R.plurals.voiceSpeedMilesPerHour;
             double speedInUnit = distancePerTime.to(isMetricUnits);
@@ -53,7 +62,20 @@ class VoiceAnnouncementUtils {
 
         currentRateMsg = currentInterval == null ? "" : " " + currentRateMsg;
 
-        return context.getString(R.string.voice_template, totalDistance, getAnnounceTime(context, trackStatistics.getMovingTime()), rate) + currentRateMsg;
+        if (sensorStatistics != null && sensorStatistics.hasHeartRate()) {
+            heartRateMsg = context.getString(R.string.average_heart_rate, Math.round(sensorStatistics.getAvgHeartRate().getBPM()));
+        }
+
+        if (currentInterval != null && currentInterval.hasAverageHeartRate()) {
+            if (!heartRateMsg.isEmpty()) {
+                heartRateMsg += " ";
+            }
+            heartRateMsg += context.getString(R.string.current_heart_rate, Math.round(currentInterval.getAverageHeartRate().getBPM()));
+        }
+
+        heartRateMsg = heartRateMsg.isEmpty() ? "": " " + heartRateMsg;
+
+        return context.getString(R.string.voice_template, totalDistance, getAnnounceTime(context, trackStatistics.getMovingTime()), rate) + currentRateMsg + heartRateMsg;
     }
 
     //TODO We might need to localize this using strings.xml if order is relevant.

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -316,6 +316,10 @@ public class PreferencesUtils {
         return getFloat(R.string.voice_speed_rate_key, DEFAULT);
     }
 
+    public static boolean shouldVoiceAnnounceHeartRate() {
+        return getBoolean(R.string.voice_announce_heart_rate_key, false);
+    }
+
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));
     }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -172,6 +172,13 @@ public class PreferencesUtils {
         setString(keyId, resources.getString(valueId));
     }
 
+    @VisibleForTesting
+    public static void setBoolean(int keyId, Boolean value) {
+        Editor editor = sharedPreferences.edit();
+        editor.putBoolean(getKey(keyId), value);
+        editor.apply();
+    }
+
     static void setInt(int keyId, int value) {
         Editor editor = sharedPreferences.edit();
         editor.putInt(getKey(keyId), value);
@@ -318,6 +325,11 @@ public class PreferencesUtils {
 
     public static boolean shouldVoiceAnnounceHeartRate() {
         return getBoolean(R.string.voice_announce_heart_rate_key, false);
+    }
+
+    @VisibleForTesting
+    public static void setVoiceAnnounceHeartRate(boolean value) {
+        setBoolean(R.string.voice_announce_heart_rate_key, value);
     }
 
     public static Distance getRecordingDistanceInterval() {

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -247,6 +247,10 @@ public class TrackStatistics {
         return totalTime.minus(movingTime);
     }
 
+    public boolean hasAverageHeartRate() {
+        return avgHeartRate != null;
+    }
+
     @Nullable
     public HeartRate getAverageHeartRate() {
         return avgHeartRate;

--- a/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/stats/TrackStatistics.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 
 import de.dennisguse.opentracks.data.models.Altitude;
 import de.dennisguse.opentracks.data.models.Distance;
+import de.dennisguse.opentracks.data.models.HeartRate;
 import de.dennisguse.opentracks.data.models.Speed;
 import de.dennisguse.opentracks.data.models.Track;
 import de.dennisguse.opentracks.data.models.TrackPoint;
@@ -56,6 +57,8 @@ public class TrackStatistics {
     private Speed maxSpeed;
     private Float totalAltitudeGain_m = null;
     private Float totalAltitudeLoss_m = null;
+    // The average heart rate seen on this track
+    private HeartRate avgHeartRate = null;
 
     public TrackStatistics() {
         reset();
@@ -76,6 +79,7 @@ public class TrackStatistics {
         altitudeExtremities.set(other.altitudeExtremities.getMin(), other.altitudeExtremities.getMax());
         totalAltitudeGain_m = other.totalAltitudeGain_m;
         totalAltitudeLoss_m = other.totalAltitudeLoss_m;
+        avgHeartRate = other.avgHeartRate;
     }
 
     @VisibleForTesting
@@ -106,6 +110,19 @@ public class TrackStatistics {
             stopTime = other.stopTime;
         } else {
             stopTime = stopTime.isAfter(other.stopTime) ? stopTime : other.stopTime;
+        }
+
+        if (avgHeartRate == null) {
+            avgHeartRate = other.avgHeartRate;
+        } else {
+            if (other.avgHeartRate != null) {
+                // Using total time as weights for the averaging.
+                // Important to do this before total time is updated
+                avgHeartRate = HeartRate.of(
+                        (totalTime.getSeconds() * avgHeartRate.getBPM() + other.totalTime.getSeconds() * other.avgHeartRate.getBPM())
+                                / (totalTime.getSeconds() + other.totalTime.getSeconds())
+                );
+            }
         }
 
         totalDistance = totalDistance.plus(other.totalDistance);
@@ -230,6 +247,11 @@ public class TrackStatistics {
         return totalTime.minus(movingTime);
     }
 
+    @Nullable
+    public HeartRate getAverageHeartRate() {
+        return avgHeartRate;
+    }
+
     /**
      * Gets the average speed.
      * This calculation only takes into account the displacement until the last point that was accounted for in statistics.
@@ -284,6 +306,12 @@ public class TrackStatistics {
     public void updateAltitudeExtremities(Altitude altitude) {
         if (altitude != null) {
             altitudeExtremities.update(altitude.toM());
+        }
+    }
+
+    public void setAverageHeartRate(HeartRate heartRate) {
+        if (heartRate != null) {
+            avgHeartRate = heartRate;
         }
     }
 

--- a/src/main/java/de/dennisguse/opentracks/ui/intervals/IntervalStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/intervals/IntervalStatistics.java
@@ -172,6 +172,7 @@ public class IntervalStatistics {
             time = time.plus(trackStatistics.getTotalTime());
             gain_m = trackStatistics.hasTotalAltitudeGain() ? trackStatistics.getTotalAltitudeGain() : gain_m;
             loss_m = trackStatistics.hasTotalAltitudeLoss() ? trackStatistics.getTotalAltitudeLoss() : loss_m;
+            avgHeartRate = trackStatistics.getAverageHeartRate();
             if (lastTrackPoint == null) {
                 return;
             }
@@ -188,6 +189,7 @@ public class IntervalStatistics {
             time = trackStatistics.getTotalTime();
             gain_m = trackStatistics.hasTotalAltitudeGain() ? trackStatistics.getTotalAltitudeGain() : gain_m;
             loss_m = trackStatistics.hasTotalAltitudeLoss() ? trackStatistics.getTotalAltitudeLoss() : loss_m;
+            avgHeartRate = trackStatistics.getAverageHeartRate();
         }
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/ui/intervals/IntervalStatistics.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/intervals/IntervalStatistics.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import de.dennisguse.opentracks.data.TrackPointIterator;
 import de.dennisguse.opentracks.data.models.Distance;
+import de.dennisguse.opentracks.data.models.HeartRate;
 import de.dennisguse.opentracks.data.models.Speed;
 import de.dennisguse.opentracks.data.models.TrackPoint;
 import de.dennisguse.opentracks.stats.TrackStatistics;
@@ -102,6 +103,7 @@ public class IntervalStatistics {
         private Duration time = Duration.ofSeconds(0);
         private Float gain_m;
         private Float loss_m;
+        private HeartRate avgHeartRate;
 
         public Interval() {
         }
@@ -117,6 +119,7 @@ public class IntervalStatistics {
             time = i.time;
             gain_m = i.gain_m;
             loss_m = i.loss_m;
+            avgHeartRate = i.avgHeartRate;
         }
 
         public Interval(Interval i) {
@@ -124,6 +127,7 @@ public class IntervalStatistics {
             time = i.time;
             gain_m = i.gain_m;
             loss_m = i.loss_m;
+            avgHeartRate = i.avgHeartRate;
         }
 
         private void adjust(double adjustFactor) {
@@ -153,6 +157,14 @@ public class IntervalStatistics {
 
         public Float getLoss_m() {
             return loss_m;
+        }
+
+        public boolean hasAverageHeartRate() {
+            return avgHeartRate != null;
+        }
+
+        public HeartRate getAverageHeartRate() {
+            return avgHeartRate;
         }
 
         private void add(TrackStatistics trackStatistics, @Nullable TrackPoint lastTrackPoint) {

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -283,6 +283,7 @@
         <item>1.2</item>
         <item>1.3</item>
     </string-array>
+    <string name="voice_announce_heart_rate_key" translatable="false">voiceAnnounceHeartRate</string>
 
     <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <!-- See TrackFileFormat -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -405,6 +405,7 @@ limitations under the License.
     <string name="settings_announcements">Announcements</string>
     <string name="settings_announcements_totaltime_frequency">Time interval</string>
     <string name="settings_announcements_distance_frequency">Distance interval</string>
+    <string name="settings_announcements_report_heart_rate">Report heart rate</string>
 
     <string name="settings_reset">Reset</string>
     <!-- Custom Layout -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -575,6 +575,13 @@ limitations under the License.
     <string name="voice_template">%1$s in %2$s at %3$s</string>
     <string name="voice_speed_lap">Lap speed of %1$s</string>
     <string name="voice_pace_lap">Lap time of %1$s</string>
+    <string name="voice_per_kilometer">per kilometer</string>
+    <string name="voice_per_mile">per mile</string>
+    <string name="lap_time">Lap time</string>
+    <string name="pace">Pace</string>
+    <string name="lap_speed">Lap speed</string>
+    <string name="speed">Speed</string>
+    <string name="total_distance">Total distance</string>
     <plurals name="voiceTotalDistanceKilometers">
         <item quantity="one">total distance 1 kilometer</item>
         <item quantity="other">total distance %1$.2f kilometers</item>
@@ -583,8 +590,16 @@ limitations under the License.
         <item quantity="one">total distance 1 mile</item>
         <item quantity="other">total distance %1$.2f miles</item>
     </plurals>
-    <string name="average_heart_rate">Average heart rate %1$d BPM</string>
-    <string name="current_heart_rate">Current heart rate %1$d BPM</string>
+    <plurals name="voiceDistanceKilometers">
+        <item quantity="one">1 kilometer</item>
+        <item quantity="other">%1$.2f kilometers</item>
+    </plurals>
+    <plurals name="voiceDistanceMiles">
+        <item quantity="one">1 mile</item>
+        <item quantity="other">%1$.2f miles</item>
+    </plurals>
+    <string name="average_heart_rate">Average heart rate</string>
+    <string name="current_heart_rate">Current heart rate</string>
     <!-- Waypoint Type -->
     <string name="waypoint_type_atm">ATM</string>
     <string name="waypoint_type_bank">bank</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -582,6 +582,8 @@ limitations under the License.
         <item quantity="one">total distance 1 mile</item>
         <item quantity="other">total distance %1$.2f miles</item>
     </plurals>
+    <string name="average_heart_rate">Average heart rate %1$d BPM</string>
+    <string name="current_heart_rate">Current heart rate %1$d BPM</string>
     <!-- Waypoint Type -->
     <string name="waypoint_type_atm">ATM</string>
     <string name="waypoint_type_bank">bank</string>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -26,4 +26,9 @@
         android:title="@string/menu_voice_rate"
         app:useSimpleSummaryProvider="true" />
 
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/voice_announce_heart_rate_key"
+        android:title="@string/settings_announcements_report_heart_rate" />
+
 </PreferenceScreen>


### PR DESCRIPTION
# Thanks for your contribution.

## PLEASE REMOVE
To support us in providing a nice (and fast) open-source experience:
1. Verify that the tests are passing
2. Check that the code is properly formatted (using AndroidStudio's autoformatter)
3. Provide write access to the [branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
4. If the PR is not ready for review, please submit it as a [draft](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
## PLEASE REMOVE

**Describe the pull request**
This fixes decimal point being incorrect in TTS spans for certain language-region combinations.

One clear example is `en-SE` which I use on my phone. That English language, with region Sweden. The issue arises because TTS will only speak decimal values with a decimal point matching the language of the TTS. But, when you do `String.format("%.2f", ...)`, the string formatting will pick its decimal point based on the region of the current locale. And in Sweden, the decimal point is `,` and not `.` which breaks TTS.

So this PR implements a fix by stripping the locale of its region - so that decimal points defaults to whatever is considered the default for the language.

It's an unusual edge case but nonetheless one which I am experiencing.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
