### PR TITLE
Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ captures/
 .idea/.name
 .idea/caches/
 .idea/compiler.xml
+.idea/androidTestResultsUserPreferences.xml
 .idea/copyright/profiles_settings.xml
 .idea/dataSources.ids
 .idea/datasources.xml

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -64,7 +64,6 @@ import de.dennisguse.opentracks.sensors.sensorData.SensorDataCyclingPower;
 import de.dennisguse.opentracks.sensors.sensorData.SensorDataHeartRate;
 import de.dennisguse.opentracks.sensors.sensorData.SensorDataSet;
 import de.dennisguse.opentracks.services.TrackRecordingService;
-import de.dennisguse.opentracks.services.TrackRecordingServiceTestUtils;
 import de.dennisguse.opentracks.services.handlers.TrackPointCreator;
 import de.dennisguse.opentracks.stats.TrackStatistics;
 
@@ -113,14 +112,10 @@ public class ExportImportTest {
 
     @Before
     public void fileSetup() throws IOException {
-        TrackRecordingServiceTestUtils.resetService(mServiceRule, context);
-
         tmpFile = File.createTempFile("test", "test", context.getFilesDir());
         tmpFileUri = Uri.fromFile(tmpFile);
 
         trackImporter = new TrackImporter(context, contentProviderUtils, Distance.of(200), true);
-
-        TrackRecordingServiceTestUtils.resetService(mServiceRule, context);
     }
 
     @After
@@ -130,8 +125,6 @@ public class ExportImportTest {
 
         // Ensure that the database is empty after every test
         contentProviderUtils.deleteAllTracks(context);
-
-        TrackRecordingServiceTestUtils.resetService(mServiceRule, context);
     }
 
     public void setUp() throws TimeoutException {

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceMarkerTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceMarkerTest.java
@@ -87,8 +87,6 @@ public class TrackRecordingServiceMarkerTest {
 
     @After
     public void tearDown() {
-        TrackRecordingServiceTestUtils.resetService(mServiceRule, context);
-
         // Ensure that the database is empty after every test
         contentProviderUtils.deleteAllTracks(context);
     }

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceRecordingTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceRecordingTest.java
@@ -13,7 +13,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
 import androidx.test.rule.ServiceTestRule;
 
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -87,19 +86,11 @@ public class TrackRecordingServiceRecordingTest {
     @Before
     public void setUp() throws TimeoutException {
         contentProviderUtils = new ContentProviderUtils(context);
-        tearDown();
 
         PreferencesUtils.setString(R.string.recording_distance_interval_key, R.string.recording_distance_interval_default);
         PreferencesUtils.setString(R.string.idle_speed_key, R.string.idle_speed_default);
 
         service = startService();
-    }
-
-    @After
-    public void tearDown() {
-        TrackRecordingServiceTestUtils.resetService(mServiceRule, context);
-        // Ensure that the database is empty after every test
-        contentProviderUtils.deleteAllTracks(context);
     }
 
     @MediumTest

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceStateMachineTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceStateMachineTest.java
@@ -132,7 +132,7 @@ public class TrackRecordingServiceStateMachineTest {
         assertEquals(GpsStatusValue.GPS_ENABLED, service.getGpsStatusObservable().getValue());
 
         // when
-        service.stopSensorsAndShutdown();
+        service.stopSensors();
         Thread.sleep(1000);
 
         // then
@@ -177,7 +177,7 @@ public class TrackRecordingServiceStateMachineTest {
         // then
         assertFalse(service.isRecording());
         assertEquals(TrackRecordingService.STATUS_DEFAULT, service.getRecordingStatusObservable().getValue());
-        assertEquals(TrackRecordingService.NOT_RECORDING, service.getRecordingDataObservable().getValue());
+        assertNotEquals(TrackRecordingService.NOT_RECORDING, service.getRecordingDataObservable().getValue());
         assertEquals(GpsStatusValue.GPS_NONE, service.getGpsStatusObservable().getValue());
 
 

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceStateMachineTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceStateMachineTest.java
@@ -94,7 +94,6 @@ public class TrackRecordingServiceStateMachineTest {
 
     @After
     public void tearDown() {
-        TrackRecordingServiceTestUtils.resetService(mServiceRule, context);
         // Ensure that the database is empty after every test
         contentProviderUtils.deleteAllTracks(context);
     }

--- a/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestUtils.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/services/TrackRecordingServiceTestUtils.java
@@ -1,23 +1,10 @@
 package de.dennisguse.opentracks.services;
 
-import android.content.Context;
 import android.location.Location;
 
-import androidx.test.rule.ServiceTestRule;
-
 import de.dennisguse.opentracks.services.handlers.TrackPointCreator;
-import de.dennisguse.opentracks.settings.PreferencesUtils;
 
 public class TrackRecordingServiceTestUtils {
-
-
-    //TODO Workaround as service is not stopped on API23; thus sharedpreferences are not reset between tests.
-    //TODO Anyhow, the service should re-create all it's resources if a recording starts and makes sure that there is no leftovers from previous recordings.
-    @Deprecated
-    public static void resetService(ServiceTestRule mServiceRule, Context context) {
-        // Let's use default values.
-        PreferencesUtils.clear();
-    }
 
     static void sendGPSLocation(TrackPointCreator trackPointCreator, String time, double latitude, double longitude, float accuracy, long speed) {
         Location location = new Location("mock");

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -172,15 +172,10 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
             if (locationManager != null && !locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
                 startActivity(new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS));
             } else {
-                // Invoke trackRecordingService
-                if (!gpsStatusValue.isGpsStarted()) {
-                    trackRecordingServiceConnection.startAndBindWithCallback(this);
-                } else {
-                    TrackRecordingService trackRecordingService = trackRecordingServiceConnection.getServiceIfBound();
-                    if (trackRecordingService != null) {
-                        trackRecordingService.stopSensorsAndShutdown(); //TODO Handle this in TrackRecordingServiceConnection
-                    }
+                if (gpsStatusValue.isGpsStarted()) {
                     trackRecordingServiceConnection.unbindAndStop(this);
+                } else {
+                    trackRecordingServiceConnection.startAndBindWithCallback(this);
                 }
             }
         });

--- a/src/main/java/de/dennisguse/opentracks/sensors/BluetoothRemoteSensorManager.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/BluetoothRemoteSensorManager.java
@@ -47,7 +47,7 @@ import de.dennisguse.opentracks.util.PermissionRequester;
  *
  * @author Sandor Dornbush
  */
-public class BluetoothRemoteSensorManager implements SensorConnector, AbstractBluetoothConnectionManager.SensorDataObserver {
+public class BluetoothRemoteSensorManager implements SensorConnector, AbstractBluetoothConnectionManager.SensorDataObserver, SharedPreferences.OnSharedPreferenceChangeListener {
 
     private static final String TAG = BluetoothRemoteSensorManager.class.getSimpleName();
 
@@ -65,39 +65,6 @@ public class BluetoothRemoteSensorManager implements SensorConnector, AbstractBl
     private final BluetoothConnectionManagerCyclingPower cyclingPower = new BluetoothConnectionManagerCyclingPower(this);
     private final BluetoothConnectionRunningSpeedAndCadence runningSpeedAndCadence = new BluetoothConnectionRunningSpeedAndCadence(this);
 
-    private final SharedPreferences.OnSharedPreferenceChangeListener sharedPreferenceChangeListener = (sharedPreferences, key) -> {
-        if (!started) return;
-
-        if (PreferencesUtils.isKey(R.string.settings_sensor_bluetooth_heart_rate_key, key)) {
-            String address = PreferencesUtils.getBluetoothHeartRateSensorAddress();
-            connect(heartRate, address);
-        }
-
-        if (PreferencesUtils.isKey(R.string.settings_sensor_bluetooth_cycling_cadence_key, key)) {
-            String address = PreferencesUtils.getBluetoothCyclingCadenceSensorAddress();
-            connect(cyclingCadence, address);
-        }
-
-        if (PreferencesUtils.isKey(R.string.settings_sensor_bluetooth_cycling_speed_key, key)) {
-            String address = PreferencesUtils.getBluetoothCyclingSpeedSensorAddress();
-
-            connect(cyclingSpeed, address);
-        }
-
-        if (PreferencesUtils.isKey(R.string.settings_sensor_bluetooth_cycling_power_key, key)) {
-            String address = PreferencesUtils.getBluetoothCyclingPowerSensorAddress();
-
-            connect(cyclingPower, address);
-        }
-
-
-        if (PreferencesUtils.isKey(R.string.settings_sensor_bluetooth_running_speed_and_cadence_key, key)) {
-            String address = PreferencesUtils.getBluetoothRunningSpeedAndCadenceAddress();
-
-            connect(runningSpeedAndCadence, address);
-        }
-    };
-
     public BluetoothRemoteSensorManager(@NonNull Context context, @NonNull Handler handler, @Nullable SensorManager.SensorDataChangedObserver observer) {
         this.context = context;
         this.handler = handler;
@@ -109,8 +76,8 @@ public class BluetoothRemoteSensorManager implements SensorConnector, AbstractBl
     public void start(Context context, Handler handler) {
         started = true;
 
-        //Registering triggers connection startup
-        PreferencesUtils.registerOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
+        // Triggers connection startup
+        onSharedPreferenceChanged(null, null);
     }
 
     @Override
@@ -121,7 +88,6 @@ public class BluetoothRemoteSensorManager implements SensorConnector, AbstractBl
         cyclingPower.disconnect();
         runningSpeedAndCadence.disconnect();
 
-        PreferencesUtils.unregisterOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
         started = false;
     }
 
@@ -174,5 +140,38 @@ public class BluetoothRemoteSensorManager implements SensorConnector, AbstractBl
     @Override
     public Handler getHandler() {
         return handler;
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences unused, @Nullable String key) {
+        if (!started) return;
+
+        if (PreferencesUtils.isKey(R.string.settings_sensor_bluetooth_heart_rate_key, key)) {
+            String address = PreferencesUtils.getBluetoothHeartRateSensorAddress();
+            connect(heartRate, address);
+        }
+
+        if (PreferencesUtils.isKey(R.string.settings_sensor_bluetooth_cycling_cadence_key, key)) {
+            String address = PreferencesUtils.getBluetoothCyclingCadenceSensorAddress();
+            connect(cyclingCadence, address);
+        }
+
+        if (PreferencesUtils.isKey(R.string.settings_sensor_bluetooth_cycling_speed_key, key)) {
+            String address = PreferencesUtils.getBluetoothCyclingSpeedSensorAddress();
+
+            connect(cyclingSpeed, address);
+        }
+
+        if (PreferencesUtils.isKey(R.string.settings_sensor_bluetooth_cycling_power_key, key)) {
+            String address = PreferencesUtils.getBluetoothCyclingPowerSensorAddress();
+
+            connect(cyclingPower, address);
+        }
+
+        if (PreferencesUtils.isKey(R.string.settings_sensor_bluetooth_running_speed_and_cadence_key, key)) {
+            String address = PreferencesUtils.getBluetoothRunningSpeedAndCadenceAddress();
+
+            connect(runningSpeedAndCadence, address);
+        }
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/sensors/SensorManager.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/SensorManager.java
@@ -62,20 +62,14 @@ public class SensorManager implements SharedPreferences.OnSharedPreferenceChange
     }
 
     public void stop(Context context) {
-        if (bluetoothSensorManager != null) {
-            bluetoothSensorManager.stop(context);
-            bluetoothSensorManager = null;
-        }
+        bluetoothSensorManager.stop(context);
+        bluetoothSensorManager = null;
 
-        if (altitudeSumManager != null) {
-            altitudeSumManager.stop(context);
-            altitudeSumManager = null;
-        }
+        altitudeSumManager.stop(context);
+        altitudeSumManager = null;
 
-        if (gpsManager != null) {
-            gpsManager.stop(context);
-            gpsManager = null;
-        }
+        gpsManager.stop(context);
+        gpsManager = null;
 
         sensorDataSet.clear();
     }

--- a/src/main/java/de/dennisguse/opentracks/sensors/SensorManager.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/SensorManager.java
@@ -1,9 +1,11 @@
 package de.dennisguse.opentracks.sensors;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Handler;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import de.dennisguse.opentracks.data.models.TrackPoint;
@@ -12,7 +14,7 @@ import de.dennisguse.opentracks.sensors.sensorData.SensorDataSet;
 import de.dennisguse.opentracks.services.handlers.GPSManager;
 import de.dennisguse.opentracks.services.handlers.TrackPointCreator;
 
-public class SensorManager {
+public class SensorManager implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     private static final String TAG = SensorManager.class.getSimpleName();
 
@@ -49,11 +51,12 @@ public class SensorManager {
 
     public void start(Context context, Handler handler) {
         gpsManager = new GPSManager(observer); //TODO Pass listener
-        gpsManager.start(context, handler);
-
         altitudeSumManager = new AltitudeSumManager();
         bluetoothSensorManager = new BluetoothRemoteSensorManager(context, handler, listener);
 
+        onSharedPreferenceChanged(null, null);
+
+        gpsManager.start(context, handler);
         altitudeSumManager.start(context, handler);
         bluetoothSensorManager.start(context, handler);
     }
@@ -112,6 +115,14 @@ public class SensorManager {
     @VisibleForTesting
     public void setAltitudeSumManager(AltitudeSumManager altitudeSumManager) {
         this.altitudeSumManager = altitudeSumManager;
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, @Nullable String key) {
+        if (gpsManager != null) {
+            gpsManager.onSharedPreferenceChanged(sharedPreferences, key);
+            bluetoothSensorManager.onSharedPreferenceChanged(sharedPreferences, key);
+        }
     }
 
     public interface SensorDataChangedObserver {

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
@@ -58,14 +58,6 @@ class TrackRecordingManager implements SharedPreferences.OnSharedPreferenceChang
         contentProviderUtils = new ContentProviderUtils(context);
     }
 
-    public void start() {
-        PreferencesUtils.registerOnSharedPreferenceChangeListener(this);
-    }
-
-    public void stop() {
-        PreferencesUtils.unregisterOnSharedPreferenceChangeListener(this);
-    }
-
     Track.Id startNewTrack() {
         TrackPoint segmentStartTrackPoint = trackPointCreator.createSegmentStartManual();
         // Create new track

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceNotificationManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceNotificationManager.java
@@ -42,7 +42,6 @@ class TrackRecordingServiceNotificationManager implements SharedPreferences.OnSh
     private UnitSystem unitSystem = null;
 
     TrackRecordingServiceNotificationManager(Context context) {
-        PreferencesUtils.registerOnSharedPreferenceChangeListener(this);
         notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel notificationChannel = new NotificationChannel(CHANNEL_ID, context.getString(R.string.app_name), NotificationManager.IMPORTANCE_HIGH);
@@ -65,7 +64,6 @@ class TrackRecordingServiceNotificationManager implements SharedPreferences.OnSh
 
     void stop() {
         cancelNotification();
-        PreferencesUtils.unregisterOnSharedPreferenceChangeListener(this);
     }
 
     @VisibleForTesting

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -60,7 +60,6 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
 
     public VoiceAnnouncementManager(@NonNull TrackRecordingService trackRecordingService) {
         this.trackRecordingService = trackRecordingService;
-        PreferencesUtils.registerOnSharedPreferenceChangeListener(this);
     }
 
     public void start(@Nullable TrackStatistics trackStatistics) {
@@ -106,7 +105,6 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
     }
 
     public void stop() {
-        PreferencesUtils.unregisterOnSharedPreferenceChangeListener(this);
         if (voiceAnnouncement != null) {
             voiceAnnouncement.stop();
             voiceAnnouncement = null;

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/GPSManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/GPSManager.java
@@ -48,7 +48,8 @@ public class GPSManager implements SensorConnector, LocationListenerCompat, GpsS
         this.context = context;
         this.handler = handler;
 
-        PreferencesUtils.registerOnSharedPreferenceChangeListener(this);
+        onSharedPreferenceChanged(null, null);
+
         gpsStatusManager = new GpsStatusManager(context, this, handler);
         locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
         registerLocationListener();
@@ -62,20 +63,15 @@ public class GPSManager implements SensorConnector, LocationListenerCompat, GpsS
     @SuppressWarnings({"MissingPermission"})
     //TODO upgrade to AGP7.0.0/API31 started complaining about removeUpdates.
     public void stop(Context context) {
-        if (locationManager != null && context != null) {
-            if (PermissionRequester.GPS.hasPermission(context)) {
-                LocationManagerCompat.removeUpdates(locationManager, this);
-            }
-            locationManager = null;
-            context = null;
-            handler = null;
+        if (locationManager != null) {
+            LocationManagerCompat.removeUpdates(locationManager, this);
         }
+        locationManager = null;
+        this.context = null;
+        handler = null;
 
-        if (gpsStatusManager != null) {
-            gpsStatusManager.stop();
-            gpsStatusManager = null;
-        }
-        PreferencesUtils.unregisterOnSharedPreferenceChangeListener(this);
+        gpsStatusManager.stop();
+        gpsStatusManager = null;
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/GPSManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/GPSManager.java
@@ -31,7 +31,7 @@ public class GPSManager implements SensorConnector, LocationListenerCompat, GpsS
 
     private static final String LOCATION_PROVIDER = LocationManager.GPS_PROVIDER;
 
-    private final TrackPointCreator trackPointCreator;
+    private TrackPointCreator trackPointCreator;
     private Context context;
     private Handler handler;
 
@@ -71,6 +71,8 @@ public class GPSManager implements SensorConnector, LocationListenerCompat, GpsS
 
         gpsStatusManager.stop();
         gpsStatusManager = null;
+
+        trackPointCreator = null;
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/GpsStatusManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/GpsStatusManager.java
@@ -37,9 +37,6 @@ class GpsStatusManager {
     @Nullable
     private TrackPoint lastTrackPoint = null;
 
-    // Flag to prevent GpsStatus checks two or more locations at the same time.
-    private boolean checking = false;
-
     private Handler handler;
 
     public final Runnable gpsStatusTimer = () -> {
@@ -87,18 +84,10 @@ class GpsStatusManager {
      * Receive new trackPoint and calculate the new status if needed.
      * It look for GPS changes in lastLocation if it's not null. If it's null then look for in lastValidLocation if any.
      */
-    //TODO Remove checking; should be synchronized if this is a problem.
     public void onNewTrackPoint(@NonNull final TrackPoint trackPoint) {
-        if (checking) {
-            return;
-        }
-
-        checking = true;
         lastTrackPoint = trackPoint;
 
         determineGpsStatusOnTrackpoint(trackPoint);
-
-        checking = false;
     }
 
     /**

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/GpsStatusManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/GpsStatusManager.java
@@ -61,6 +61,7 @@ class GpsStatusManager {
      * The client that uses GpsStatus has to call this method to stop the Runnable if needed.
      */
     public void stop() {
+        stopTimer();
         client.onGpsStatusChanged(GpsStatusValue.GPS_NONE);
         client = null;
         handler = null;

--- a/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
+++ b/src/main/java/de/dennisguse/opentracks/services/handlers/TrackPointCreator.java
@@ -1,6 +1,7 @@
 package de.dennisguse.opentracks.services.handlers;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.location.Location;
 import android.os.Handler;
 import android.util.Log;
@@ -23,7 +24,7 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
 /**
  * Creates TrackPoints while recording by fusing data from different sensors (e.g., GNSS, barometer, BLE sensors).
  */
-public class TrackPointCreator {
+public class TrackPointCreator implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     private static final String TAG = TrackPointCreator.class.getSimpleName();
 
@@ -148,6 +149,11 @@ public class TrackPointCreator {
 
     void sendGpsStatus(GpsStatusValue gpsStatusValue) {
         service.newGpsStatus(gpsStatusValue);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, @Nullable String key) {
+        sensorManager.onSharedPreferenceChanged(sharedPreferences, key);
     }
 
     public interface Callback {


### PR DESCRIPTION
Follow-up to removal of "race condition"-prevention: e9f24f6bae351e2efe9911ec15e61a2ae1be5daa

Idea: crash as early as possible and stop hiding state errors.
NOTE: all operations should be happening in the same thread.

Some findings:
* all executions happen in the same thread (yeah)
* at least for tests
  * often LocationManager submits locations also `LocationManager.removeUpdates()` was called ending up in a destroyed TrackRecordingService
  * there might be more than one TrackRecordingService (used `hashCode()` to determine)
  * ... a dangling reference might a problem


More stuff will follow :D
