### PR TITLE
Add information about Wahoo Tickr X

### DIFF
--- a/README_TESTED_SENSORS.md
+++ b/README_TESTED_SENSORS.md
@@ -59,6 +59,7 @@ We do not support type of movement (i.e., walking vs running).
 
 * Polar Stride
 * Stryd (incl. power)
+* Wahoo Tickr X (Cadence appears to be reported in SPM rather than RPM)
 
 ## Tested Barometric Sensor Smartphones
 


### PR DESCRIPTION
**Describe the pull request**
Cadence is a bit of an unknown.  OpenTracks sees the Tickr X as being able to provide
cadence but doesn't display anything for it while walking on the treadmill, for example.

The Wahoo Fitness app does show cadence from the Tickr X while walking on the
treadmill.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).