### PR TITLE
README: add FitTrackee to format compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The Public API is disabled by default to protect the user's privacy, but it can 
 | [Golden Cheetah 3.5](https://www.goldencheetah.org/) | ?                                              | [no](https://github.com/GoldenCheetah/GoldenCheetah/issues/4271)     | [no](https://github.com/GoldenCheetah/GoldenCheetah/issues/4271)     |
 | [GpxPod](https://apps.nextcloud.com/apps/gpxpod)     | ?                                              | ?                                                                    | ?                                                                    |
 | [OsmAnd](https://github.com/osmandapp/OsmAnd)        | ?                                              | [no](https://github.com/osmandapp/OsmAnd/issues/15271)               | [no](https://github.com/osmandapp/OsmAnd/issues/15271)               |
+| [FitTrackee](https://github.com/SamR1/FitTrackee)    | yes                                            | n/a                                                                  | n/a                                                                  |
 
 ## Dashboard API (incl. map)
 


### PR DESCRIPTION
Hi,

This PR adds the opensource application [**FitTrackee**](https://github.com/SamR1/FitTrackee) to the compatibility matrix in README.  
(Note: **FitTrackee** is only compatible with GPX format and not KML/KMZ formats for now).