### PR TITLE
Voice announcements: distance only with one decimal unit.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 android.useAndroidX=true
+org.gradle.jvmargs=-Xmx1024m -XX:MaxPermSize=256m

--- a/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtilsTest.java
@@ -64,7 +64,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 20.00 kilometers. 1 hour 5 minutes 10 seconds. Average moving speed 18.4 kilometers per hour.", announcement);
+        assertEquals("Total distance 20.0 kilometers. 1 hour 5 minutes 10 seconds. Average moving speed 18.4 kilometers per hour.", announcement);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 20.00 kilometers. 1 hour 1 second. Average moving speed 20.0 kilometers per hour.", announcement);
+        assertEquals("Total distance 20.0 kilometers. 1 hour 1 second. Average moving speed 20.0 kilometers per hour.", announcement);
     }
 
     @Test
@@ -96,13 +96,13 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 20.00 kilometers. 1 hour. Average moving speed 20.0 kilometers per hour.", announcement);
+        assertEquals("Total distance 20.0 kilometers. 1 hour. Average moving speed 20.0 kilometers per hour.", announcement);
     }
 
     @Test
     public void getAnnouncement_metric_distance_rounding_check_two() {
         TrackStatistics stats = new TrackStatistics();
-        stats.setTotalDistance(Distance.of(19990));
+        stats.setTotalDistance(Distance.of(19900));
         stats.setTotalTime(Duration.ofHours(1).plusMinutes(5).plusSeconds(10));
         stats.setMovingTime(Duration.ofHours(1));
         stats.setMaxSpeed(Speed.of(100));
@@ -112,7 +112,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 19.99 kilometers. 1 hour. Average moving speed 20.0 kilometers per hour.", announcement);
+        assertEquals("Total distance 19.9 kilometers. 1 hour. Average moving speed 19.9 kilometers per hour.", announcement);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, lastInterval, null).toString();
 
         // then
-        assertEquals("Total distance 14.21 kilometers. 16 minutes 39 seconds. Average moving speed 51.2 kilometers per hour. Lap speed 51.2 kilometers per hour.", announcement);
+        assertEquals("Total distance 14.2 kilometers. 16 minutes 39 seconds. Average moving speed 51.2 kilometers per hour. Lap speed 51.2 kilometers per hour.", announcement);
     }
 
     @Test
@@ -150,7 +150,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, false, null, null).toString();
 
         // then
-        assertEquals("Total distance 20.00 kilometers. 1 hour 5 minutes 10 seconds. Pace 3 minutes 15 seconds per kilometer.", announcement);
+        assertEquals("Total distance 20.0 kilometers. 1 hour 5 minutes 10 seconds. Pace 3 minutes 15 seconds per kilometer.", announcement);
     }
 
     @Test
@@ -172,7 +172,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, false, lastInterval, null).toString();
 
         // then
-        assertEquals("Total distance 14.21 kilometers. 16 minutes 39 seconds. Pace 1 minute 10 seconds per kilometer. Lap time 1 minute 10 seconds per kilometer.", announcement);
+        assertEquals("Total distance 14.2 kilometers. 16 minutes 39 seconds. Pace 1 minute 10 seconds per kilometer. Lap time 1 minute 10 seconds per kilometer.", announcement);
     }
 
     @Test
@@ -188,7 +188,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.IMPERIAL, true, null, null).toString();
 
         // then
-        assertEquals("Total distance 12.43 miles. 1 hour 5 minutes 10 seconds. Average moving speed 11.4 miles per hour.", announcement);
+        assertEquals("Total distance 12.4 miles. 1 hour 5 minutes 10 seconds. Average moving speed 11.4 miles per hour.", announcement);
     }
 
     @Test
@@ -210,7 +210,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.IMPERIAL, true, lastInterval, null).toString();
 
         // then
-        assertEquals("Total distance 8.83 miles. 16 minutes 39 seconds. Average moving speed 31.8 miles per hour. Lap speed 31.8 miles per hour.", announcement);
+        assertEquals("Total distance 8.8 miles. 16 minutes 39 seconds. Average moving speed 31.8 miles per hour. Lap speed 31.8 miles per hour.", announcement);
     }
 
     @Test
@@ -226,7 +226,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.IMPERIAL, false, null, null).toString();
 
         // then
-        assertEquals("Total distance 12.43 miles. 1 hour 5 minutes 10 seconds. Pace 5 minutes 15 seconds per mile.", announcement);
+        assertEquals("Total distance 12.4 miles. 1 hour 5 minutes 10 seconds. Pace 5 minutes 15 seconds per mile.", announcement);
     }
 
     @Test
@@ -248,7 +248,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.IMPERIAL, false, lastInterval, null).toString();
 
         // then
-        assertEquals("Total distance 8.83 miles. 16 minutes 39 seconds. Pace 1 minute 53 seconds per mile. Lap time 1 minute 53 seconds per mile.", announcement);
+        assertEquals("Total distance 8.8 miles. 16 minutes 39 seconds. Pace 1 minute 53 seconds per mile. Lap time 1 minute 53 seconds per mile.", announcement);
     }
 
     @Test
@@ -274,7 +274,7 @@ public class VoiceAnnouncementUtilsTest {
         String announcement = VoiceAnnouncementUtils.getAnnouncement(context, stats, UnitSystem.METRIC, true, lastInterval, sensorStatistics).toString();
 
         // then
-        assertEquals("Total distance 14.21 kilometers. 16 minutes 39 seconds. Average moving speed 51.2 kilometers per hour. Lap speed 51.2 kilometers per hour. Average heart rate 180 bpm. Current heart rate 133 bpm.", announcement);
+        assertEquals("Total distance 14.2 kilometers. 16 minutes 39 seconds. Average moving speed 51.2 kilometers per hour. Lap speed 51.2 kilometers per hour. Average heart rate 180 bpm. Current heart rate 133 bpm.", announcement);
     }
 
     @Test

--- a/src/androidTest/java/de/dennisguse/opentracks/ui/aggregatedStatistics/EspressoAggregatedFilterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/ui/aggregatedStatistics/EspressoAggregatedFilterTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.Matchers.allOf;
 import static de.dennisguse.opentracks.util.EspressoUtils.waitFor;
 
 import android.util.Pair;
-import android.view.View;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.ViewInteraction;
@@ -72,7 +71,7 @@ public class EspressoAggregatedFilterTest {
         ViewInteraction checkBox = onView(
                 allOf(withId(R.id.filter_dialog_check_button), withText(CATEGORY),
                         withParent(allOf(withId(R.id.filter_items),
-                                withParent(IsInstanceOf.<View>instanceOf(android.view.ViewGroup.class)))),
+                                withParent(IsInstanceOf.instanceOf(android.view.ViewGroup.class)))),
                         isDisplayed()));
         checkBox.perform(waitFor(2000));
 

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -38,7 +38,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
-import androidx.core.splashscreen.SplashScreen;
 import androidx.cursoradapter.widget.ResourceCursorAdapter;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.CursorLoader;

--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -27,7 +27,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
-import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/TrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/TrackImporter.java
@@ -25,7 +25,6 @@ import de.dennisguse.opentracks.data.models.Marker;
 import de.dennisguse.opentracks.data.models.Speed;
 import de.dennisguse.opentracks.data.models.Track;
 import de.dennisguse.opentracks.data.models.TrackPoint;
-import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 import de.dennisguse.opentracks.stats.TrackStatisticsUpdater;
 import de.dennisguse.opentracks.ui.markers.MarkerUtils;

--- a/src/main/java/de/dennisguse/opentracks/services/TrackDeleteService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackDeleteService.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Executors;
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.ContentProviderUtils;
 import de.dennisguse.opentracks.data.models.Track;
-import de.dennisguse.opentracks.settings.PreferencesUtils;
 
 public class TrackDeleteService extends Service {
 

--- a/src/main/res/drawable/ic_baseline_delete_24.xml
+++ b/src/main/res/drawable/ic_baseline_delete_24.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
-</vector>

--- a/src/main/res/values-b+es+419/strings.xml
+++ b/src/main/res/values-b+es+419/strings.xml
@@ -511,11 +511,11 @@
     <string name="total_distance">Distancia total</string>
     <plurals name="voiceDistanceKilometers">
         <item quantity="one">1 kilómetro</item>
-        <item quantity="other">%1$.2f kilómetros</item>
+        <item quantity="other">%1$.1f kilómetros</item>
     </plurals>
     <plurals name="voiceDistanceMiles">
         <item quantity="one">1 milla</item>
-        <item quantity="other">%1$.2f millas</item>
+        <item quantity="other">%1$.1f millas</item>
     </plurals>
     <string name="average_heart_rate">Ritmo cardíaco promedio</string>
     <string name="current_heart_rate">Ritmo cardíaco actual</string>

--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -550,11 +550,6 @@ limitations under the License.
     <string name="lap_speed">Rychlost kola</string>
     <string name="speed">Rychlost</string>
     <string name="total_distance">Celková vzdálenost</string>
-    <plurals name="voiceDistanceKilometers">
-        <item quantity="one"/>
-        <item quantity="few"/>
-        <item quantity="other"/>
-    </plurals>
     <string name="average_heart_rate">Průměrný srdeční tep</string>
     <string name="current_heart_rate">Aktuální srdeční tep</string>
     <string name="settings_public_api_enabled_summary_on">Ostatní nainstalované aplikace mohou nahrávání spustit nebo zastavit.</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -540,7 +540,7 @@ Meldet das GPS-Gerät ungenaue Daten (z.B. Standort, Geschwindigkeit, Höhe), ka
     <string name="stats_sensors_cadence">Trittfrequenz</string>
     <plurals name="voiceDistanceMiles">
         <item quantity="one">1 Meile</item>
-        <item quantity="other">%1$.2f Meilen</item>
+        <item quantity="other">%1$.1f Meilen</item>
     </plurals>
     <string name="field_set_primary">Primär</string>
     <string name="voice_per_mile">pro Meile</string>
@@ -552,7 +552,7 @@ Meldet das GPS-Gerät ungenaue Daten (z.B. Standort, Geschwindigkeit, Höhe), ka
     <string name="total_distance">Gesamtstrecke</string>
     <plurals name="voiceDistanceKilometers">
         <item quantity="one">1 Kilometer</item>
-        <item quantity="other">%1$.2f Kilometer</item>
+        <item quantity="other">%1$.1f Kilometer</item>
     </plurals>
     <string name="no_compatible_file_manager_installed">Kein kompatibler Dateimanager installiert</string>
     <string name="aggregated_stats_filter_no_results">Es gibt keine Aktivitäten für diesen Filter</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -562,11 +562,11 @@ limitations under the License.
     <string name="total_distance">Distancia total</string>
     <plurals name="voiceDistanceKilometers">
         <item quantity="one">1 kilómetro</item>
-        <item quantity="other">%1$.2f kilómetros</item>
+        <item quantity="other">%1$.1f kilómetros</item>
     </plurals>
     <plurals name="voiceDistanceMiles">
         <item quantity="one">1 milla</item>
-        <item quantity="other">%1$.2f millas</item>
+        <item quantity="other">%1$.1f millas</item>
     </plurals>
     <string name="average_heart_rate">Ritmo cardíaco promedio</string>
     <string name="current_heart_rate">Ritmo cardíaco actual</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -545,8 +545,8 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
     <string name="average_heart_rate">Fréquence cardiaque moyenne</string>
     <string name="current_heart_rate">Fréquence cardiaque actuelle</string>
     <plurals name="voiceDistanceMiles">
-        <item quantity="one">%1$.2f mile</item>
-        <item quantity="other">%1$.2f miles</item>
+        <item quantity="one">%1$.1f mile</item>
+        <item quantity="other">%1$.1f miles</item>
     </plurals>
     <string name="lap_time">Temps par tour</string>
     <string name="speed">Vitesse</string>
@@ -554,8 +554,8 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
     <string name="settings_public_api_enabled_summary_on">D\'autres applications installées peuvent démarrer ou arrêter les enregistrements.</string>
     <string name="settings_public_api_enabled_summary_off">Seul OpenTracks peut démarrer et arrêter les enregistrements.</string>
     <plurals name="voiceDistanceKilometers">
-        <item quantity="one">%1$.2f kilomètre</item>
-        <item quantity="other">%1$.2f kilomètres</item>
+        <item quantity="one">%1$.1f kilomètre</item>
+        <item quantity="other">%1$.1f kilomètres</item>
     </plurals>
     <string name="total_distance">Distance totale</string>
     <string name="activity_type_swimming">natation</string>
@@ -602,8 +602,8 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
         <item quantity="other">%1$.1f nœuds</item>
     </plurals>
     <plurals name="voiceDistanceNauticalMiles">
-        <item quantity="one">%1$.2f mile nautique</item>
-        <item quantity="other">%1$.2f milles nautique</item>
+        <item quantity="one">%1$.1f mile nautique</item>
+        <item quantity="other">%1$.1f milles nautique</item>
     </plurals>
     <string name="settings_public_api_package_title">Nom du paquet pour l\'API Publique</string>
     <string name="track_delete_number_of_tracks">%1$d parcours</string>

--- a/src/main/res/values-gl/strings.xml
+++ b/src/main/res/values-gl/strings.xml
@@ -552,7 +552,7 @@ Se o GPS informa sobre datos pouco precisos (ex.: localización, velocidade, ele
     <string name="total_distance">Distancia total</string>
     <plurals name="voiceDistanceMiles">
         <item quantity="one">1 milla</item>
-        <item quantity="other">%1$.2f millas</item>
+        <item quantity="other">%1$.1f millas</item>
     </plurals>
     <string name="settings_public_api_enabled_summary_on">Outras aplicacións instaladas poden iniciar ou deter gravacións.</string>
     <string name="settings_public_api_enabled_summary_off">Só OpenTracks pode iniciar e deter as gravacións.</string>
@@ -565,7 +565,7 @@ Se o GPS informa sobre datos pouco precisos (ex.: localización, velocidade, ele
     <string name="speed">Vel. media en movemento</string>
     <plurals name="voiceDistanceKilometers">
         <item quantity="one">1 quilómetro</item>
-        <item quantity="other">%1$.2f quilómetros</item>
+        <item quantity="other">%1$.1f quilómetros</item>
     </plurals>
     <string name="average_heart_rate">Pulso medio</string>
     <string name="current_heart_rate">Pulso actual</string>
@@ -595,7 +595,7 @@ Se o GPS informa sobre datos pouco precisos (ex.: localización, velocidade, ele
     <string name="voice_per_nautical_mile">por milla náutica</string>
     <plurals name="voiceDistanceNauticalMiles">
         <item quantity="one">1 milla náutica</item>
-        <item quantity="other">%1$.2f millas náuticas</item>
+        <item quantity="other">%1$.1f millas náuticas</item>
     </plurals>
     <string name="show_on_dashboard">Usar API OpenTracks</string>
     <plurals name="voiceSpeedMKnots">

--- a/src/main/res/values-nb/strings.xml
+++ b/src/main/res/values-nb/strings.xml
@@ -558,12 +558,12 @@ limitations under the License.
     <string name="total_distance">Total distanse</string>
     <plurals name="voiceDistanceMiles">
         <item quantity="one">1 engelsk mil</item>
-        <item quantity="other">%1$.2f engelske mil</item>
+        <item quantity="other">%1$.1f engelske mil</item>
     </plurals>
     <string name="average_heart_rate">Gjennomsnittlig puls</string>
     <plurals name="voiceDistanceKilometers">
         <item quantity="one">1 kilometer</item>
-        <item quantity="other">%1$.2f kilometer</item>
+        <item quantity="other">%1$.1f kilometer</item>
     </plurals>
     <string name="current_heart_rate">Gjeldende puls</string>
     <string name="settings_export_filename_title">Format på filnavnet</string>
@@ -596,7 +596,7 @@ limitations under the License.
     </plurals>
     <plurals name="voiceDistanceNauticalMiles">
         <item quantity="one">1 nautisk mil</item>
-        <item quantity="other">%1$.2f nautiske mil</item>
+        <item quantity="other">%1$.1f nautiske mil</item>
     </plurals>
     <string name="show_on_dashboard_not_installed">Ingen app som støtter OpenTracks Dashboard API er installert.</string>
     <string name="track_delete_number_of_tracks">%1$d spor</string>

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -512,11 +512,11 @@ Als het GPS-apparaat onnauwkeurige gegevens rapporteert (bijv. locatie, snelheid
     <string name="total_distance">Totale afstand</string>
     <plurals name="voiceDistanceKilometers">
         <item quantity="one">1 kilometer</item>
-        <item quantity="other">%1$.2f kilometers</item>
+        <item quantity="other">%1$.1f kilometers</item>
     </plurals>
     <plurals name="voiceDistanceMiles">
         <item quantity="one">1 mijl</item>
-        <item quantity="other">%1$.2f mijlen</item>
+        <item quantity="other">%1$.1f mijlen</item>
     </plurals>
     <string name="average_heart_rate">Gemiddelde hartslag</string>
     <string name="current_heart_rate">Actuele hartslag</string>

--- a/src/main/res/values-pt-rBR/strings.xml
+++ b/src/main/res/values-pt-rBR/strings.xml
@@ -503,8 +503,8 @@
     <string name="settings_public_api_dashboard_enabled_summary_on">Um aplicativo que iniciou uma gravação também pode acessar os dados gravados.</string>
     <string name="settings_public_api_dashboard_enabled_summary_off">Os dados gravados não serão compartilhados automaticamente com outros aplicativos.</string>
     <plurals name="voiceDistanceKilometers">
-        <item quantity="one">%1$.2f quilômetro</item>
-        <item quantity="other">%1$.2f quilômetros</item>
+        <item quantity="one">%1$.1f quilômetro</item>
+        <item quantity="other">%1$.1f quilômetros</item>
     </plurals>
     <string name="generic_dismiss">Dispensar</string>
     <string name="settings_api_title">API pública</string>
@@ -514,8 +514,8 @@
     <string name="lap_speed">Velocidade da volta</string>
     <string name="total_distance">Distância total</string>
     <plurals name="voiceDistanceMiles">
-        <item quantity="one">%1$.2f milha</item>
-        <item quantity="other">%1$.2f milhas</item>
+        <item quantity="one">%1$.1f milha</item>
+        <item quantity="other">%1$.1f milhas</item>
     </plurals>
     <string name="current_heart_rate">Frequência cardíaca atual</string>
     <string name="settings_export_filename_title">Formato do nome do arquivo</string>
@@ -548,12 +548,10 @@
     <string name="description_speed_nautical">Velocidade (nós)</string>
     <plurals name="voiceSpeedMKnots">
         <item quantity="one">%1$.1f nó</item>
-        <item quantity="many">%1$.1f nós</item>
         <item quantity="other">%1$.1f nós</item>
     </plurals>
     <plurals name="voiceDistanceNauticalMiles">
-        <item quantity="one">%1$.2f milha náutica</item>
-        <item quantity="many">%1$.2f milhas náuticas</item>
-        <item quantity="other">%1$.2f milhas náuticas</item>
+        <item quantity="one">%1$.1f milha náutica</item>
+        <item quantity="other">%1$.1f milhas náuticas</item>
     </plurals>
 </resources>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -515,10 +515,10 @@ limitations under the License.
     <string name="aggregated_stats_filter_no_results">Нет активностей для данного фильтра</string>
     <string name="custom_layout_list_edit_already_exists">Имя раскладки уже существует</string>
     <plurals name="voiceDistanceKilometers">
-        <item quantity="one">%1$.2f километр</item>
-        <item quantity="few">%1$.2f километра</item>
-        <item quantity="many">%1$.2f километров</item>
-        <item quantity="other">%1$.2f километров</item>
+        <item quantity="one">%1$.1f километр</item>
+        <item quantity="few">%1$.1f километра</item>
+        <item quantity="many">%1$.1f километров</item>
+        <item quantity="other">%1$.1f километров</item>
     </plurals>
     <string name="settings_layout_reset">Сбросить свои раскладки</string>
     <string name="settings_layout_reset_done">Настройки всех раскладок были сброшены</string>
@@ -546,10 +546,10 @@ limitations under the License.
     <string name="speed">Скорость</string>
     <string name="total_distance">Общая дистанция</string>
     <plurals name="voiceDistanceMiles">
-        <item quantity="one">%1$.2f миля</item>
-        <item quantity="few">%1$.2f миля</item>
-        <item quantity="many">%1$.2f миль</item>
-        <item quantity="other">%1$.2f миль</item>
+        <item quantity="one">%1$.1f миля</item>
+        <item quantity="few">%1$.1f миля</item>
+        <item quantity="many">%1$.1f миль</item>
+        <item quantity="other">%1$.1f миль</item>
     </plurals>
     <string name="average_heart_rate">Средний пульс</string>
     <string name="current_heart_rate">Текущий пульс</string>
@@ -594,10 +594,10 @@ limitations under the License.
     </plurals>
     <string name="unit_knots">уз</string>
     <plurals name="voiceDistanceNauticalMiles">
-        <item quantity="one">%1$.2f морская миля</item>
-        <item quantity="few">%1$.2f морские мили</item>
-        <item quantity="many">%1$.2f морских миль</item>
-        <item quantity="other">%1$.2f морских миль</item>
+        <item quantity="one">%1$.1f морская миля</item>
+        <item quantity="few">%1$.1f морские мили</item>
+        <item quantity="many">%1$.1f морских миль</item>
+        <item quantity="other">%1$.1f морских миль</item>
     </plurals>
     <string name="value_integer_knots">%1$d узлов</string>
     <string name="value_float_knots">%1$.1f узла</string>

--- a/src/main/res/values-tr/strings.xml
+++ b/src/main/res/values-tr/strings.xml
@@ -526,7 +526,7 @@ limitations under the License.
     <string name="total_distance">Toplam mesafe</string>
     <plurals name="voiceDistanceKilometers">
         <item quantity="one">1 kilometre</item>
-        <item quantity="other">%1$.2f kilometre</item>
+        <item quantity="other">%1$.1f kilometre</item>
     </plurals>
     <string name="instant_export_enabled_summary">Kayıt tamamlandıktan sonra parçayı depolamaya aktar</string>
     <string name="value_float_mile_hour">%1$.1f mi/s</string>
@@ -545,7 +545,7 @@ limitations under the License.
     <string name="speed">Hız</string>
     <plurals name="voiceDistanceMiles">
         <item quantity="one">1 mil</item>
-        <item quantity="other">%1$.2f mil</item>
+        <item quantity="other">%1$.1f mil</item>
     </plurals>
     <string name="settings_recording_fullscreen_on_while_recording_title">Tam ekran</string>
     <string name="current_heart_rate">Şu anki kalp atış hızı</string>
@@ -587,7 +587,7 @@ limitations under the License.
     <string name="voice_per_nautical_mile">deniz mili başına</string>
     <plurals name="voiceDistanceNauticalMiles">
         <item quantity="one">1 deniz mili</item>
-        <item quantity="other">%1$.2f deniz mili</item>
+        <item quantity="other">%1$.1f deniz mili</item>
     </plurals>
     <string name="image_discard"/>
     <string name="settings_public_api_package_title">Genel API için paket adı</string>

--- a/src/main/res/values-vi/strings.xml
+++ b/src/main/res/values-vi/strings.xml
@@ -548,10 +548,10 @@ limitations under the License.
     <string name="lap_speed">Vòng tốc độ</string>
     <string name="speed">Tốc độ di chuyển trung bình</string>
     <plurals name="voiceDistanceKilometers">
-        <item quantity="other">%1$.2f Tầng km</item>
+        <item quantity="other">%1$.1f Tầng km</item>
     </plurals>
     <plurals name="voiceDistanceMiles">
-        <item quantity="other">%1$.2f dặm</item>
+        <item quantity="other">%1$.1f dặm</item>
     </plurals>
     <string name="average_heart_rate">Nhịp tim trung bình</string>
     <string name="current_heart_rate">Hiện tại nhịp tim</string>
@@ -568,7 +568,7 @@ limitations under the License.
     <string name="settings_stats_units_nautical">Hải lý (dặm hải lý, ft)</string>
     <string name="settings_public_api_package_title">Tên gói cho API công khai</string>
     <plurals name="voiceDistanceNauticalMiles">
-        <item quantity="other">%1$.2f dặm hải lý</item>
+        <item quantity="other">%1$.1f dặm hải lý</item>
     </plurals>
     <string name="select_show_on_map_behavior">Chọn hành vi \"hiện trên bản đồ\"</string>
     <string name="settings_announcements_lap_speed_pace">Tốc độ vòng/nhịp độ</string>

--- a/src/main/res/values-zh/strings.xml
+++ b/src/main/res/values-zh/strings.xml
@@ -490,10 +490,10 @@ limitations under the License.
     <string name="value_float_mile_hour_recommended">%1$.1f 英里/小时（推荐）</string>
     <string name="lap_time">单圈用时</string>
     <plurals name="voiceDistanceKilometers">
-        <item quantity="other">%1$.2f 公里</item>
+        <item quantity="other">%1$.1f 公里</item>
     </plurals>
     <plurals name="voiceDistanceMiles">
-        <item quantity="other">%1$.2f 英里</item>
+        <item quantity="other">%1$.1f 英里</item>
     </plurals>
     <string name="average_heart_rate">平均心率</string>
     <string name="export_without_photos">不带照片</string>
@@ -503,7 +503,7 @@ limitations under the License.
     </plurals>
     <string name="voice_per_nautical_mile">每海里</string>
     <plurals name="voiceDistanceNauticalMiles">
-        <item quantity="other">%1$.2f 海里</item>
+        <item quantity="other">%1$.1f 海里</item>
     </plurals>
     <string name="share_image_subject">我想跟你分享一张图片</string>
     <string name="share_image_body">我觉得你可能对这张图片感兴趣。</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -581,15 +581,15 @@ limitations under the License.
     <string name="total_distance">Total distance</string>
     <plurals name="voiceDistanceKilometers">
         <item quantity="one">1 kilometer</item>
-        <item quantity="other">%1$.2f kilometers</item>
+        <item quantity="other">%1$.1f kilometers</item>
     </plurals>
     <plurals name="voiceDistanceMiles">
         <item quantity="one">1 mile</item>
-        <item quantity="other">%1$.2f miles</item>
+        <item quantity="other">%1$.1f miles</item>
     </plurals>
     <plurals name="voiceDistanceNauticalMiles">
         <item quantity="one">1 nautical mile</item>
-        <item quantity="other">%1$.2f nautical miles</item>
+        <item quantity="other">%1$.1f nautical miles</item>
     </plurals>
     <string name="average_heart_rate">Average heart rate</string>
     <string name="current_heart_rate">Current heart rate</string>


### PR DESCRIPTION
... before it was 2 decimal units.
Leading situations like `5.01 km` or `10.02 km`.

The 2nd decimal unit is not useful (at least not too me) and it suggests a precision that is not there.
