### PR TITLE
Fixed bad string for an answer in the FAQ

### DIFF
--- a/src/main/res/layout/help.xml
+++ b/src/main/res/layout/help.xml
@@ -89,13 +89,14 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     style="?attr/textAppearanceHeadline6"
+                    android:layout_marginTop="20dp"
                     android:text="@string/help_data_google_play_services_title" />
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     style="?attr/textAppearanceBody1"
-                    android:text="@android:string/no" />
+                    android:text="@string/help_data_google_play_services_content" />
 
                 <TextView
                     android:layout_width="match_parent"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@ limitations under the License.
     </string>
 
     <string name="help_data_google_play_services_title">Does OpenTracks require/use Google Play Service?</string>
+    <string name="help_data_google_play_services_content">No</string>
 
     <string name="help_recording_title">How does OpenTracks record data?</string>
     <string name="help_recording_content">


### PR DESCRIPTION
The question "Does OpenTracks require/use Google Play Service?" used "@android:string/no" as answer. But actually the value of this string is "Cancel". So i add new string.