### PR TITLE
Handle LocationManager callbacks with TrackRecordingService's handler.

### DIFF
--- a/.github/workflows/test.yml.disabled
+++ b/.github/workflows/test.yml.disabled
@@ -1,3 +1,6 @@
+# We have flaky test results due to performance limitations in Github Actions.
+# Happens too often nowadays; See https://github.com/OpenTracksApp/OpenTracks/issues/1409
+
 #https://github.com/marketplace/actions/android-emulator-runner
 name: Test
 on:

--- a/src/androidTest/java/de/dennisguse/opentracks/services/handlers/GPSHandlerTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/handlers/GPSHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 
 import android.content.Context;
 import android.location.Location;
+import android.os.Handler;
 import android.os.Looper;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -49,7 +50,7 @@ public class GPSHandlerTest {
         Mockito.when(trackPointCreator.createNow())
                 .thenReturn(Instant.now());
 
-        locationHandler.onStart(context);
+        locationHandler.onStart(context, new Handler());
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
@@ -52,7 +52,7 @@ public class TrackPointCreator implements BluetoothRemoteSensorManager.SensorDat
     public synchronized void start(@NonNull Context context, @NonNull Handler handler) {
         this.context = context;
 
-        gpsHandler.onStart(context);
+        gpsHandler.onStart(context, handler);
 
         remoteSensorManager = new BluetoothRemoteSensorManager(context, handler, this);
         altitudeSumManager = new AltitudeSumManager();


### PR DESCRIPTION
Fixes #1328.

This should fix the race condition while shutting down TrackRecordingService and getting GPS data in parallel.