### PR TITLE
Change track title capitalization to sentences

### DIFF
--- a/src/main/res/layout/track_edit_fields.xml
+++ b/src/main/res/layout/track_edit_fields.xml
@@ -23,7 +23,7 @@
                 android:id="@+id/track_edit_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textCapWords"
+                android:inputType="textCapSentences"
                 android:selectAllOnFocus="true" />
 
         </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
**Describe the pull request**
When naming activities, I always have to manually disable capitalization for every new word, which alters my experience of entering text. I think it is more natural to capitalize sentences only. Maybe you could even envision adding a setting that would enable the user to choose between word or sentence-only capitalization.

**License agreement**
I am providing my contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).