### PR TITLE
Upgrade to KML2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,19 @@ _OpenTracks_ is a sport tracking application that completely respects your priva
 * __Voice announcements__
 * __Photos and Markers:__ mark interesting locations while tracking
 * __Export:__
-  * export tracks either as KMZ (incl. photos), KML, or GPX
-  * export automatically after each recording (e.g., to sync via [Nextcloud](https://nextcloud.com/))
-  * avoid duplication: each exported file contain a random unique identifier (i.e., `opentracks:trackid`)
+    * export tracks either as [KMZ 2.3](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html) (incl. photos), [KML 2.3](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html), or [GPX 1.1](https://www.topografix.com/GPX/1/1/)
+    * export automatically after each recording (e.g., to sync via [Nextcloud](https://nextcloud.com/))
+    * avoid duplication: each exported file contain a random unique identifier (i.e., `opentracks:trackid`)
 * __Altitude:__
-  * gain/loss via barometric sensor (if present)
-  * shown in EGM2008 (above mean sea level); exported as WGS84
+    * gain/loss via barometric sensor (if present)
+    * shown in EGM2008 (above mean sea level); exported as WGS84
 * __Bluetooth LE sensors:__
-  * heart rate
-  * cycling: speed and distance
-  * cycling: cadence
-  * cycling: power meter
-  * running: speed and cadence
-  * support for BLE sensor training only (i.e., without GPS) for indoor training
+    * heart rate
+    * cycling: speed and distance
+    * cycling: cadence
+    * cycling: power meter
+    * running: speed and cadence
+    * support for BLE sensor training only (i.e., without GPS) for indoor training
 
   An overview of tested sensors: [README_TESTED_SENSORS.md](README_TESTED_SENSORS.md)
 
@@ -121,7 +121,14 @@ For testing via adb: `adb shell am start -e someParameter someValue -n "package/
 
 The Public API is disabled by default to protect the user's privacy, but it can easily be enabled in the settings.
 
-__IMPORTANT__: triggering `StartRecording` does not check if Android permissions (location or Bluetooth) were granted. If they are not granted, nothing will be recorded.
+## File formats compatibility with open-source software
+
+|                                                      | [GPX 1.1](https://www.topografix.com/GPX/1/1/) | [KML 2.3](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html) | [KMZ 2.3](https://docs.opengeospatial.org/is/12-007r2/12-007r2.html) |
+|------------------------------------------------------|------------------------------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------|
+| [OpenLayers 7.1.0](https://openlayers.org/)          | ?                                              | [no](https://github.com/openlayers/openlayers/issues/14104)          | [no](https://github.com/openlayers/openlayers/issues/14104)          |
+| [Golden Cheetah 3.5](https://www.goldencheetah.org/) | ?                                              | [no](https://github.com/GoldenCheetah/GoldenCheetah/issues/4271)     | [no](https://github.com/GoldenCheetah/GoldenCheetah/issues/4271)     |
+| [GpxPod](https://apps.nextcloud.com/apps/gpxpod)     | ?                                              | ?                                                                    | ?                                                                    |
+| [OsmAnd](https://github.com/osmandapp/OsmAnd)        | ?                                              | [no](https://github.com/osmandapp/OsmAnd/issues/15271)               | [no](https://github.com/osmandapp/OsmAnd/issues/15271)               |
 
 ## Dashboard API (incl. map)
 

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackExporterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackExporterTest.java
@@ -28,14 +28,14 @@ public class KmlTrackExporterTest {
     @Test
     public void writeCloseSegment_only_write_sensordata_if_present() {
         String expected = "<when>1970-01-01T00:00:00Z</when>\n" +
-                "<gx:coord/>\n" +
+                "<coord/>\n" +
                 "<when>1970-01-01T01:00:00+01:00</when>\n" +
-                "<gx:coord/>\n" +
+                "<coord/>\n" +
                 "<ExtendedData>\n" +
                 "<SchemaData schemaUrl=\"#schema\">\n" +
                 "</SchemaData>\n" +
                 "</ExtendedData>\n" +
-                "</gx:Track>\n";
+                "</Track>\n";
 
         // given
         TrackPoint trackPoint = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochSecond(0));


### PR DESCRIPTION
Export format is now KML2.3.
The importer supports KML2.2 and KML2.3.

Tested with:
- [x] ~OpenLayers~ (not supported as of 7.1.0): https://github.com/openlayers/openlayers/issues/14104
- [x] ~GoldenChetah~ (cannot import KML2.2 or KML2.3) https://github.com/GoldenCheetah/GoldenCheetah/issues/4271
- [x] ~OsmAnd~ (not supported; supports KML2.2); actually does not have proper KML support; they use XML transformation to GPX https://github.com/osmandapp/OsmAnd/issues/15271
- [x] ~OrganicMaps~ (not supported: supports KML 2.2)
- [x] GpxPod (only supports 2.3)
- [x] ~Google Maps~ (not supported; supports KML2.2)
- [x] https://www.gpsvisualizer.com (supported) ~(not supported; supports KML2.2): informed by email~