### PR TITLE
Implement Public API stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The API can be invoked by sending an explicit Intent to start an activity.
 
 `Class`:
 * **Start a recording:**  `de.dennisguse.opentracks.publicapi.StartRecording`
+* **Start a recording:**  `de.dennisguse.opentracks.publicapi.StopRecording`
 
 For testing via adb: `adb shell am start -n "package/class"`
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -77,14 +77,14 @@ limitations under the License.
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
-        <!--        <activity-->
-        <!--            android:name=".publicapi.StopRecording"-->
-        <!--            android:exported="true"-->
-        <!--            android:theme="@style/SplashTheme">-->
-        <!--            <intent-filter>-->
-        <!--                <category android:name="android.intent.category.DEFAULT" />-->
-        <!--            </intent-filter>-->
-        <!--        </activity>-->
+        <activity
+            android:name=".publicapi.StopRecording"
+            android:exported="true"
+            android:theme="@style/SplashTheme">
+            <intent-filter>
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
 
         <activity android:name=".AboutActivity" />
 

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -79,7 +79,7 @@ public class TrackRecordedActivity extends AbstractTrackDeleteActivity implement
 
     private TrackRecordingServiceConnection trackRecordingServiceConnection;
 
-    private final TrackRecordingServiceConnection.Callback bindCallback = service -> service.getRecordingStatusObservable()
+    private final TrackRecordingServiceConnection.Callback bindCallback = (service, unused) -> service.getRecordingStatusObservable()
             .observe(TrackRecordedActivity.this, this::onRecordingStatusChanged);
 
     @Override
@@ -203,11 +203,17 @@ public class TrackRecordedActivity extends AbstractTrackDeleteActivity implement
         }
 
         if (item.getItemId() == R.id.track_detail_resume_track) {
-            Intent newIntent = IntentUtils.newIntent(TrackRecordedActivity.this, TrackRecordingActivity.class)
-                    .putExtra(TrackRecordingActivity.EXTRA_TRACK_ID, trackId);
-            startActivity(newIntent);
-            overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
-            finish();
+            new TrackRecordingServiceConnection((service, connection) -> {
+                service.resumeTrack(trackId);
+
+                Intent newIntent = IntentUtils.newIntent(TrackRecordedActivity.this, TrackRecordingActivity.class)
+                        .putExtra(TrackRecordingActivity.EXTRA_TRACK_ID, trackId);
+                startActivity(newIntent);
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
+
+                connection.unbind(this);
+                finish();
+            }).startAndBind(this);
             return true;
         }
 

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordingFragment.java
@@ -77,7 +77,7 @@ public class StatisticsRecordingFragment extends Fragment {
         }
     };
 
-    private final TrackRecordingServiceConnection.Callback bindChangedCallback = service -> {
+    private final TrackRecordingServiceConnection.Callback bindChangedCallback = (service, unused) -> {
         service.getRecordingDataObservable()
                 .observe(StatisticsRecordingFragment.this, this::onRecordingDataChanged);
     };

--- a/src/main/java/de/dennisguse/opentracks/publicapi/AbstractAPIActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/publicapi/AbstractAPIActivity.java
@@ -16,38 +16,30 @@ public abstract class AbstractAPIActivity extends AppCompatActivity {
 
     private final String TAG = AbstractAPIActivity.class.getSimpleName();
 
-    private final TrackRecordingServiceConnection.Callback serviceConnectedCallback = service -> {
+    private final TrackRecordingServiceConnection.Callback serviceConnectedCallback = (service, connection) -> {
         if (!isFinishing() && !isDestroyed()) {
             execute(service);
         }
         if (isPostExecuteStopService()) {
-            AbstractAPIActivity.this.trackRecordingServiceConnection.unbindAndStop(AbstractAPIActivity.this);
+            connection.unbindAndStop(AbstractAPIActivity.this);
         } else {
-            AbstractAPIActivity.this.trackRecordingServiceConnection.unbind(AbstractAPIActivity.this);
+            connection.unbind(AbstractAPIActivity.this);
         }
         finish();
     };
-
-    private TrackRecordingServiceConnection trackRecordingServiceConnection;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (PreferencesUtils.isPublicAPIenabled()) {
             Log.i(TAG, "Received and trying to execute requested action.");
-            trackRecordingServiceConnection = new TrackRecordingServiceConnection(serviceConnectedCallback);
-            trackRecordingServiceConnection.startAndBind(this);
+            new TrackRecordingServiceConnection(serviceConnectedCallback)
+                    .startAndBind(this);
         } else {
             Toast.makeText(this, getString(R.string.settings_public_api_disabled_toast), Toast.LENGTH_LONG).show();
             Log.w(TAG, "Public API is disabled; ignoring request.");
             finish();
         }
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        trackRecordingServiceConnection = null;
     }
 
     protected abstract void execute(TrackRecordingService service);

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceConnection.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceConnection.java
@@ -92,15 +92,10 @@ public class TrackRecordingServiceConnection implements ServiceConnection, Death
             return;
         }
         if (callback != null) {
-            callback.onConnected(trackRecordingService);
+            callback.onConnected(trackRecordingService, this);
         }
     }
 
-    /**
-     * Resumes the track recording service connection.
-     *
-     * @param context the context
-     */
     public void startConnection(@NonNull Context context) {
         if (trackRecordingService != null) {
             // Service is already started and bound.
@@ -115,6 +110,7 @@ public class TrackRecordingServiceConnection implements ServiceConnection, Death
     /**
      * Unbinds the service (but leave it running).
      */
+    //TODO This is often called for one-shot operations and should be refactored as unbinding is required.
     public void unbind(Context context) {
         try {
             context.unbindService(this);
@@ -141,7 +137,7 @@ public class TrackRecordingServiceConnection implements ServiceConnection, Death
         trackRecordingService = value;
         if (callback != null) {
             if (value != null) {
-                callback.onConnected(value);
+                callback.onConnected(value, this);
             } else {
                 callback.onDisconnected();
             }
@@ -214,7 +210,7 @@ public class TrackRecordingServiceConnection implements ServiceConnection, Death
     }
 
     public interface Callback {
-        void onConnected(TrackRecordingService service);
+        void onConnected(TrackRecordingService service, TrackRecordingServiceConnection connection);
 
         default void onDisconnected() {
         }

--- a/src/main/java/de/dennisguse/opentracks/settings/MainSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/MainSettingsFragment.java
@@ -18,7 +18,7 @@ public class MainSettingsFragment extends PreferenceFragmentCompat {
     private RecordingStatus recordingStatus = TrackRecordingService.STATUS_DEFAULT;
     private TrackRecordingServiceConnection trackRecordingServiceConnection;
     private final TrackRecordingServiceConnection.Callback bindServiceCallback =
-            service -> service.getRecordingStatusObservable()
+            (service, unused) -> service.getRecordingStatusObservable()
                     .observe(MainSettingsFragment.this, this::onRecordingStatusChanged);
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerListActivity.java
@@ -71,7 +71,7 @@ public class MarkerListActivity extends AbstractActivity implements DeleteMarker
 
     private TrackRecordingServiceConnection trackRecordingServiceConnection;
 
-    private final TrackRecordingServiceConnection.Callback bindCallback = service -> service.getRecordingStatusObservable()
+    private final TrackRecordingServiceConnection.Callback bindCallback = (service, unused) -> service.getRecordingStatusObservable()
             .observe(MarkerListActivity.this, this::onRecordingStatusChanged);
 
     // Callback when an item is selected in the contextual action mode


### PR DESCRIPTION
The stop intent is now handled properly.
This is achieved by extracting starting the recording from `TrackRecordingActivity` into the calling code.
`TrackRecordingActivity` finishes automatically if the recording is stopped. 

Beforehand `TrackRecordingActivity` was starting the recording if the `TrackRecordingService` was not recording.
However, this restarted recording if stopped via Intent if `TrackRecordingActivity` was brought into foreground.


Build on top of #1155.

TODO:
- [x] wait for merging #1155.
- [x] rebase onto main
- [x] test again ;)