### PR TITLE
Re-enable Github Action executes tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,3 @@
-# We have flaky test results due to performance limitations in Github Actions.
-# Happens too often nowadays; See https://github.com/OpenTracksApp/OpenTracks/issues/1409
-
 #https://github.com/marketplace/actions/android-emulator-runner
 name: Test
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,27 +8,20 @@ jobs:
   test:
     timeout-minutes: 45
     runs-on: macos-latest
-    strategy:
-      matrix:
-        api-level: [ 24, 30 ]
-        target: [ default ]
-      fail-fast: false
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '11'
+          distribution: 'adopt'
+          java-version: '17'
 
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2.26.0
+        uses: reactivecircus/android-emulator-runner@v2.28.0
         with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
           arch: x86_64
-          profile: Nexus 6
+          api-level: 34
           script: ./gradlew connectedCheck
 
       - name: Archive


### PR DESCRIPTION
... we have missed to adjust some test in the recent past before merging PRs.
A flacky test execution is better than no test execution.