### PR TITLE
StatisticsRecordedFragment: Reimplement Sensor Statistics

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/fragments/SensorStatisticsAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/SensorStatisticsAdapter.java
@@ -1,0 +1,114 @@
+package de.dennisguse.opentracks.fragments;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.stats.SensorStatistics;
+
+public class SensorStatisticsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    private SensorStatistics statistics;
+    private List<Stat> statList;
+
+    public void swapData(Context ctx, SensorStatistics statistics) {
+        this.statistics = statistics;
+
+        statList = new ArrayList<Stat>();
+        // Heart Rate
+        if (statistics.hasHeartRate()) {
+            Stat maxHr = new Stat();
+            maxHr.description_main = ctx.getString(R.string.sensor_state_heart_rate_max);
+            maxHr.value = String.valueOf(Math.round(statistics.getMaxHeartRate().getBPM()));
+            maxHr.unit = ctx.getString(R.string.sensor_state_heart_rate_unit);
+
+            Stat avgHr = new Stat();
+            avgHr.description_main = ctx.getString(R.string.sensor_state_heart_rate_avg);
+            avgHr.value = String.valueOf(Math.round(statistics.getAvgHeartRate().getBPM()));
+            avgHr.unit = ctx.getString(R.string.sensor_state_heart_rate_unit);
+
+            statList.add(maxHr);
+            statList.add(avgHr);
+        }
+        // Cadence
+        if (statistics.hasCadence()) {
+            Stat maxCadence = new Stat();
+            maxCadence.description_main = ctx.getString(R.string.sensor_state_cadence_max);
+            maxCadence.value = String.valueOf(Math.round(statistics.getMaxCadence().getRPM()));
+            maxCadence.unit = ctx.getString(R.string.sensor_state_cadence_unit);
+
+            Stat avgCadence = new Stat();
+            avgCadence.description_main = ctx.getString(R.string.sensor_state_cadence_avg);
+            avgCadence.value = String.valueOf(Math.round(statistics.getAvgCadence().getRPM()));
+            avgCadence.unit = ctx.getString(R.string.sensor_state_cadence_unit);
+
+            statList.add(maxCadence);
+            statList.add(avgCadence);
+        }
+        // Power
+        if (statistics.hasPower()) {
+            Stat avgPower = new Stat();
+            avgPower.description_main = ctx.getString(R.string.sensor_state_power_avg);
+            avgPower.value = String.valueOf(Math.round(statistics.getAvgPower().getW()));
+            avgPower.unit = ctx.getString(R.string.sensor_state_power_unit);
+
+            statList.add(avgPower);
+        }
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.stats_recorded_item, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
+        ViewHolder viewHolder = (ViewHolder) holder;
+
+        Stat stat = statList.get(position);
+        viewHolder.description_main.setText(stat.description_main);
+        viewHolder.value.setText(stat.value);
+        viewHolder.unit.setText(stat.unit);
+        viewHolder.description_secondary.setText("");
+    }
+
+    @Override
+    public int getItemCount() {
+        if (statList == null) {
+            return 0;
+        }
+        return statList.size();
+    }
+
+    private class Stat {
+        public String description_main;
+        public String value;
+        public String unit;
+    }
+
+    private static class ViewHolder extends RecyclerView.ViewHolder {
+        final TextView description_main;
+        final TextView value;
+        final TextView unit;
+        final TextView description_secondary;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            description_main = itemView.findViewById(R.id.stats_description_main);
+            value = itemView.findViewById(R.id.stats_value);
+            unit = itemView.findViewById(R.id.stats_unit);
+            description_secondary = itemView.findViewById(R.id.stats_description_secondary);
+        }
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
@@ -68,6 +68,7 @@ public class StatisticsRecordedFragment extends Fragment {
     }
 
     private SensorStatistics sensorStatistics;
+    private SensorStatisticsAdapter sensorsAdapter;
 
     private Track.Id trackId;
     @Nullable // Lazily loaded.
@@ -116,7 +117,8 @@ public class StatisticsRecordedFragment extends Fragment {
 
         RecyclerView sensorsRecyclerView = viewBinding.statsSensorsRecyclerView;
         sensorsRecyclerView.setLayoutManager(new GridLayoutManager(getContext(), 2));
-//        sensorsRecyclerView.setAdapter(sensorsAdapter);
+        sensorsAdapter = new SensorStatisticsAdapter();
+        sensorsRecyclerView.setAdapter(sensorsAdapter);
 
         return viewBinding.getRoot();
     }
@@ -141,6 +143,7 @@ public class StatisticsRecordedFragment extends Fragment {
     public void onDestroyView() {
         super.onDestroyView();
         viewBinding = null;
+        sensorsAdapter = null;
     }
 
     public void loadStatistics() {
@@ -258,6 +261,6 @@ public class StatisticsRecordedFragment extends Fragment {
         if (sensorStatistics == null) {
             return;
         }
-        //TODO
+        sensorsAdapter.swapData(getContext(), sensorStatistics);
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -328,12 +328,15 @@ limitations under the License.
     <!-- Sensor State -->
     <string name="sensor_state_cadence_avg">Avg Cadence</string>
     <string name="sensor_state_cadence_max">Max Cadence</string>
+    <string name="sensor_state_cadence_unit">rpm</string>
     <string name="sensor_state_heart_rate">Heart rate</string>
     <string name="sensor_state_heart_rate_avg">Avg Heart rate</string>
     <string name="sensor_state_heart_rate_max">Max Heart rate</string>
+    <string name="sensor_state_heart_rate_unit">bpm</string>
     <string name="sensor_state_heart_rate_value">%1$d bpm</string>
     <string name="sensor_state_power">Power</string>
     <string name="sensor_state_power_avg">Avg Power</string>
+    <string name="sensor_state_power_unit">W</string>
     <string name="sensor_could_not_scan">Could not scan for Bluetooth devices (error %1$i).</string>
     <string name="bluetooth_disabled">Please enable Bluetooth.</string>
 


### PR DESCRIPTION
Closes: #1426

This adds the sensor stats back to the StatisticsRecordedFragment by adding a new class SensorStatisticsAdapter for the RecyclerView and connecting everything.

I have used the `stats_recorded_item` layout, but left the `description_secondary` field empty.

The basic thought here is, that we look through each type in SensorStatistics and when it's available, we fill a struct-like class called Stats with the field values, so in onBindViewHolder(), we only have to set these values in the views.

I have put SensorStatisticsAdapter.java into the same directory as StatisticsRecordedFragment.java, but I have no problem moving it to a better spot, if you have any idea ;)

I only tested this change with Heart Rate, since it's the only external device I have.