### PR TITLE
Check if the device has GPS

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/handlers/GPSHandler.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/GPSHandler.java
@@ -10,6 +10,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.location.LocationManagerCompat;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -152,6 +153,12 @@ public class GPSHandler implements LocationListener, GpsStatus.GpsStatusListener
             Log.e(TAG, "Not started.");
             return;
         }
+
+        if(!LocationManagerCompat.hasProvider(locationManager, LocationManager.GPS_PROVIDER)) {
+            Log.e(TAG, "Device doesn't have GPS.");
+            return;
+        }
+
         if (PermissionRequester.GPS.hasPermission(context)) {
             try {
                 locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, gpsInterval.toMillis(), 0, this);


### PR DESCRIPTION
Fixes #1380

Just a simple check to avoid a crash. The user won't get notified though. I'm just assuming the user knows that their device doesn't have this feature.

API level 31 (Android 12) has the nicer method [hasProvider()](https://developer.android.com/reference/android/location/LocationManager#hasProvider(java.lang.String)), but my check does basically the same.
