### PR TITLE
Bug kml#1522

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackExporterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/exporter/KmlTrackExporterTest.java
@@ -43,7 +43,7 @@ public class KmlTrackExporterTest {
         TrackPoint trackPoint = new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochSecond(0));
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        KMLTrackExporter kmlTrackWriter = (KMLTrackExporter) TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA.createTrackExporter(context);
+        KMLTrackExporter kmlTrackWriter = (KMLTrackExporter) TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA.createTrackExporter(context, null);
         kmlTrackWriter.prepare(outputStream);
 
         kmlTrackWriter.writeTrackPoint(ZoneOffset.UTC, trackPoint);

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -204,7 +204,7 @@ public class ExportImportTest {
         // given
         Track track = contentProviderUtils.getTrack(trackId);
 
-        TrackExporter trackExporter = TrackFileFormat.KMZ_WITH_TRACKDETAIL_AND_SENSORDATA.createTrackExporter(context);
+        TrackExporter trackExporter = TrackFileFormat.KMZ_WITH_TRACKDETAIL_AND_SENSORDATA.createTrackExporter(context, contentProviderUtils);
 
         // when
         // 1. export
@@ -287,7 +287,7 @@ public class ExportImportTest {
         editor.commit();
         Track track = contentProviderUtils.getTrack(trackId);
 
-        TrackExporter trackExporter = TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA.createTrackExporter(context);
+        TrackExporter trackExporter = TrackFileFormat.KML_WITH_TRACKDETAIL_AND_SENSORDATA.createTrackExporter(context, contentProviderUtils);
 
         // when
         trackExporter.writeTrack(track, context.getContentResolver().openOutputStream(tmpFileUri));
@@ -310,7 +310,7 @@ public class ExportImportTest {
         // given
         Track track = contentProviderUtils.getTrack(trackId);
 
-        TrackExporter trackExporter = TrackFileFormat.GPX.createTrackExporter(context);
+        TrackExporter trackExporter = TrackFileFormat.GPX.createTrackExporter(context, contentProviderUtils);
 
         // when
         // 1. export
@@ -428,7 +428,7 @@ public class ExportImportTest {
         editor.commit();
         Track track = contentProviderUtils.getTrack(trackId);
 
-        TrackExporter trackExporter = TrackFileFormat.GPX.createTrackExporter(context);
+        TrackExporter trackExporter = TrackFileFormat.GPX.createTrackExporter(context, contentProviderUtils);
 
         // when
         // 1. export
@@ -453,7 +453,7 @@ public class ExportImportTest {
         // given
         Track track = contentProviderUtils.getTrack(trackId);
 
-        TrackExporter trackExporter = TrackFileFormat.CSV.createTrackExporter(context);
+        TrackExporter trackExporter = TrackFileFormat.CSV.createTrackExporter(context, contentProviderUtils);
 
         // when
         // 1. export

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/GPXTrackImporterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/GPXTrackImporterTest.java
@@ -231,7 +231,7 @@ public class GPXTrackImporterTest {
         importTrackId = importer.importFile(inputStream).get(0);
         Track importedTrack = contentProviderUtils.getTrack(importTrackId);
 
-        TrackExporter trackExporter = TrackFileFormat.GPX.createTrackExporter(context);
+        TrackExporter trackExporter = TrackFileFormat.GPX.createTrackExporter(context, contentProviderUtils);
         trackExporter.writeTrack(importedTrack, outputStream);
 
         // then

--- a/src/main/java/de/dennisguse/opentracks/data/ShareContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/ShareContentProvider.java
@@ -214,7 +214,7 @@ public class ShareContentProvider extends CustomContentProvider {
             }
         }
 
-        final TrackExporter trackExporter = getTrackFileFormat(uri).createTrackExporter(getContext());
+        final TrackExporter trackExporter = getTrackFileFormat(uri).createTrackExporter(getContext(), new ContentProviderUtils(getContext()));
 
         PipeDataWriter<String> pipeDataWriter = (output, uri1, mimeType, opts, args) -> {
             try (FileOutputStream fileOutputStream = new FileOutputStream(output.getFileDescriptor())) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/TrackFileFormat.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/TrackFileFormat.java
@@ -3,6 +3,8 @@ package de.dennisguse.opentracks.io.file;
 import android.content.Context;
 import android.content.res.Resources;
 
+import androidx.annotation.NonNull;
+
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -25,8 +27,8 @@ public enum TrackFileFormat {
 
     KML_WITH_TRACKDETAIL_AND_SENSORDATA("KML_WITH_TRACKDETAIL_AND_SENSORDATA") {
         @Override
-        public TrackExporter createTrackExporter(Context context) {
-            return new KMLTrackExporter(context, false);
+        public TrackExporter createTrackExporter(@NonNull Context context, @NonNull ContentProviderUtils contentProviderUtils) {
+            return new KMLTrackExporter(context, contentProviderUtils, false);
         }
 
         @Override
@@ -45,9 +47,9 @@ public enum TrackFileFormat {
         private static final boolean exportPhotos = false;
 
         @Override
-        public TrackExporter createTrackExporter(Context context) {
-            KMLTrackExporter exporter = new KMLTrackExporter(context, exportPhotos);
-            return new KmzTrackExporter(context, new ContentProviderUtils(context), exporter, exportPhotos);
+        public TrackExporter createTrackExporter(@NonNull Context context, @NonNull ContentProviderUtils contentProviderUtils) {
+            KMLTrackExporter exporter = new KMLTrackExporter(context, contentProviderUtils, exportPhotos);
+            return new KmzTrackExporter(context, contentProviderUtils, exporter, exportPhotos);
         }
 
         @Override
@@ -70,9 +72,9 @@ public enum TrackFileFormat {
         private static final boolean exportPhotos = true;
 
         @Override
-        public TrackExporter createTrackExporter(Context context) {
-            KMLTrackExporter exporter = new KMLTrackExporter(context, exportPhotos);
-            return new KmzTrackExporter(context, new ContentProviderUtils(context), exporter, exportPhotos);
+        public TrackExporter createTrackExporter(@NonNull Context context, @NonNull ContentProviderUtils contentProviderUtils) {
+            KMLTrackExporter exporter = new KMLTrackExporter(context, contentProviderUtils, exportPhotos);
+            return new KmzTrackExporter(context, contentProviderUtils, exporter, exportPhotos);
         }
 
         @Override
@@ -93,8 +95,8 @@ public enum TrackFileFormat {
 
     GPX("GPX") {
         @Override
-        public TrackExporter createTrackExporter(Context context) {
-            return new GPXTrackExporter(new ContentProviderUtils(context), context.getString(R.string.app_name));
+        public TrackExporter createTrackExporter(@NonNull Context context, @NonNull ContentProviderUtils contentProviderUtils) {
+            return new GPXTrackExporter(contentProviderUtils, context.getString(R.string.app_name));
         }
 
         @Override
@@ -109,8 +111,8 @@ public enum TrackFileFormat {
 
     CSV("CSV") {
         @Override
-        public TrackExporter createTrackExporter(Context context) {
-            return new CSVTrackExporter(new ContentProviderUtils(context));
+        public TrackExporter createTrackExporter(@NonNull Context context, @NonNull ContentProviderUtils contentProviderUtils) {
+            return new CSVTrackExporter(contentProviderUtils);
         }
 
         @Override
@@ -161,7 +163,7 @@ public enum TrackFileFormat {
      *
      * @param context the context
      */
-    public abstract TrackExporter createTrackExporter(Context context);
+    public abstract TrackExporter createTrackExporter(@NonNull Context context, @NonNull ContentProviderUtils contentProviderUtils);
 
     /**
      * Returns the file extension for each format.

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
@@ -226,15 +226,19 @@ public class KMLTrackExporter implements TrackExporter {
 
     private void writeHeader(Track[] tracks) {
         if (printWriter != null) {
-            printWriter.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-            printWriter.println("<kml xmlns=\"http://www.opengis.net/kml/2.3\"");
-            printWriter.println("xmlns:atom=\"http://www.w3.org/2005/Atom\"");
-            printWriter.println("xmlns:opentracks=\"http://opentracksapp.com/xmlschemas/v1\">");
-            //TODO ADD xsi:schemaLocation for atom
-            printWriter.println("xsi:schemaLocation=" +
-                    "\"http://www.opengis.net/kml/2.3 http://schemas.opengis.net/kml/2.3/ogckml23.xsd"
-                    + " http://opentracksapp.com/xmlschemas/v1 http://opentracksapp.com/xmlschemas/OpenTracks_v1.xsd\">");
-
+            printWriter.println(
+                    """
+                            <?xml version="1.0" encoding="UTF-8"?>
+                            """);
+            printWriter.println(
+                    """
+                            <kml xmlns="http://www.opengis.net/kml/2.3"
+                                xmlns:atom="http://www.w3.org/2005/Atom"
+                                xmlns:opentracks="http://opentracksapp.com/xmlschemas/v1"
+                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                xsi:schemaLocation="http://www.opengis.net/kml/2.3 http://schemas.opengis.net/kml/2.3/ogckml23.xsd
+                                                    http://opentracksapp.com/xmlschemas/v1 http://opentracksapp.com/xmlschemas/OpenTracks_v1.xsd">
+                            """); //TODO ADD xsi:schemaLocation for atom
             printWriter.println("<Document>");
             printWriter.println("<open>1</open>");
             printWriter.println("<visibility>1</visibility>");

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
@@ -93,10 +93,10 @@ public class KMLTrackExporter implements TrackExporter {
     private final List<Float> accuracyHorizontal = new ArrayList<>();
     private final List<Float> accuracyVertical = new ArrayList<>();
 
-    public KMLTrackExporter(Context context, boolean exportPhotos) {
+    public KMLTrackExporter(Context context, ContentProviderUtils contentProviderUtils, boolean exportPhotos) {
         this.context = context;
         this.exportPhotos = exportPhotos;
-        this.contentProviderUtils = new ContentProviderUtils(context);
+        this.contentProviderUtils = contentProviderUtils;
     }
 
     public boolean writeTrack(Track track, @NonNull OutputStream outputStream) {

--- a/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.data.ContentProviderUtils;
 import de.dennisguse.opentracks.data.models.Track;
 import de.dennisguse.opentracks.io.file.TrackFileFormat;
 import de.dennisguse.opentracks.io.file.exporter.ExportService;
@@ -56,7 +57,7 @@ public class ExportUtils {
     }
 
     public static boolean exportTrack(Context context, TrackFileFormat trackFileFormat, DocumentFile directory, Track track) {
-        TrackExporter trackExporter = trackFileFormat.createTrackExporter(context);
+        TrackExporter trackExporter = trackFileFormat.createTrackExporter(context, new ContentProviderUtils(context));
 
         Uri exportDocumentFileUri = getExportDocumentFileUri(context, track, trackFileFormat, directory);
         if (exportDocumentFileUri == null) {


### PR DESCRIPTION
That fixes an ugly bug.
For KML, the `<kml>` was closed to early (aka before all attributes were set) and those landed in the body of `<kml>`.

Sadly, this was not catched by the ExportImportTest as it was valid XML.