### PR TITLE
Fix alignment of Statistics

### DIFF
--- a/src/main/res/layout/statistics_recorded.xml
+++ b/src/main/res/layout/statistics_recorded.xml
@@ -30,7 +30,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:orientation="vertical"
-            app:layout_constraintGuide_begin="206dp" />
+            app:layout_constraintGuide_percent="0.5" />
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/guideline3"


### PR DESCRIPTION
This bug accidentally made it into db1a37f. Android Studio, for some reason, has made this change automatically and I didn't notice it. Sorry about that.

Without this fix, the alignment of the two columns isn't correct in landscape orientation or different screen sizes.
