### PR TITLE
Enable backups if client side encryption is enabled

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -62,7 +62,9 @@ limitations under the License.
 
     <application
         android:name=".Startup"
-        android:allowBackup="false"
+        android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules_30_lower"
+        android:dataExtractionRules="@xml/backup_rules_31_higher"
         android:hardwareAccelerated="true"
         android:hasFragileUserData="false"
         android:icon="@drawable/ic_launcher"

--- a/src/main/res/xml/backup_rules_30_lower.xml
+++ b/src/main/res/xml/backup_rules_30_lower.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="sharedpref" path="." requireFlags="clientSideEncryption"/>
+    <include domain="database" path="." requireFlags="clientSideEncryption"/>
+    <include domain="external" path="." requireFlags="clientSideEncryption"/>
+</full-backup-content>

--- a/src/main/res/xml/backup_rules_31_higher.xml
+++ b/src/main/res/xml/backup_rules_31_higher.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+        <include domain="sharedpref" path="."/>
+        <include domain="database" path="."/>
+        <include domain="external" path="."/>
+    </cloud-backup>
+    <device-transfer>
+        <include domain="sharedpref" path="."/>
+        <include domain="database" path="."/>
+        <include domain="external" path="."/>
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
TL;DR: This PR enables the native android backup feature **only** if the backup is encrypted on the client side.

I was setting up [seedvault](https://github.com/seedvault-app/seedvault) on LineageOS when I realized that backups were not a thing on my device for OpenTracks only.
From my brief issue searching I found 2 issues, #346 and subsequently #710 I understand that this is a touchy subject.

Even if I don't completely align with the rational behind the decision to not implement this straight out of the box, I respect it.

So as @dennisguse [replied in the latter issue](https://github.com/OpenTracksApp/OpenTracks/issues/710#issuecomment-822656039), here goes a PR to try to reach a solution to which everyone can be content with.

Followed the [android documentation](https://developer.android.com/guide/topics/data/autobackup#define-device-conditions).

It has been over 10 years since I last did any Android development and I don't have an environment set up, this should be a pretty simple change (famous last words) so I'll test the build output from the CI :disappointed:
In the meantime I'll keep this marked as draft.