### PR TITLE
Pixeebot/Introduced protections against predictable RNG abuse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ android {
 
     defaultConfig {
         applicationId "de.dennisguse.opentracks"
-        versionCode 5389
-        versionName "v4.8.3"
+        versionCode 5399
+        versionName "v4.8.4"
 
         buildConfigField "String", "VERSION_NAME_FULL", "\"${getVersionName()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/5399.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5399.txt
@@ -1,0 +1,7 @@
+v4.8.4: OpenTracks
+
+Changes:
+- Show max power for recorded tracks
+
+Developer:
+- TrackList now uses RecyclerView

--- a/src/androidTest/java/de/dennisguse/opentracks/data/CustomContentProviderUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/data/CustomContentProviderUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package de.dennisguse.opentracks.data;
 
+import java.security.SecureRandom;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1212,7 +1213,7 @@ public class CustomContentProviderUtilsTest {
         // given
         Instant start = Instant.now();
         TestSensorDataUtil sensorDataUtil = new TestSensorDataUtil();
-        Random random = new Random();
+        Random random = new SecureRandom();
         for (int i = 0; i < totalPoints; i++) {
             int randomNum = withStartSegments ? random.nextInt(50) - 2 : 0;
             TrackPoint.Type type = randomNum >= 0 ? TrackPoint.Type.TRACKPOINT : TrackPoint.Type.getById(randomNum);


### PR DESCRIPTION
**Describe the pull request**
This change replaces all new instances of `java.util.Random` with the marginally slower, but much more secure `java.security.SecureRandom`.

We have to work pretty hard to get computers to generate genuinely unguessable random bits. The `java.util.Random` type uses a method of pseudo-random number generation that unfortunately emits fairly predictable numbers.

If the numbers it emits are predictable, then it's obviously not safe to use in cryptographic operations, file name creation, token construction, password generation, and anything else that's related to security. In fact, it may affect security even if it's not directly obvious.

Switching to a more secure version is simple and our changes all look something like this:

```diff
- Random r = new Random();
+ Random r = new java.security.SecureRandom();
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/vulnerabilities/Insecure_Randomness](https://owasp.org/www-community/vulnerabilities/Insecure_Randomness)
  * [https://metebalci.com/blog/everything-about-javas-securerandom/](https://metebalci.com/blog/everything-about-javas-securerandom/)
  * [https://cwe.mitre.org/data/definitions/330.html](https://cwe.mitre.org/data/definitions/330.html)
</details>

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/secure-random](https://docs.pixee.ai/codemods/java/pixee_java_secure-random)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Czcarroll4%2FOpenTracks%7C6490df72f7bccecb9533a017d6d8170a57f2ebc3)
