### PR TITLE
Build: remove resConfigs limiting included languages.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,8 +74,6 @@ android {
 
         testInstrumentationRunner "de.dennisguse.opentracks.TestRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
-
-        resConfigs "ar", "bg", "ca", "cs", "da", "de", "el", "en", "es", "et", "eu", "fa", "fi", "fr", "ga", "gl", "hi", "hr", "hu", "in", "it", "iw", "ja", "ko", "lt", "lv", "mo", "ms", "nb", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tl", "tr", "uk", "vi", "zh"
     }
     signingConfigs {
         nightly {


### PR DESCRIPTION
@elastic-rock was `resConfigs` required for Android 13's per app-language setting?

In 7dcc0ec8, I changed the behavior to use AGP  to generate the configuration.
I presume that thus resConfigs should not be necessary anymore.

Would you have time to test this?