### PR TITLE
Feat: Add Android shortcut to start track recording

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -96,6 +96,9 @@ limitations under the License.
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
 
         <activity android:name=".AboutActivity" />

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -673,6 +673,7 @@ limitations under the License.
     <string name="show_on_dashboard">OpenTracks Dashboard API</string>
     <string name="show_on_dashboard_not_installed">No application supporting OpenTracks Dashboard API installed.</string>
     <string name="always">Always</string>
+    <string name="shortcut_start_recording">Start recording</string>
 
     <string name="introduction_osm_dashboard">OpenTracks itself does not provide a map. Please install OSMDashboard to view your recordings on a map.</string>
 </resources>

--- a/src/main/res/xml/shortcuts.xml
+++ b/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,15 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_launcher"
+        android:shortcutDisabledMessage="@string/settings_public_api_disabled_toast"
+        android:shortcutId="start"
+        android:shortcutLongLabel="@string/shortcut_start_recording"
+        android:shortcutShortLabel="@string/shortcut_start_recording">
+
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetClass="de.dennisguse.opentracks.publicapi.StartRecording"
+            android:targetPackage="de.dennisguse.opentracks"></intent>
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
**Describe the pull request**
Adds Android launcher shortcut to _Start recording_. This uses the Public API intents from #1072.

![Screenshot_20230104-092605~2](https://user-images.githubusercontent.com/1429672/210615127-afe75f73-7fbb-40b1-b67d-063a628d32b6.png)

**Link to the the issue**
#331, I wanted to revisit this and check if shortcuts are still unwanted. Please close this PR if so

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
