### PR TITLE
Adhere to recording distance interval for TrackPoint storage.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -172,7 +172,7 @@ public class ExportImportTest {
         track = contentProviderUtils.getTrack(trackId);
         trackPoints = TestDataUtil.getTrackPoints(contentProviderUtils, trackId);
         markers = contentProviderUtils.getMarkers(trackId);
-        assertEquals(11, trackPoints.size());
+        assertEquals(10, trackPoints.size());
         assertEquals(2, markers.size());
     }
 


### PR DESCRIPTION
Fixes #1059.

A valid LastTrackPoint (with distance) is not stored if it did not met the recording distance requirement and no change idle/non-idle took place.

@vlmendz @niekto350 could you test this?