### PR TITLE
Fix incorrect German translation of "Open Track"

### DIFF
--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -450,7 +450,7 @@ Meldet das GPS-Gerät ungenaue Daten (z.B. Standort, Geschwindigkeit, Höhe), ka
     <string name="gps_fixed_and_ready">GPS-Position bestimmt und bereit</string>
     <string name="instant_export_enabled_title">Sofortiger Export im Anschluss an die Übung</string>
     <string name="instant_export_enabled_summary">Streckenaufzeichnung nach Beendigung der Aufnahme in den Speicher exportieren</string>
-    <string name="generic_open_track">Offene Strecke</string>
+    <string name="generic_open_track">Strecke öffnen</string>
     <string name="sensor_state_power_avg">Durchschnittliche Leistung</string>
     <string name="sensor_state_cadence_avg">Durchschnittliche Trittfrequenz</string>
     <string name="sensor_state_cadence_max">Maximale Trittfrequenz</string>


### PR DESCRIPTION
Change the German translation of the "Open Track" button label from "Offene Strecke" ("open" as an adjective) to "Strecke öffnen" ("open" as a verb).

Without context, the original english phrase is ambiguous and both variants would be correct translations, but as a button label in the context of importing a track it is clear that "open" is supposed to be a verb and the phrase is an action prompt, and not an adjective to describe the track.

_On a personal note: I've been happily using OpenTracks for about two years now to track shorter routes and display tracks from a fitness tracker. It's a really useful app to me. Thanks for all the effort! :)_