### PR TITLE
Prevent crash if no dashboard is installed.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/util/IntentDashboardUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/IntentDashboardUtils.java
@@ -1,11 +1,13 @@
 package de.dennisguse.opentracks.util;
 
+import android.content.ActivityNotFoundException;
 import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
 import android.util.Pair;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AlertDialog;
 
@@ -173,7 +175,12 @@ public class IntentDashboardUtils {
             Log.i(TAG, "Starting dashboard activity with generic intent (package=" + targetPackage + ", class=" + targetClass + ")");
         }
 
-        context.startActivity(intent);
+        try {
+            context.startActivity(intent);
+        } catch (ActivityNotFoundException e) {
+            Log.e(TAG, "Dashboard not installed; cannot start it.");
+            Toast.makeText(context, R.string.show_on_dashboard_not_installed, Toast.LENGTH_SHORT).show();
+        }
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -666,5 +666,6 @@ limitations under the License.
     <string name="select_show_on_map_behavior">Select \"show on map\" behavior</string>
     <string name="show_on_map_format_ask">Ask</string>
     <string name="show_on_dashboard">OpenTracks Dashboard API</string>
+    <string name="show_on_dashboard_not_installed">No application supporting OpenTracks Dashboard API installed.</string>
     <string name="always">Always</string>
 </resources>


### PR DESCRIPTION
Reported via PlayStore

```
android.content.ActivityNotFoundException: 
  at android.app.Instrumentation.checkStartActivityResult (Instrumentation.java:2100)
  at android.app.Instrumentation.execStartActivity (Instrumentation.java:1747)
  at android.app.Activity.startActivityForResult (Activity.java:5465)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.java:597)
  at android.app.Activity.startActivityForResult (Activity.java:5423)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.java:583)
  at android.app.Activity.startActivity (Activity.java:5809)
  at android.app.Activity.startActivity (Activity.java:5762)
  at de.dennisguse.opentracks.util.IntentDashboardUtils.startDashboard (IntentDashboardUtils.java:176)
  at de.dennisguse.opentracks.util.IntentDashboardUtils.onFormatSelected (IntentDashboardUtils.java:124)
  at de.dennisguse.opentracks.util.IntentDashboardUtils.lambda$showTrackOnMap$1 (IntentDashboardUtils.java:96)
  at de.dennisguse.opentracks.util.IntentDashboardUtils$$ExternalSyntheticLambda1.onClick (Unknown Source:12)
  at androidx.appcompat.app.AlertController$ButtonHandler.handleMessage (AlertController.java:167)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8633)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:567)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1133)
```