### PR TITLE
Switch order of literals to prevent NullPointerException 

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/util/StatisticsUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/util/StatisticsUtilsTest.java
@@ -57,12 +57,12 @@ public class StatisticsUtilsTest extends TestCase {
 
         // then
         assertEquals(resultTrue.getFields().size(), 3);
-        assertTrue(resultTrue.getFields().stream().anyMatch(f -> f.getKey().equals("key1")));
-        assertTrue(resultTrue.getFields().stream().anyMatch(f -> f.getKey().equals("key3")));
-        assertTrue(resultTrue.getFields().stream().anyMatch(f -> f.getKey().equals("key5")));
+        assertTrue(resultTrue.getFields().stream().anyMatch(f -> "key1".equals(f.getKey())));
+        assertTrue(resultTrue.getFields().stream().anyMatch(f -> "key3".equals(f.getKey())));
+        assertTrue(resultTrue.getFields().stream().anyMatch(f -> "key5".equals(f.getKey())));
 
         assertEquals(resultFalse.getFields().size(), 2);
-        assertTrue(resultFalse.getFields().stream().anyMatch(f -> f.getKey().equals("key2")));
-        assertTrue(resultFalse.getFields().stream().anyMatch(f -> f.getKey().equals("key4")));
+        assertTrue(resultFalse.getFields().stream().anyMatch(f -> "key2".equals(f.getKey())));
+        assertTrue(resultFalse.getFields().stream().anyMatch(f -> "key4".equals(f.getKey())));
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
@@ -489,7 +489,7 @@ public class KMLTrackExporter implements TrackExporter {
     }
 
     private void writeActivityType(String activityTypeLocalized) {
-        if (activityTypeLocalized == null || activityTypeLocalized.equals("")) {
+        if (activityTypeLocalized == null || "".equals(activityTypeLocalized)) {
             return;
         }
         printWriter.println("<ExtendedData>");

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlTrackImporter.java
@@ -402,7 +402,7 @@ public class KmlTrackImporter extends DefaultHandler implements XMLImporter.Trac
         Float value = null;
         if (content != null) {
             content = content.trim();
-            if (!content.equals("")) {
+            if (!"".equals(content)) {
                 try {
                     value = Float.parseFloat(content);
                 } catch (NumberFormatException e) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
@@ -231,7 +231,7 @@ public class KmzTrackImporter {
      */
     @Deprecated //TODO Use JDK9's inputStream.transferTo() instead of manual buffer
     private void readAndSaveImageFile(ZipInputStream zipInputStream, Track.Id trackId, String fileName) throws IOException {
-        if (trackId == null || fileName.equals("")) {
+        if (trackId == null || "".equals(fileName)) {
             return;
         }
 

--- a/src/main/java/de/dennisguse/opentracks/ui/TrackListAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/TrackListAdapter.java
@@ -244,7 +244,7 @@ public class TrackListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             String category = activityType == null ? activityTypeLocalized : null;
             String categoryDescription = StringUtils.getCategoryDescription(category, description);
             viewBinding.trackListItemCategoryDescription.setText(categoryDescription);
-            viewBinding.trackListItemCategoryDescription.setVisibility(categoryDescription.equals("") ? View.GONE : View.VISIBLE);
+            viewBinding.trackListItemCategoryDescription.setVisibility("".equals(categoryDescription) ? View.GONE : View.VISIBLE);
 
             setSelected(selection.get(getLayoutPosition()));
         }

--- a/src/main/java/de/dennisguse/opentracks/ui/customRecordingLayout/RecordingLayoutIO.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/customRecordingLayout/RecordingLayoutIO.java
@@ -44,8 +44,8 @@ public class RecordingLayoutIO {
     private static DataField fromCSV(String[] fieldParts, @NonNull Resources resources) {
         return new DataField(
                 fieldParts[0],
-                fieldParts[1].equals(YES_VALUE),
-                fieldParts[2].equals(YES_VALUE),
+                YES_VALUE.equals(fieldParts[1]),
+                YES_VALUE.equals(fieldParts[2]),
                 fieldParts[0].equals(resources.getString(R.string.stats_custom_layout_coordinates_key)));
     }
 


### PR DESCRIPTION
**Describe the pull request**
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [http://cwe.mitre.org/data/definitions/476.html](http://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Czcarroll4%2FOpenTracks%7C05e1f1ac09980b309ab83ed5fdc59ced854c5941)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->
