### PR TITLE
Fix clipped x graph in ChartView

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
@@ -946,7 +946,7 @@ public class ChartView extends View {
      */
     private void updateEffectiveDimensions() {
         effectiveWidth = Math.max(0, width - leftBorder - rightBorder);
-        effectiveHeight = Math.max(0, height - topBorder - bottomBorder);
+        effectiveHeight = Math.max(0, height - topBorder - bottomBorder - spacer);
     }
 
     /**


### PR DESCRIPTION
fixes #1627

I'm not entirely sure that taking `spacer` into account here is the correct approach, but it works and `spacer` is used in several other places when calculating the height / bottom.