### PR TITLE
PlayStore: use an inverted icon (app launcher only).

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,7 @@ android {
         releasePlayStore {
             applicationIdSuffix ".playstore"
             versionNameSuffix "-PlayStore"
+            signingConfig signingConfigs.debug
         }
     }
 

--- a/src/releasePlayStore/res/drawable-v26/ic_launcher.xml
+++ b/src/releasePlayStore/res/drawable-v26/ic_launcher.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground>
+        <inset
+            android:inset="20dp"
+            android:drawable="@drawable/ic_logo_24dp" />
+    </foreground>
+    <monochrome>
+        <inset
+            android:inset="20dp"
+            android:drawable="@drawable/ic_logo_24dp" />
+    </monochrome>
+</adaptive-icon>

--- a/src/releasePlayStore/res/drawable/ic_launcher.xml
+++ b/src/releasePlayStore/res/drawable/ic_launcher.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_logo_24dp" />

--- a/src/releasePlayStore/res/values-v26/ic_launcher_background.xml
+++ b/src/releasePlayStore/res/values-v26/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#FFFF6D00</color>
+</resources>


### PR DESCRIPTION
Part of #1329.

If I didn't do anything completely wrong, buildTypes only allow us to modify _some_ resources (like app_icon).
So, to replace the internally used app_icon, we would need to use buildFlavors as well.

https://developer.android.com/studio/build/build-variants#groovy