### PR TITLE
Allow settings reset and import/export while recording

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/settings/MainSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/MainSettingsFragment.java
@@ -2,6 +2,7 @@ package de.dennisguse.opentracks.settings;
 
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
@@ -13,19 +14,9 @@ import de.dennisguse.opentracks.services.TrackRecordingServiceConnection;
 
 public class MainSettingsFragment extends PreferenceFragmentCompat {
 
-    private static final String TAG = MainSettingsFragment.class.getSimpleName();
-
-    private RecordingStatus recordingStatus = TrackRecordingService.STATUS_DEFAULT;
-    private TrackRecordingServiceConnection trackRecordingServiceConnection;
-    private final TrackRecordingServiceConnection.Callback bindServiceCallback =
-            (service, unused) -> service.getRecordingStatusObservable()
-                    .observe(MainSettingsFragment.this, this::onRecordingStatusChanged);
-
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         addPreferencesFromResource(R.xml.settings);
-
-        trackRecordingServiceConnection = new TrackRecordingServiceConnection(bindServiceCallback);
 
         findPreference(getString(R.string.settings_defaults_key)).setOnPreferenceClickListener(preference -> {
             ((SettingsActivity) getActivity()).openScreen(getString(R.string.settings_defaults_key));
@@ -69,20 +60,7 @@ public class MainSettingsFragment extends PreferenceFragmentCompat {
     }
 
     @Override
-    public void onResume() {
-        super.onResume();
-        trackRecordingServiceConnection.bind(getContext());
-        updatePrefsDependOnRecording();
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        trackRecordingServiceConnection.unbind(getContext());
-    }
-
-    @Override
-    public void onDisplayPreferenceDialog(Preference preference) {
+    public void onDisplayPreferenceDialog(@NonNull Preference preference) {
         DialogFragment dialogFragment = null;
 
         if (preference instanceof ResetDialogPreference) {
@@ -96,21 +74,5 @@ public class MainSettingsFragment extends PreferenceFragmentCompat {
         }
 
         super.onDisplayPreferenceDialog(preference);
-    }
-
-    private void onRecordingStatusChanged(RecordingStatus status) {
-        this.recordingStatus = status;
-        if (isAdded()) {
-            updatePrefsDependOnRecording();
-        }
-    }
-
-    private void updatePrefsDependOnRecording() {
-        Preference importExportPreference = findPreference(getString(R.string.settings_import_export_key));
-
-        boolean isRecording = recordingStatus.isRecording();
-
-        importExportPreference.setSummary(isRecording ? getString(R.string.settings_not_while_recording) : getString(R.string.settings_import_export_summary));
-        importExportPreference.setEnabled(!isRecording);
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/settings/MainSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/MainSettingsFragment.java
@@ -107,14 +107,10 @@ public class MainSettingsFragment extends PreferenceFragmentCompat {
 
     private void updatePrefsDependOnRecording() {
         Preference importExportPreference = findPreference(getString(R.string.settings_import_export_key));
-        Preference resetPreference = findPreference(getString(R.string.settings_reset_key));
 
         boolean isRecording = recordingStatus.isRecording();
 
         importExportPreference.setSummary(isRecording ? getString(R.string.settings_not_while_recording) : getString(R.string.settings_import_export_summary));
         importExportPreference.setEnabled(!isRecording);
-
-        resetPreference.setSummary(isRecording ? getString(R.string.settings_not_while_recording) : getString(R.string.settings_reset_summary));
-        resetPreference.setEnabled(!isRecording);
     }
 }

--- a/src/main/res/values-ar/strings.xml
+++ b/src/main/res/values-ar/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d نبضة في الدقيقة</string>
     <string name="sensor_state_power">الطاقة</string>
     <string name="sensor_state_power_value">%1$d واط</string>
-    <string name="settings_not_while_recording">غير متاح أثناء تسجيل مسار</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">خيارات متقدمة</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-b+en+001/strings.xml
+++ b/src/main/res/values-b+en+001/strings.xml
@@ -146,7 +146,6 @@
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Power</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Not available while recording a track</string>
     <string name="settings_advanced">Advanced</string>
     <string name="settings_chart_by_distance">By distance</string>
     <string name="settings_chart_by_time">By time</string>

--- a/src/main/res/values-b+es+419/strings.xml
+++ b/src/main/res/values-b+es+419/strings.xml
@@ -148,7 +148,6 @@
     <string name="sensor_state_heart_rate_value">%1$d lpm</string>
     <string name="sensor_state_power">Potencia</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">No está disponible durante la grabación de un recorrido</string>
     <string name="settings_advanced">Opciones avanzadas</string>
     <string name="settings_chart_by_distance">Por distancia</string>
     <string name="settings_chart_by_time">Por tiempo</string>

--- a/src/main/res/values-bg/strings.xml
+++ b/src/main/res/values-bg/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d уд/мин</string>
     <string name="sensor_state_power">Захранване</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Не е налице при записване на маршрут</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Разширени</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-ca/strings.xml
+++ b/src/main/res/values-ca/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d ppm</string>
     <string name="sensor_state_power">Potència</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">No està disponible durant l\'enregistrament d\'una ruta.</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Avançades</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -233,7 +233,6 @@ limitations under the License.
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">Nelze vyhledat zařízení Bluetooth (chyba %1$i).</string>
     <string name="bluetooth_disabled">Aktivujte prosím Bluetooth.</string>
-    <string name="settings_not_while_recording">Při záznamu trasy není tato funkce dostupná</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Pokročilé</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-da/strings.xml
+++ b/src/main/res/values-da/strings.xml
@@ -238,7 +238,6 @@ Hvis GPS-enheden rapporterer unøjagtige data (f.eks. Placering, hastighed, høj
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">Kunne ikke scanne efter Bluetooth-enheder (fejl %1$i).</string>
     <string name="bluetooth_disabled">Aktivér Bluetooth.</string>
-    <string name="settings_not_while_recording">Ikke tilgængelig ved registrering af rute</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Avanceret</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -241,7 +241,6 @@ Meldet das GPS-Gerät ungenaue Daten (z.B. Standort, Geschwindigkeit, Höhe), ka
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">Konnte nicht nach Bluetooth-Geräten scannen (Fehler %1$i).</string>
     <string name="bluetooth_disabled">Bitte Bluetooth aktivieren.</string>
-    <string name="settings_not_while_recording">Während der Aufzeichnung eines Tracks nicht verfügbar</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Erweitert</string>
     <string name="settings_default_trackfileformat">Dateiformat für export/teilen</string>

--- a/src/main/res/values-el/strings.xml
+++ b/src/main/res/values-el/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Ισχύς</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Η επιλογή δεν είναι διαθέσιμη κατά την εγγραφή ίχνους</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Προηγμένες</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -233,7 +233,6 @@ limitations under the License.
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">No se pudieron buscar dispositivos Bluetooth (error %1$i).</string>
     <string name="bluetooth_disabled">Por favor habilite Bluetooth.</string>
-    <string name="settings_not_while_recording">No está disponible durante la grabación de un recorrido</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Opciones avanzadas</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-et/strings.xml
+++ b/src/main/res/values-et/strings.xml
@@ -233,7 +233,6 @@ limitations under the License.
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">Bluetooth seadmeid ei õnnestunud skannida (tõrge %1$i).</string>
     <string name="bluetooth_disabled">Lubage Bluetooth.</string>
-    <string name="settings_not_while_recording">Raja salvestamise ajal ei ole kättesaadav</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Täpsemad seaded</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-eu/strings.xml
+++ b/src/main/res/values-eu/strings.xml
@@ -236,7 +236,6 @@ GPS gailuak datu okerrak salatzen baditu (adibidez, kokapena, abiadura, kota), O
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">Ezin izan da Bluetooth gailuak bilatu (%1$i errorea).</string>
     <string name="bluetooth_disabled">Mesedez, aktibatu Bluetooth.</string>
-    <string name="settings_not_while_recording">Ez dago erabilgarri ibilbidea grabatzen ari den bitartean</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Aurreratua</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-fa/strings.xml
+++ b/src/main/res/values-fa/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d ضربان در دقیقه</string>
     <string name="sensor_state_power">توان</string>
     <string name="sensor_state_power_value">%1$d وات</string>
-    <string name="settings_not_while_recording">در حال ضبط گذر، در دسترس نیست</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">پیشرفته</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-fi/strings.xml
+++ b/src/main/res/values-fi/strings.xml
@@ -239,7 +239,6 @@ limitations under the License.
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">Bluetooth-laitteita ei saatu etsittyä (virhe %1$i).</string>
     <string name="bluetooth_disabled">Ota Bluetooth käyttöön.</string>
-    <string name="settings_not_while_recording">Ei saatavilla reitin tallennuksen aikana</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Lisäasetukset</string>
     <string name="settings_default_trackfileformat">Tiedostomuoto vientiä ja jakamista varten</string>

--- a/src/main/res/values-fr-rCA/strings.xml
+++ b/src/main/res/values-fr-rCA/strings.xml
@@ -146,7 +146,6 @@
     <string name="sensor_state_heart_rate_value">%1$d b/m</string>
     <string name="sensor_state_power">Alimentation</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Cette option n\'est pas accessible pendant l\'enregistrement d\'un parcours.</string>
     <string name="settings_advanced">Options avancées</string>
     <string name="settings_chart_by_distance">Par distance</string>
     <string name="settings_chart_by_time">Par heure</string>

--- a/src/main/res/values-fr-rCH/strings.xml
+++ b/src/main/res/values-fr-rCH/strings.xml
@@ -146,7 +146,6 @@
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Puissance</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Non disponible pendant l\'enregistrement d\'un parcours.</string>
     <string name="settings_advanced">Avancé</string>
     <string name="settings_chart_by_distance">En fonction de la distance</string>
     <string name="settings_chart_by_time">En fonction de la durée</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -236,7 +236,6 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">Impossible de rechercher les appareils Bluetooth (erreur %1$i).</string>
     <string name="bluetooth_disabled">Veuillez activer Bluetooth.</string>
-    <string name="settings_not_while_recording">Non disponible pendant l\'enregistrement d\'un parcours</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Avancé</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-gl/strings.xml
+++ b/src/main/res/values-gl/strings.xml
@@ -246,7 +246,6 @@ Se te detés ou estás en interiores, non se gardarán datos do sensor (mais ser
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">Non se escanearon dispositivos Bluetooth (fallo %1$i).</string>
     <string name="bluetooth_disabled">Activa o Bluetooth.</string>
-    <string name="settings_not_while_recording">Non dispoñible durante a gravación dunha ruta</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Opcións avanzadas</string>
     <string name="settings_default_trackfileformat">Formato do ficheiro a exportar/compartir</string>

--- a/src/main/res/values-hi/strings.xml
+++ b/src/main/res/values-hi/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">पॉवर</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">ट्रैक रिकॉर्ड करते समय उपलब्ध नहीं</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">उन्नत</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-hr/strings.xml
+++ b/src/main/res/values-hr/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d otkuc./min.</string>
     <string name="sensor_state_power">Napajanje</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Nije dostupno tijekom snimanja staze</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Napredno</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-hu/strings.xml
+++ b/src/main/res/values-hu/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d ütés/perc</string>
     <string name="sensor_state_power">Teljesítmény</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Pálya rögzítése közben nem érhető el</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Speciális</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-in/strings.xml
+++ b/src/main/res/values-in/strings.xml
@@ -146,7 +146,6 @@
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Daya</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Tidak tersedia saat merekam trek</string>
     <string name="settings_advanced">Lanjutan</string>
     <string name="settings_chart_by_distance">Menurut jarak</string>
     <string name="settings_chart_by_time">Menurut waktu</string>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -217,7 +217,6 @@ Infatti, un\'applicazione deve supportare <i>ACTION_VIEW</i> con MIME <i>applica
     <string name="sensor_state_heart_rate_value">%1$d battiti al minuto</string>
     <string name="sensor_state_power">Potenza</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Non disponibile durante la registrazione di un percorso</string>
 
     <!-- Settings Advanced -->
     <string name="settings_advanced">Avanzate</string>

--- a/src/main/res/values-iw/strings.xml
+++ b/src/main/res/values-iw/strings.xml
@@ -146,7 +146,6 @@
     <string name="sensor_state_heart_rate_value">%1$d פעימות לדקה</string>
     <string name="sensor_state_power">הספק</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">לא זמין בעת הקלטת מסלול</string>
     <string name="settings_advanced">מתקדם</string>
     <string name="settings_chart_by_distance">לפי מרחק</string>
     <string name="settings_chart_by_time">לפי זמן</string>

--- a/src/main/res/values-ja/strings.xml
+++ b/src/main/res/values-ja/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$dbpm</string>
     <string name="sensor_state_power">電源</string>
     <string name="sensor_state_power_value">%1$dW</string>
-    <string name="settings_not_while_recording">トラックの記録中はご利用いただけません</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">詳細設定</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-ko/strings.xml
+++ b/src/main/res/values-ko/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">출력</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">운동기록을 기록하는 동안 사용할 수 없습니다.</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">고급</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-lt/strings.xml
+++ b/src/main/res/values-lt/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d dūž./min</string>
     <string name="sensor_state_power">Maitinimas</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Kol įrašinėjamas maršrutas, nepasiekiama</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Išplėstinės</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-lv/strings.xml
+++ b/src/main/res/values-lv/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d sit./min</string>
     <string name="sensor_state_power">Jauda</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Nav pieejams maršruta ierakstīšanas laikā</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Papildu iestatījumi</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-mo/strings.xml
+++ b/src/main/res/values-mo/strings.xml
@@ -146,7 +146,6 @@
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Putere</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Indisponibilă în timp ce înregistrați un traseu.</string>
     <string name="settings_advanced">Avansate</string>
     <string name="settings_chart_by_distance">După distanță</string>
     <string name="settings_chart_by_time">După durată</string>

--- a/src/main/res/values-ms/strings.xml
+++ b/src/main/res/values-ms/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Kuasa</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Tidak tersedia semasa merakam laluan</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Terperinci</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-nb/strings.xml
+++ b/src/main/res/values-nb/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d slag/min</string>
     <string name="sensor_state_power">Kraft</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Ikke tilgjengelig mens du tar opp et spor</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Avansert</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -235,7 +235,6 @@ Als het GPS-apparaat onnauwkeurige gegevens rapporteert (bijv. locatie, snelheid
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">Kon niet scannen naar Bluetooth-apparaten (fout %1$i).</string>
     <string name="bluetooth_disabled">Schakel Bluetooth in.</string>
-    <string name="settings_not_while_recording">Niet beschikbaar tijdens het opnemen van een route</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Geavanceerd</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-pl/strings.xml
+++ b/src/main/res/values-pl/strings.xml
@@ -189,7 +189,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d uderz./min</string>
     <string name="sensor_state_power">Moc</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Niedostępne podczas rejestrowania trasy</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Zaawansowane</string>
     <string name="settings_default_trackfileformat">Format pliku eksportu/udostępniania</string>

--- a/src/main/res/values-pt-rBR/strings.xml
+++ b/src/main/res/values-pt-rBR/strings.xml
@@ -146,7 +146,6 @@
     <string name="sensor_state_heart_rate_value">%1$d bom</string>
     <string name="sensor_state_power">Alimentação</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Não disponível durante a gravação de uma trilha</string>
     <string name="settings_advanced">Avançado</string>
     <string name="settings_chart_by_distance">Por distância</string>
     <string name="settings_chart_by_time">Por tempo</string>

--- a/src/main/res/values-pt-rPT/strings.xml
+++ b/src/main/res/values-pt-rPT/strings.xml
@@ -146,7 +146,6 @@
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Potência</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Indisponível durante a gravação de um percurso</string>
     <string name="settings_advanced">Avançado</string>
     <string name="settings_chart_by_distance">Por distância</string>
     <string name="settings_chart_by_time">Por tempo</string>

--- a/src/main/res/values-pt/strings.xml
+++ b/src/main/res/values-pt/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Alimentação</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Não disponível durante a gravação de uma trilha</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Avançado</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-ro/strings.xml
+++ b/src/main/res/values-ro/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d Bpm</string>
     <string name="sensor_state_power">Putere</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Indisponibilă în timp ce înregistrați un traseu</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Avansate</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d уд/мин</string>
     <string name="sensor_state_power">Энергия</string>
     <string name="sensor_state_power_value">%1$d Вт</string>
-    <string name="settings_not_while_recording">Недоступно во время записи трека</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Расширенные</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-sk/strings.xml
+++ b/src/main/res/values-sk/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d úderov/min</string>
     <string name="sensor_state_power">Výkon</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Počas záznamu trasy nie je k dispozícii</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Rozšírené</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-sl/strings.xml
+++ b/src/main/res/values-sl/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Moč</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Ni na voljo med snemanjem poti</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Dodatno</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-sr/strings.xml
+++ b/src/main/res/values-sr/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d откуцаја у минуту</string>
     <string name="sensor_state_power">Снага</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Није доступно при снимању праћења</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Напредно</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-sv/strings.xml
+++ b/src/main/res/values-sv/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d BPM</string>
     <string name="sensor_state_power">Kraft</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Inte tillgängligt under inspelning av ett spår</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Avancerat</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-th/strings.xml
+++ b/src/main/res/values-th/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d ครั้งต่อนาที</string>
     <string name="sensor_state_power">กำลัง</string>
     <string name="sensor_state_power_value">%1$d วัตต์</string>
-    <string name="settings_not_while_recording">ไม่สามารถใช้งานได้ในขณะบันทึกเส้นการเดินทาง</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">ขั้นสูง</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-tl/strings.xml
+++ b/src/main/res/values-tl/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Power</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Hindi available habang inire-rekord ang isang track</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Advanced</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-tr/strings.xml
+++ b/src/main/res/values-tr/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Güç</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Parkur kaydı sırasında kullanılamaz</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Gelişmiş</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-uk/strings.xml
+++ b/src/main/res/values-uk/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d уд/хв</string>
     <string name="sensor_state_power">Потужність</string>
     <string name="sensor_state_power_value">%1$d В</string>
-    <string name="settings_not_while_recording">Недоступно під час записування шляху</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Розширені</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-vi/strings.xml
+++ b/src/main/res/values-vi/strings.xml
@@ -177,7 +177,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d nhịp đập/phút</string>
     <string name="sensor_state_power">Công suất</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">Không khả dụng khi đang ghi tuyến đường</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">Nâng cao</string>
     <!-- Settings Chart -->

--- a/src/main/res/values-zh-rHK/strings.xml
+++ b/src/main/res/values-zh-rHK/strings.xml
@@ -146,7 +146,6 @@
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">電源</string>
     <string name="sensor_state_power_value">%1$d 瓦</string>
-    <string name="settings_not_while_recording">記錄足跡時無法使用這個選項</string>
     <string name="settings_advanced">進階</string>
     <string name="settings_chart_by_distance">依距離</string>
     <string name="settings_chart_by_time">依時間</string>

--- a/src/main/res/values-zh-rTW/strings.xml
+++ b/src/main/res/values-zh-rTW/strings.xml
@@ -146,7 +146,6 @@
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">電源</string>
     <string name="sensor_state_power_value">%1$d 瓦</string>
-    <string name="settings_not_while_recording">記錄足跡時無法使用這個選項</string>
     <string name="settings_advanced">進階</string>
     <string name="settings_chart_by_distance">依距離</string>
     <string name="settings_chart_by_time">依時間</string>

--- a/src/main/res/values-zh/strings.xml
+++ b/src/main/res/values-zh/strings.xml
@@ -179,7 +179,6 @@ limitations under the License.
     <string name="sensor_state_heart_rate_value">%1$d BPM</string>
     <string name="sensor_state_power">功率</string>
     <string name="sensor_state_power_value">%1$d W</string>
-    <string name="settings_not_while_recording">记录路线时不可用</string>
     <!-- Settings Advanced -->
     <string name="settings_advanced">高级</string>
     <string name="settings_default_trackfileformat">导出文件格式</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -336,7 +336,6 @@ limitations under the License.
     <string name="sensor_state_power_value">%1$d W</string>
     <string name="sensor_could_not_scan">Could not scan for Bluetooth devices (error %1$i).</string>
     <string name="bluetooth_disabled">Please enable Bluetooth.</string>
-    <string name="settings_not_while_recording">Not available while recording a track</string>
 
     <string name="settings_open_tracks_title">Open Tracks</string>
     <string name="settings_open_tracks_summary">All About OpenTracks Project</string>


### PR DESCRIPTION
Nowadays, we should be able to reset the preferences while recording.
Also the import/export functionality should be working.

Only nitpick: the export all feature.
A currently recording track would only include the data that was already recorded.