### PR TITLE
Fix broken TrackList UI tests

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/EspressoDeleteTrackTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/EspressoDeleteTrackTest.java
@@ -8,6 +8,8 @@ import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withParent;
+import static androidx.test.espresso.matcher.ViewMatchers.withParentIndex;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anything;
@@ -49,7 +51,7 @@ public class EspressoDeleteTrackTest {
         onView(withId(R.id.finish_button)).perform(click());
 
         // select track
-        onData(anything()).inAdapterView(withId(R.id.track_list)).atPosition(0).perform(longClick());
+        onView(allOf(withParent(withId(R.id.track_list)), withParentIndex(0))).perform(longClick());
 
         // open menu and delete selected track
         //TODO openActionBarOverflowOrOptionsMenu(); doesn't work

--- a/src/androidTest/java/de/dennisguse/opentracks/EspressoUITest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/EspressoUITest.java
@@ -8,6 +8,8 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isClickable;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withParent;
+import static androidx.test.espresso.matcher.ViewMatchers.withParentIndex;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anything;
 import static de.dennisguse.opentracks.util.EspressoUtils.selectTabAtIndex;
@@ -95,6 +97,6 @@ public class EspressoUITest {
     @Test
     public void selectAndDeleteTrack() {
         onView(withId(R.id.track_list)).check(matches(isDisplayed()));
-        onData(anything()).inAdapterView(withId(R.id.track_list)).atPosition(0).perform(longClick());
+        onView(allOf(withParent(withId(R.id.track_list)), withParentIndex(0))).perform(longClick());
     }
 }


### PR DESCRIPTION
We can just find the element by matching the first child of the RecyclerView.

Tested locally, since CI has some issues right now.

`selectAndDeleteTrack` does basically a subset of `espressoDeleteTrackTest`, so it probably can be deleted without changing the test coverage.
