### PR TITLE
Handling of unsigned values

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/sensors/UintUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/sensors/UintUtilsTest.java
@@ -16,14 +16,16 @@ public class UintUtilsTest {
         
         /*   Test modulo arithmetic for arguments that are out of range */
         
-        assertEquals(0, UintUtils.diff(65537, 1, UintUtils.UINT16_MAX));
-        assertEquals(0, UintUtils.diff(1, 65537, UintUtils.UINT16_MAX)); 
-        assertEquals(0, UintUtils.diff(65537, 65537, UintUtils.UINT16_MAX)); 
-        assertEquals(0, UintUtils.diff(-65535, 1, UintUtils.UINT16_MAX));
-        assertEquals(0, UintUtils.diff(1, -65535, UintUtils.UINT16_MAX)); 
-        assertEquals(0, UintUtils.diff(-65535, -65535, UintUtils.UINT16_MAX)); 
-        assertEquals(0, UintUtils.diff(-65535, 65537, UintUtils.UINT16_MAX));
-        assertEquals(0, UintUtils.diff(65537, -65535, UintUtils.UINT16_MAX)); 
+        if (false) {   /*  false means UintUtils.diff() throws if arguments out of range */
+            assertEquals(0, UintUtils.diff(65537, 1, UintUtils.UINT16_MAX));
+            assertEquals(0, UintUtils.diff(1, 65537, UintUtils.UINT16_MAX)); 
+            assertEquals(0, UintUtils.diff(65537, 65537, UintUtils.UINT16_MAX)); 
+            assertEquals(0, UintUtils.diff(-65535, 1, UintUtils.UINT16_MAX));
+            assertEquals(0, UintUtils.diff(1, -65535, UintUtils.UINT16_MAX)); 
+            assertEquals(0, UintUtils.diff(-65535, -65535, UintUtils.UINT16_MAX)); 
+            assertEquals(0, UintUtils.diff(-65535, 65537, UintUtils.UINT16_MAX));
+            assertEquals(0, UintUtils.diff(65537, -65535, UintUtils.UINT16_MAX)); 
+        }
         
         /*  The following tests are the above, but for 32-bit unsigned. */
         
@@ -33,14 +35,16 @@ public class UintUtilsTest {
         assertEquals(4294967295, UintUtils.diff(1, 2, UintUtils.UINT32_MAX));
         assertEquals(4294967290, UintUtils.diff(UintUtils.UINT32_MAX, 5, UintUtils.UINT32_MAX));
        
-        assertEquals(0, UintUtils.diff(4294967297, 1, UintUtils.UINT32_MAX));
-        assertEquals(0, UintUtils.diff(1, 4294967297, UintUtils.UINT32_MAX)); 
-        assertEquals(0, UintUtils.diff(4294967297, 4294967297, UintUtils.UINT32_MAX)); 
-        assertEquals(0, UintUtils.diff(-4294967295, 1, UintUtils.UINT32_MAX));
-        assertEquals(0, UintUtils.diff(1, -4294967295, UintUtils.UINT32_MAX)); 
-        assertEquals(0, UintUtils.diff(-4294967295, -4294967295, UintUtils.UINT32_MAX)); 
-        assertEquals(0, UintUtils.diff(-4294967295, 4294967297, UintUtils.UINT32_MAX));
-        assertEquals(0, UintUtils.diff(65537, -4294967297, UintUtils.UINT32_MAX));
+        if (false) { /*  false means UintUtils.diff() throws if arguments out of range */
+            assertEquals(0, UintUtils.diff(4294967297, 1, UintUtils.UINT32_MAX));
+            assertEquals(0, UintUtils.diff(1, 4294967297, UintUtils.UINT32_MAX)); 
+            assertEquals(0, UintUtils.diff(4294967297, 4294967297, UintUtils.UINT32_MAX)); 
+            assertEquals(0, UintUtils.diff(-4294967295, 1, UintUtils.UINT32_MAX));
+            assertEquals(0, UintUtils.diff(1, -4294967295, UintUtils.UINT32_MAX)); 
+            assertEquals(0, UintUtils.diff(-4294967295, -4294967295, UintUtils.UINT32_MAX)); 
+            assertEquals(0, UintUtils.diff(-4294967295, 4294967297, UintUtils.UINT32_MAX));
+            assertEquals(0, UintUtils.diff(65537, -4294967297, UintUtils.UINT32_MAX));
+        }
     }
 
     @Test

--- a/src/androidTest/java/de/dennisguse/opentracks/sensors/UintUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/sensors/UintUtilsTest.java
@@ -8,12 +8,39 @@ public class UintUtilsTest {
 
     @Test
     public void diff() {
-        assertEquals(0, UintUtils.diff(1, 1, UintUtils.UINT16_MAX));
+        assertEquals(0, UintUtils.diff(1, 1, UintUtils.UINT16_MAX));  
         assertEquals(1, UintUtils.diff(2, 1, UintUtils.UINT16_MAX));
         assertEquals(3, UintUtils.diff(5, 2, UintUtils.UINT16_MAX));
-        assertEquals(65534, UintUtils.diff(1, 2, UintUtils.UINT16_MAX));
-
+        assertEquals(65535, UintUtils.diff(1, 2, UintUtils.UINT16_MAX));     /* unsigned 16 arithmetic is modulo UINT16_MAX + 1, not modulo UINT16_MAX */
         assertEquals(65530, UintUtils.diff(UintUtils.UINT16_MAX, 5, UintUtils.UINT16_MAX));
+        
+        /*   Test modulo arithmetic for arguments that are out of range */
+        
+        assertEquals(0, UintUtils.diff(65537, 1, UintUtils.UINT16_MAX));
+        assertEquals(0, UintUtils.diff(1, 65537, UintUtils.UINT16_MAX)); 
+        assertEquals(0, UintUtils.diff(65537, 65537, UintUtils.UINT16_MAX)); 
+        assertEquals(0, UintUtils.diff(-65535, 1, UintUtils.UINT16_MAX));
+        assertEquals(0, UintUtils.diff(1, -65535, UintUtils.UINT16_MAX)); 
+        assertEquals(0, UintUtils.diff(-65535, -65535, UintUtils.UINT16_MAX)); 
+        assertEquals(0, UintUtils.diff(-65535, 65537, UintUtils.UINT16_MAX));
+        assertEquals(0, UintUtils.diff(65537, -65535, UintUtils.UINT16_MAX)); 
+        
+        /*  The following tests are the above, but for 32-bit unsigned. */
+        
+        assertEquals(0, UintUtils.diff(1, 1, UintUtils.UINT32_MAX));  
+        assertEquals(1, UintUtils.diff(2, 1, UintUtils.UINT32_MAX));
+        assertEquals(3, UintUtils.diff(5, 2, UintUtils.UINT32_MAX));
+        assertEquals(4294967295, UintUtils.diff(1, 2, UintUtils.UINT32_MAX));
+        assertEquals(4294967290, UintUtils.diff(UintUtils.UINT32_MAX, 5, UintUtils.UINT32_MAX));
+       
+        assertEquals(0, UintUtils.diff(4294967297, 1, UintUtils.UINT32_MAX));
+        assertEquals(0, UintUtils.diff(1, 4294967297, UintUtils.UINT32_MAX)); 
+        assertEquals(0, UintUtils.diff(4294967297, 4294967297, UintUtils.UINT32_MAX)); 
+        assertEquals(0, UintUtils.diff(-4294967295, 1, UintUtils.UINT32_MAX));
+        assertEquals(0, UintUtils.diff(1, -4294967295, UintUtils.UINT32_MAX)); 
+        assertEquals(0, UintUtils.diff(-4294967295, -4294967295, UintUtils.UINT32_MAX)); 
+        assertEquals(0, UintUtils.diff(-4294967295, 4294967297, UintUtils.UINT32_MAX));
+        assertEquals(0, UintUtils.diff(65537, -4294967297, UintUtils.UINT32_MAX));
     }
 
     @Test

--- a/src/main/java/de/dennisguse/opentracks/sensors/UintUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/UintUtils.java
@@ -15,6 +15,13 @@ public class UintUtils {
      */
     public static long diff(long a, long b, final long UINT_MAX) {
         
+        if (a < 0 || b < 0) {
+            throw new RuntimeException("a or b cannot be less than zero.");
+        }
+        if (a > UINT_MAX || b > UINT_MAX) {
+            throw new RuntimeException("a or b are outside of the allowed range.");
+        }
+        
         a %= (UINT_MAX + 1);
         if (a < 0) {
             a += (UINT_MAX + 1);

--- a/src/main/java/de/dennisguse/opentracks/sensors/UintUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/UintUtils.java
@@ -14,17 +14,20 @@ public class UintUtils {
      * @return diff
      */
     public static long diff(long a, long b, final long UINT_MAX) {
-        if (a < 0 || b < 0) {
-            throw new RuntimeException("a or b cannot be less than zero.");
+        
+        a %= (UINT_MAX + 1);
+        if (a < 0) {
+            a += (UINT_MAX + 1);
         }
-        if (a > UINT_MAX || b > UINT_MAX) {
-            throw new RuntimeException("a or b are outside of the allowed range.");
+        b %= (UINT_MAX + 1);
+        if (b < 0){
+            b += (UINT_MAX + 1);
         }
 
         if (a >= b) {
             return a - b;
         }
 
-        return (UINT_MAX - b) + a;
+        return (UINT_MAX + 1 - b) + a;
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/sensors/UintUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/UintUtils.java
@@ -21,15 +21,6 @@ public class UintUtils {
         if (a > UINT_MAX || b > UINT_MAX) {
             throw new RuntimeException("a or b are outside of the allowed range.");
         }
-        
-        a %= (UINT_MAX + 1);
-        if (a < 0) {
-            a += (UINT_MAX + 1);
-        }
-        b %= (UINT_MAX + 1);
-        if (b < 0){
-            b += (UINT_MAX + 1);
-        }
 
         if (a >= b) {
             return a - b;


### PR DESCRIPTION
**Describe the pull request**

(1) Correction of bug related to calculating difference of "unsigned" values.   Essentially an "off by one" error.     If an unsigned variable has range 0 to UINT_MAX,  numeric operations on those variables are modulo UINT_MAX + 1 (e.g. subtracting 1 from 0 produces UINT_MAX).    The bug was doing operations modulo UINT_MAX, not modulo UINT_MAX + 1 when subtracting a large value from a small one.

(2)   Correction of test case that allowed preceding bug (1) to pass!

(3)    When calculating UintUtils.diff(a, b, UINT_MAX), no longer throw exceptions if a or b are out of range [0, UINT_MAX].   Instead, correct the values a and b using modulo arithmetic, and then calculate their difference.   This is "normal" handling of numeric operations unsigned integral types, both in hardware and in other programming languages. 

(4)    Add test cases to verify behaviour of code added in (3)

(5)   Existing test cases were only for "16 bit" unsigned subtraction.   "32 bit" tests added in interests of completeness (verify rather than assume that passing 16-bit tests mean that 32-bit tests will pass).

Edits in this pull request MAY address some contributors to this and other bugs related to spikes in sensor data (e.g. my experience of a recorded speed of 2394.0 km/hr on a bicycle, despite belief I did not achieve such a speed :-) ).    The nature of the bug is that it can map a small value to a large value, and vice versa.

**Link to the issue**

Bug (1 above) with handling calculation of difference of unsigned values is mentioned in https://github.com/OpenTracksApp/OpenTracks/issues/1557

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

Acknowledged.

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.

Refrained!
