### PR TITLE
Bluetooth: use TrackRecording handler for callback.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -158,7 +158,7 @@ public class ExportImportTest {
         service.insertMarker("Marker 2", "Marker 2 category", "Marker 2 desc", null);
 
         trackPointCreator.setClock("2020-02-02T02:02:06Z");
-        trackPointCreator.setRemoteSensorManager(new BluetoothRemoteSensorManager(context, trackPointCreator));
+        trackPointCreator.setRemoteSensorManager(new BluetoothRemoteSensorManager(context, null, trackPointCreator));
         service.pauseCurrentTrack();
 
         trackPointCreator.setClock("2020-02-02T02:02:20Z");
@@ -171,7 +171,7 @@ public class ExportImportTest {
         sendLocation(trackPointCreator, "2020-02-02T02:02:23Z", 3, 16.001, 10, 15, 10, 0);
 
         trackPointCreator.setClock("2020-02-02T02:02:24Z");
-        trackPointCreator.setRemoteSensorManager(new BluetoothRemoteSensorManager(context, trackPointCreator));
+        trackPointCreator.setRemoteSensorManager(new BluetoothRemoteSensorManager(context, null, trackPointCreator));
         service.endCurrentTrack();
 
         Track track = contentProviderUtils.getTrack(trackId);
@@ -487,7 +487,7 @@ public class ExportImportTest {
     }
 
     private void mockBLESensorData(TrackPointCreator trackPointCreator, Float speed, Distance distance, float heartRate, float cadence, Float power) {
-        trackPointCreator.setRemoteSensorManager(new BluetoothRemoteSensorManager(context, trackPointCreator) {
+        trackPointCreator.setRemoteSensorManager(new BluetoothRemoteSensorManager(context, null, trackPointCreator) {
             @Override
             public SensorDataSet fill(@NonNull TrackPoint trackPoint) {
                 SensorDataSet sensorDataSet = new SensorDataSet();

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestUtils.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestUtils.java
@@ -27,7 +27,7 @@ public class TrackRecordingServiceTestUtils {
         TrackRecordingService service = ((TrackRecordingService.Binder) mServiceRule.bindService(new Intent(context, TrackRecordingService.class)))
                 .getService();
 
-        service.getTrackPointCreator().setRemoteSensorManager(new BluetoothRemoteSensorManager(context, service.getTrackPointCreator()));
+        service.getTrackPointCreator().setRemoteSensorManager(new BluetoothRemoteSensorManager(context, null, service.getTrackPointCreator()));
         service.getTrackPointCreator().setClock(Clock.systemUTC());
         service.endCurrentTrack();
     }

--- a/src/androidTest/java/de/dennisguse/opentracks/services/handlers/TrackPointCreatorTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/handlers/TrackPointCreatorTest.java
@@ -32,7 +32,7 @@ public class TrackPointCreatorTest {
     @Before
     public void setUp() {
         subject = new TrackPointCreator(locationHandler, server);
-        subject.start(context);
+        subject.start(context, null);
     }
 
     @After

--- a/src/main/java/de/dennisguse/opentracks/sensors/BluetoothRemoteSensorManager.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/BluetoothRemoteSensorManager.java
@@ -20,6 +20,7 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Handler;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -57,7 +58,7 @@ public class BluetoothRemoteSensorManager implements BluetoothConnectionManager.
 
     private final BluetoothAdapter bluetoothAdapter;
     private final Context context;
-
+    private final Handler handler;
     private boolean started = false;
 
     private Distance preferenceWheelCircumference;
@@ -111,8 +112,9 @@ public class BluetoothRemoteSensorManager implements BluetoothConnectionManager.
         }
     };
 
-    public BluetoothRemoteSensorManager(@NonNull Context context, @NonNull SensorDataSetChangeObserver observer) {
+    public BluetoothRemoteSensorManager(@NonNull Context context, @NonNull Handler handler, @NonNull SensorDataSetChangeObserver observer) {
         this.context = context;
+        this.handler = handler;
         this.observer = observer;
         bluetoothAdapter = BluetoothUtils.getAdapter(context);
     }
@@ -216,6 +218,12 @@ public class BluetoothRemoteSensorManager implements BluetoothConnectionManager.
     @Override
     public void onDisconnecting(SensorData<?> sensorData) {
         sensorDataSet.remove(sensorData);
+    }
+
+    @NonNull
+    @Override
+    public Handler getHandler() {
+        return handler;
     }
 
     public interface SensorDataSetChangeObserver {

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -19,6 +19,7 @@ package de.dennisguse.opentracks.services;
 import android.app.Service;
 import android.content.Intent;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.PowerManager.WakeLock;
 import android.util.Log;
 import android.util.Pair;
@@ -102,7 +103,7 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
     public void onCreate() {
         super.onCreate();
 
-        handler = new Handler();
+        handler = new Handler(Looper.getMainLooper());
 
         recordingStatusObservable = new MutableLiveData<>();
         updateRecordingStatus(STATUS_DEFAULT);

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -212,7 +212,7 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
 
     private void startSensors() {
         wakeLock = SystemUtils.acquireWakeLock(this, wakeLock);
-        trackPointCreator.start(this);
+        trackPointCreator.start(this, handler);
         showNotification(true);
     }
 

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
@@ -2,6 +2,7 @@ package de.dennisguse.opentracks.services.handlers;
 
 import android.content.Context;
 import android.location.Location;
+import android.os.Handler;
 import android.util.Log;
 import android.util.Pair;
 
@@ -48,12 +49,12 @@ public class TrackPointCreator implements BluetoothRemoteSensorManager.SensorDat
         this.gpsHandler = gpsHandler;
     }
 
-    public synchronized void start(@NonNull Context context) {
+    public synchronized void start(@NonNull Context context, @NonNull Handler handler) {
         this.context = context;
 
         gpsHandler.onStart(context);
 
-        remoteSensorManager = new BluetoothRemoteSensorManager(context, this);
+        remoteSensorManager = new BluetoothRemoteSensorManager(context, handler, this);
         altitudeSumManager = new AltitudeSumManager();
 
         remoteSensorManager.start();


### PR DESCRIPTION
Otherwise the thread is not defined and a SecurityException may be triggered when inserting data into the ContentProvider.

Part of #1165.

BUT we can only deploy this actual fix for API>26.
All others may always/often/sometimes/never be able to store BLE sensor provided data (without GPS).

```
/home/runner/work/OpenTracks/OpenTracks/src/main/java/de/dennisguse/opentracks/sensors/BluetoothConnectionManager.java:132: Error: Call requires API level 26 (current min is 21): android.bluetooth.BluetoothDevice#connectGatt [NewApi]
        bluetoothGatt = device.connectGatt(context, true, connectCallback, BluetoothDevice.TRANSPORT_AUTO, 0, this.observer.getHandler());
```