### PR TITLE
Voice announcements: "speed" -> "average moving speed" (en only).

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
@@ -64,7 +64,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 20.00 kilometers. 1 hour 5 minutes 10 seconds. Speed 18.4 kilometers per hour.", announcement);
+        assertEquals("Total distance 20.00 kilometers. 1 hour 5 minutes 10 seconds. Average moving speed 18.4 kilometers per hour.", announcement);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 20.00 kilometers. 1 hour 1 second. Speed 20.0 kilometers per hour.", announcement);
+        assertEquals("Total distance 20.00 kilometers. 1 hour 1 second. Average moving speed 20.0 kilometers per hour.", announcement);
     }
 
     @Test
@@ -96,7 +96,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 20.00 kilometers. 1 hour. Speed 20.0 kilometers per hour.", announcement);
+        assertEquals("Total distance 20.00 kilometers. 1 hour. Average moving speed 20.0 kilometers per hour.", announcement);
     }
 
     @Test
@@ -112,7 +112,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 19.99 kilometers. 1 hour. Speed 20.0 kilometers per hour.", announcement);
+        assertEquals("Total distance 19.99 kilometers. 1 hour. Average moving speed 20.0 kilometers per hour.", announcement);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, lastInterval, null).toString();
 
         // then
-        assertEquals("Total distance 14.21 kilometers. 16 minutes 39 seconds. Speed 51.2 kilometers per hour. Lap speed 51.2 kilometers per hour.", announcement);
+        assertEquals("Total distance 14.21 kilometers. 16 minutes 39 seconds. Average moving speed 51.2 kilometers per hour. Lap speed 51.2 kilometers per hour.", announcement);
     }
 
     @Test
@@ -188,7 +188,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.IMPERIAL, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 12.43 miles. 1 hour 5 minutes 10 seconds. Speed 11.4 miles per hour.", announcement);
+        assertEquals("Total distance 12.43 miles. 1 hour 5 minutes 10 seconds. Average moving speed 11.4 miles per hour.", announcement);
     }
 
     @Test
@@ -210,7 +210,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.IMPERIAL, true, lastInterval, null).toString();
 
         // then
-        assertEquals("Total distance 8.83 miles. 16 minutes 39 seconds. Speed 31.8 miles per hour. Lap speed 31.8 miles per hour.", announcement);
+        assertEquals("Total distance 8.83 miles. 16 minutes 39 seconds. Average moving speed 31.8 miles per hour. Lap speed 31.8 miles per hour.", announcement);
     }
 
     @Test
@@ -274,7 +274,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, lastInterval, sensorStatistics).toString();
 
         // then
-        assertEquals("Total distance 14.21 kilometers. 16 minutes 39 seconds. Speed 51.2 kilometers per hour. Lap speed 51.2 kilometers per hour. Average heart rate 180 bpm. Current heart rate 133 bpm.", announcement);
+        assertEquals("Total distance 14.21 kilometers. 16 minutes 39 seconds. Average moving speed 51.2 kilometers per hour. Lap speed 51.2 kilometers per hour. Average heart rate 180 bpm. Current heart rate 133 bpm.", announcement);
     }
 
     @Test

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -33,8 +33,8 @@ class VoiceAnnouncementUtils {
 
     static Spannable getAnnouncement(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem, boolean isReportSpeed, @Nullable IntervalStatistics.Interval currentInterval, @Nullable SensorStatistics sensorStatistics) {
         SpannableStringBuilder builder = new SpannableStringBuilder();
-        Distance distance = trackStatistics.getTotalDistance();
-        Speed distancePerTime = trackStatistics.getAverageMovingSpeed();
+        Distance totalDistance = trackStatistics.getTotalDistance();
+        Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
         Speed currentDistancePerTime = currentInterval != null ? currentInterval.getSpeed() : null;
 
         int perUnitStringId;
@@ -68,7 +68,7 @@ class VoiceAnnouncementUtils {
                 throw new RuntimeException("Not implemented");
         }
 
-        double distanceInUnit = distance.toKM_Miles(unitSystem);
+        double distanceInUnit = totalDistance.toKM_Miles(unitSystem);
 
         if (shouldVoiceAnnounceTotalDistance()) {
             builder.append(context.getString(R.string.total_distance));
@@ -78,7 +78,7 @@ class VoiceAnnouncementUtils {
             // Punctuation helps introduce natural pauses in TTS
             builder.append(".");
         }
-        if (distance.isZero()) {
+        if (totalDistance.isZero()) {
             return builder;
         }
 
@@ -91,7 +91,7 @@ class VoiceAnnouncementUtils {
 
         if (isReportSpeed) {
             if (shouldVoiceAnnounceAverageSpeedPace()) {
-                double speedInUnit = distancePerTime.to(unitSystem);
+                double speedInUnit = averageMovingSpeed.to(unitSystem);
                 builder.append(" ")
                         .append(context.getString(R.string.speed));
                 appendDecimalUnit(builder, context.getResources().getQuantityString(speedId, getQuantityCount(speedInUnit), speedInUnit), speedInUnit, 1, unitSpeedTTS);
@@ -108,7 +108,7 @@ class VoiceAnnouncementUtils {
             }
         } else {
             if (shouldVoiceAnnounceAverageSpeedPace()) {
-                Duration time = distancePerTime.toPace(unitSystem);
+                Duration time = averageMovingSpeed.toPace(unitSystem);
                 builder.append(" ")
                         .append(context.getString(R.string.pace));
                 appendDuration(context, builder, time);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -577,7 +577,7 @@ limitations under the License.
     <string name="lap_time">Lap time</string>
     <string name="pace">Pace</string>
     <string name="lap_speed">Lap speed</string>
-    <string name="speed">Speed</string>
+    <string name="speed">Average moving speed</string>
     <string name="total_distance">Total distance</string>
     <plurals name="voiceDistanceKilometers">
         <item quantity="one">1 kilometer</item>


### PR DESCRIPTION
And report distance only with one decimal unit.
Fixes #1346.