### PR TITLE
Bugfix: GPS disabled warning was showing (repeatedly but incorrectly).

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -381,13 +381,18 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
     }
 
     private void onGpsStatusChanged(GpsStatusValue gpsStatusValue) {
-        if (gpsStatusValue.isGpsStarted() && snackbar != null && snackbar.isShown()) {
-            snackbar.dismiss();
+        boolean snackbarShowing = snackbar != null && snackbar.isShown();
+        if (gpsStatusValue.isGpsStarted()) {
+            if (snackbarShowing) {
+                snackbar.dismiss();
+            }
             return;
         }
-        if (gpsStatusValue != GpsStatusValue.GPS_DISABLED) {
+
+        if (snackbarShowing) {
             return;
         }
+
         snackbar = Snackbar
                 .make(viewBinding.trackRecordingCoordinatorLayout,
                         getString(R.string.gps_recording_status, getString(gpsStatusValue.message), getString(R.string.gps_recording_without_signal)),


### PR DESCRIPTION
Fixes #142924.

Hopefully this fixing the incorrectly popping up of the "GPS disabled"-snackbar.