### PR TITLE
Bump com.android.tools.build:gradle from 8.1.0-beta04 to 8.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0-rc01'
+        classpath 'com.android.tools.build:gradle:8.1.0'
     }
 }
 


### PR DESCRIPTION
Merge this PR, when the stable version of AGP 8.1.0 is released.
This will allow Dependabot to propose stable updates only again for this dependency.

https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google