### PR TITLE
Bugfixed: DistanceFormatter was using the wrong unitSystem. Fixes #1288.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/ui/intervals/IntervalsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/intervals/IntervalsFragment.java
@@ -107,16 +107,16 @@ public class IntervalsFragment extends Fragment {
         // TODO handle empty view: before we did viewBinding.intervalList.setEmptyView(viewBinding.intervalListEmptyView);
         viewBinding.intervalList.setAdapter(adapter);
 
-        final DistanceFormatter formatter = DistanceFormatter.Builder()
-                .setDecimalCount(0)
-                .setUnit(unitSystem)
-                .build(getContext());
-
         intervalsAdapter = new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item, IntervalStatisticsModel.IntervalOption.values()) {
             @NonNull
             @Override
             public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
                 TextView v = (TextView) super.getView(position, convertView, parent);
+
+                DistanceFormatter formatter = DistanceFormatter.Builder()
+                        .setDecimalCount(0)
+                        .setUnit(unitSystem)
+                        .build(getContext());
 
                 IntervalStatisticsModel.IntervalOption option = getItem(position);
                 String stringValue = formatter.formatDistance(option.getDistance(unitSystem));


### PR DESCRIPTION
**Describe the pull request**
For imperial setting, intervals dropdown did show metrics values instead of imperial ones.

**Link to the the issue**
#1288

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
