### PR TITLE
Fix: GPS Access denied when device in standby

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ OpenTracks can be used with [Gadgetbridge](https://www.gadgetbridge.org/):
 * __No in-app analytics__
 * __No use of Google Play Services__
 
-__Only required permission:__
+__Only required permissions:__
 * _ACCESS_FINE_LOCATION_: required to use the GPS.
+* _ACCESS_BACKGROUND_LOCATION_: required to start recording with GPS while phone is in standby. (e.g. when triggered by Public API from an external device)
 
 ### Public API
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@ limitations under the License.
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 

--- a/src/main/java/de/dennisguse/opentracks/util/PermissionRequester.java
+++ b/src/main/java/de/dennisguse/opentracks/util/PermissionRequester.java
@@ -57,7 +57,7 @@ public class PermissionRequester {
         locationPermissionRequest.launch(permissions.toArray(permissions.toArray(new String[0])));
     }
 
-    private static final List<String> GPS_PERMISSION = List.of(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION);
+    private static final List<String> GPS_PERMISSION = List.of(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION);
 
     private static final List<String> BLUETOOTH_PERMISSIONS;
 


### PR DESCRIPTION
As discussed in https://github.com/OpenTracksApp/OpenTracks/issues/1653 , I've added the ACCESS_BACKGROUND_LOCATION and tested it successfully.
Starting to track a training while the phone is in standby now works with GPS.