### PR TITLE
Introduced ActivityType is now non-localized (i.e., English) value

### DIFF
--- a/doc/opentracks-schema-1.0.xsd
+++ b/doc/opentracks-schema-1.0.xsd
@@ -51,4 +51,13 @@
             </xsd:documentation>
         </xsd:annotation>
     </xsd:element>
+    <xsd:element name="typeTranslated"
+        type="xsd:string">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+                User-defined translation of GPX's <![CDATA[<type>]]>.
+                Only used in GPX.
+            </xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
 </xsd:schema>

--- a/src/androidTest/java/de/dennisguse/opentracks/data/CustomContentProviderUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/data/CustomContentProviderUtilsTest.java
@@ -47,7 +47,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.content.data.TestDataUtil;
 import de.dennisguse.opentracks.content.data.TestSensorDataUtil;
@@ -860,7 +859,7 @@ public class CustomContentProviderUtilsTest {
 
         List<TrackPoint.Id> trackpointIds = track.second.stream()
                 .map(it -> ContentUris.parseId(contentProviderUtils.insertTrackPoint(it, track.first.getId())))
-                .map(TrackPoint.Id::new).collect(Collectors.toList());
+                .map(TrackPoint.Id::new).toList();
 
         // when
         try (Cursor cursor = contentProviderUtils.getTrackPointCursor(trackId, trackpointIds.get(8))) {
@@ -878,7 +877,7 @@ public class CustomContentProviderUtilsTest {
 
         List<TrackPoint.Id> trackpointIds = track.second.stream()
                 .map(it -> ContentUris.parseId(contentProviderUtils.insertTrackPoint(it, track.first.getId())))
-                .map(TrackPoint.Id::new).collect(Collectors.toList());
+                .map(TrackPoint.Id::new).toList();
 
         TrackPoint.Id startTrackPointId = trackpointIds.get(0);
 

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/ExportImportTest.java
@@ -309,10 +309,10 @@ public class ExportImportTest {
         // 1. track
         Track importedTrack = contentProviderUtils.getTrack(importTrackId);
         assertNotNull(importedTrack);
+        assertEquals(track.getActivityType(), importedTrack.getActivityType());
         assertEquals(track.getActivityTypeLocalized(), importedTrack.getActivityTypeLocalized());
         assertEquals(track.getDescription(), importedTrack.getDescription());
         assertEquals(track.getName(), importedTrack.getName());
-        assertEquals(track.getActivityType(), importedTrack.getActivityType());
 
         // 2. trackpoints
         TrackPointAssert a = new TrackPointAssert();
@@ -380,12 +380,10 @@ public class ExportImportTest {
         // 1. track
         Track importedTrack = contentProviderUtils.getTrack(importTrackId);
         assertNotNull(importedTrack);
+        assertEquals(track.getActivityType(), importedTrack.getActivityType());
         assertEquals(track.getActivityTypeLocalized(), importedTrack.getActivityTypeLocalized());
         assertEquals(track.getDescription(), importedTrack.getDescription());
         assertEquals(track.getName(), importedTrack.getName());
-
-        //TODO exporting and importing a track icon is not yet supported by GpxTrackWriter.
-        //assertEquals(track.getIcon(), importedTrack.getIcon());
 
         // 2. trackpoints
         // The GPX exporter does not support exporting TrackPoints without lat/lng.

--- a/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/GPXTrackImporterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/io/file/importer/GPXTrackImporterTest.java
@@ -80,6 +80,7 @@ public class GPXTrackImporterTest {
         // 2. track
         Track importedTrack = contentProviderUtils.getTrack(importTrackId);
         assertNotNull(importedTrack);
+        assertEquals(ActivityType.UNKNOWN, importedTrack.getActivityType());
         assertEquals("the category", importedTrack.getActivityTypeLocalized());
         assertEquals("the description", importedTrack.getDescription());
         assertEquals("2021-01-07 22:51", importedTrack.getName());

--- a/src/androidTest/res/raw/gpx_timezone.gpx
+++ b/src/androidTest/res/raw/gpx_timezone.gpx
@@ -21,10 +21,11 @@ xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/
 <trk>
 <name><![CDATA[2021-01-07 22:51]]></name>
 <desc><![CDATA[the description]]></desc>
-<type><![CDATA[the category]]></type>
+<type><![CDATA[unknown]]></type>
 <extensions>
 <topografix:color>c0c0c0</topografix:color>
 <opentracks:trackid>7002101e-4198-4613-8c24-544e01ca3981</opentracks:trackid>
+<opentracks:typeTranslated><![CDATA[unknown]]></opentracks:typeTranslated>
 <gpxtrkx:TrackStatsExtension>
 <gpxtrkx:Distance>0.0</gpxtrkx:Distance>
 <gpxtrkx:TimerTime>0</gpxtrkx:TimerTime>

--- a/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
@@ -101,6 +101,7 @@ public class ContentProviderUtils {
         int uuidIndex = cursor.getColumnIndexOrThrow(TracksColumns.UUID);
         int nameIndex = cursor.getColumnIndexOrThrow(TracksColumns.NAME);
         int descriptionIndex = cursor.getColumnIndexOrThrow(TracksColumns.DESCRIPTION);
+        int activityTypeIndex = cursor.getColumnIndexOrThrow(TracksColumns.ACTIVITY_TYPE);
         int activityTypeLocalizedIndex = cursor.getColumnIndexOrThrow(TracksColumns.ACTIVITY_TYPE_LOCALIZED);
         int startTimeIndex = cursor.getColumnIndexOrThrow(TracksColumns.STARTTIME);
         int startTimeOffsetIndex = cursor.getColumnIndexOrThrow(TracksColumns.STARTTIME_OFFSET);
@@ -113,7 +114,6 @@ public class ContentProviderUtils {
         int maxAltitudeIndex = cursor.getColumnIndexOrThrow(TracksColumns.MAX_ALTITUDE);
         int altitudeGainIndex = cursor.getColumnIndexOrThrow(TracksColumns.ALTITUDE_GAIN);
         int altitudeLossIndex = cursor.getColumnIndexOrThrow(TracksColumns.ALTITUDE_LOSS);
-        int iconIndex = cursor.getColumnIndexOrThrow(TracksColumns.ICON);
 
         Track track = new Track(ZoneOffset.ofTotalSeconds(cursor.getInt(startTimeOffsetIndex)));
         TrackStatistics trackStatistics = track.getTrackStatistics();
@@ -128,6 +128,9 @@ public class ContentProviderUtils {
         }
         if (!cursor.isNull(descriptionIndex)) {
             track.setDescription(cursor.getString(descriptionIndex));
+        }
+        if (!cursor.isNull(activityTypeIndex)) {
+            track.setActivityType(ActivityType.findBy(cursor.getString(activityTypeIndex)));
         }
         if (!cursor.isNull(activityTypeLocalizedIndex)) {
             track.setActivityTypeLocalized(cursor.getString(activityTypeLocalizedIndex));
@@ -163,9 +166,7 @@ public class ContentProviderUtils {
         if (!cursor.isNull(altitudeLossIndex)) {
             trackStatistics.setTotalAltitudeLoss(cursor.getFloat(altitudeLossIndex));
         }
-        if (!cursor.isNull(iconIndex)) {
-            track.setActivityType(ActivityType.findBy(cursor.getString(iconIndex)));
-        }
+
         return track;
     }
 
@@ -230,13 +231,18 @@ public class ContentProviderUtils {
 
     public Cursor searchTracks(String searchQuery) {
         // Needed, because MARKER_COUNT is a virtual column and has to be explicitly requested.
-        final String[] PROJECTION = new String[]{TracksColumns._ID, TracksColumns.UUID, TracksColumns.NAME,
-                TracksColumns.DESCRIPTION, TracksColumns.ACTIVITY_TYPE_LOCALIZED, TracksColumns.STARTTIME,
-                TracksColumns.STARTTIME_OFFSET, TracksColumns.STOPTIME, TracksColumns.MARKER_COUNT,
-                TracksColumns.TOTALDISTANCE, TracksColumns.TOTALTIME, TracksColumns.MOVINGTIME,
-                TracksColumns.AVGSPEED, TracksColumns.AVGMOVINGSPEED, TracksColumns.MAXSPEED,
-                TracksColumns.MIN_ALTITUDE, TracksColumns.MAX_ALTITUDE, TracksColumns.ALTITUDE_GAIN,
-                TracksColumns.ALTITUDE_LOSS, TracksColumns.ICON
+        // Used only be TrackListAdapter
+        final String[] PROJECTION = new String[]{
+                TracksColumns._ID,
+                TracksColumns.NAME,
+                TracksColumns.DESCRIPTION, //TODO Needed?
+                TracksColumns.ACTIVITY_TYPE,
+                TracksColumns.ACTIVITY_TYPE_LOCALIZED,
+                TracksColumns.STARTTIME,
+                TracksColumns.STARTTIME_OFFSET,
+                TracksColumns.TOTALDISTANCE,
+                TracksColumns.TOTALTIME,
+                TracksColumns.MARKER_COUNT,
         };
 
         String selection = null;
@@ -316,6 +322,7 @@ public class ContentProviderUtils {
         values.put(TracksColumns.UUID, UUIDUtils.toBytes(track.getUuid()));
         values.put(TracksColumns.NAME, track.getName());
         values.put(TracksColumns.DESCRIPTION, track.getDescription());
+        values.put(TracksColumns.ACTIVITY_TYPE, track.getActivityType() != null ? track.getActivityType().getId() : null);
         values.put(TracksColumns.ACTIVITY_TYPE_LOCALIZED, track.getActivityTypeLocalized());
         values.put(TracksColumns.STARTTIME_OFFSET, track.getZoneOffset().getTotalSeconds());
         if (trackStatistics.getStartTime() != null) {
@@ -334,7 +341,6 @@ public class ContentProviderUtils {
         values.put(TracksColumns.MAX_ALTITUDE, trackStatistics.getMaxAltitude());
         values.put(TracksColumns.ALTITUDE_GAIN, trackStatistics.getTotalAltitudeGain());
         values.put(TracksColumns.ALTITUDE_LOSS, trackStatistics.getTotalAltitudeLoss());
-        values.put(TracksColumns.ICON, track.getActivityType() != null ? track.getActivityType().getIconId() : "");
 
         return values;
     }

--- a/src/main/java/de/dennisguse/opentracks/data/models/ActivityIcon.java
+++ b/src/main/java/de/dennisguse/opentracks/data/models/ActivityIcon.java
@@ -2,35 +2,8 @@ package de.dennisguse.opentracks.data.models;
 
 import de.dennisguse.opentracks.R;
 
-public enum ActivityIcon {
-    AIRPLANE("AIRPLANE", R.drawable.ic_activity_flight_24dp),
-    BIKE("BIKE", R.drawable.ic_activity_bike_24dp),
-    MOUNTAIN_BIKE("MOUNTAIN_BIKE", R.drawable.ic_activity_mtb_24dp),
-    MOTOR_BIKE("MOTOR_BIKE", R.drawable.ic_activity_motorbike_24dp),
-    KAYAK("KAYAK", R.drawable.ic_activity_kayaking_24dp),
-    BOAT("BOAT", R.drawable.ic_activity_boat_24dp),
-    SAILING("SAILING", R.drawable.ic_activity_sailing_24dp),
-    DRIVE("DRIVE", R.drawable.ic_activity_drive_24dp),
-    RUN("RUN", R.drawable.ic_activity_run_24dp),
-    SKI("SKI", R.drawable.ic_activity_skiing_24dp),
-    SNOW_BOARDING("SNOW_BOARDING", R.drawable.ic_activity_snowboarding_24dp),
-    UNKNOWN("UNKNOWN", R.drawable.ic_logo_24dp),
-    WALK("WALK", R.drawable.ic_activity_walk_24dp),
-    ESCOOTER("ESCOOTER", R.drawable.ic_activity_escooter_24dp),
-    KICKSCOOTER("KICKSCOOTER", R.drawable.ic_activity_scooter_24dp),
-    INLINE_SKATING("INLINES_SKATING", R.drawable.ic_activity_inline_skating_24dp),
-    SKATE_BOARDING("SKATE_BOARDING", R.drawable.ic_activity_skateboarding_24dp),
-    CLIMBING("CLIMBING", R.drawable.ic_activity_climbing_24dp),
-    SWIMMING("SWIMMING", R.drawable.ic_activity_swimming_24dp),
-    SWIMMING_OPEN("SWIMMING_OPEN", R.drawable.ic_activity_swimming_open_24dp),
-    WORKOUT("WORKOUT", R.drawable.ic_activity_workout_24dp);
+public class ActivityIcon {
 
-    @Deprecated //TODO should be removed.
-    final String iconId;
-    final int iconDrawableId;
+    static final int ICON_UNKNOWN = R.drawable.ic_logo_24dp;
 
-    ActivityIcon(String iconId, int iconDrawableId) {
-        this.iconId = iconId;
-        this.iconDrawableId = iconDrawableId;
-    }
 }

--- a/src/main/java/de/dennisguse/opentracks/data/models/ActivityType.java
+++ b/src/main/java/de/dennisguse/opentracks/data/models/ActivityType.java
@@ -12,88 +12,88 @@ import de.dennisguse.opentracks.R;
 
 public enum ActivityType {
 
-    AIRPLANE("airplane", R.string.activity_type_airplane, ActivityIcon.AIRPLANE, true),
-    ATV("ATV", R.string.activity_type_atv, ActivityIcon.DRIVE, true),
-    BIKING("biking", R.string.activity_type_biking, ActivityIcon.BIKE, true),
-    BLIMP("blimp", R.string.activity_type_blimp, ActivityIcon.UNKNOWN, true),
-    BOAT("boat", R.string.activity_type_boat, ActivityIcon.BOAT, true),
-    CLIMBING("climbing", R.string.activity_type_climbing, ActivityIcon.CLIMBING, false),
-    COMMERCIAL_AIRPLANE("commercial airplane", R.string.activity_type_commercial_airplane, ActivityIcon.AIRPLANE, true),
-    CROSS_COUNTRY_SKIING("cross-country skiing", R.string.activity_type_cross_country_skiing, ActivityIcon.SKI, true),
-    CYCLING("cycling", R.string.activity_type_cycling, ActivityIcon.BIKE, true),
-    DIRT_BIKE("dirt bike", R.string.activity_type_dirt_bike, ActivityIcon.MOTOR_BIKE, true),
-    DONKEY_BACK_RIDING("donkey back riding", R.string.activity_type_donkey_back_riding, ActivityIcon.UNKNOWN, true),
-    DRIVING("driving", R.string.activity_type_driving, ActivityIcon.DRIVE, true),
-    DRIVING_BUS("driving bus", R.string.activity_type_driving_bus, ActivityIcon.DRIVE, true),
-    DRIVING_CAR("driving car", R.string.activity_type_driving_car, ActivityIcon.DRIVE, true),
-    ESCOOTER("escooter", R.string.activity_type_escooter, ActivityIcon.ESCOOTER, true),
-    FERRY("ferry", R.string.activity_type_ferry, ActivityIcon.BOAT, true),
-    FRISBEE("frisbee", R.string.activity_type_frisbee, ActivityIcon.UNKNOWN, true),
-    GLIDING("gliding", R.string.activity_type_gliding, ActivityIcon.UNKNOWN, true),
-    HANG_GLIDING("hang gliding", R.string.activity_type_hang_gliding, ActivityIcon.UNKNOWN, true),
-    HELICOPTER("helicopter", R.string.activity_type_helicopter, ActivityIcon.UNKNOWN, true),
-    HIKING("hiking", R.string.activity_type_hiking, ActivityIcon.WALK, false),
-    HORSE_BACK_RIDING("horse back riding", R.string.activity_type_horse_back_riding, ActivityIcon.UNKNOWN, true),
-    HOT_AIR_BALLOON("hot air balloon", R.string.activity_type_hot_air_balloon, ActivityIcon.UNKNOWN, true),
-    ICE_SAILING("ice sailing", R.string.activity_type_ice_sailing, ActivityIcon.UNKNOWN, true),
-    INLINE_SKATING("inline skating", R.string.activity_type_inline_skating, ActivityIcon.INLINE_SKATING, true),
-    KAYAKING("kayaking", R.string.activity_type_kayaking, ActivityIcon.KAYAK, true),
-    KITE_SURFING("kite surfing", R.string.activity_type_kite_surfing, ActivityIcon.UNKNOWN, true),
-    LAND_SAILING("land sailing", R.string.activity_type_land_sailing, ActivityIcon.UNKNOWN, true),
-    MIXED_TYPE("mixed type", R.string.activity_type_mixed_type, ActivityIcon.UNKNOWN, true),
-    MOTOR_BIKE("motor bike", R.string.activity_type_motor_bike, ActivityIcon.MOTOR_BIKE, true),
-    MOTOR_BOATING("motor boating", R.string.activity_type_motor_boating, ActivityIcon.BOAT, true),
-    MOUNTAIN_BIKING("mountain biking", R.string.activity_type_mountain_biking, ActivityIcon.MOUNTAIN_BIKE, true),
-    OFF_TRAIL_HIKING("off trail hiking", R.string.activity_type_hiking, ActivityIcon.WALK, false),
-    OTHER("other", R.string.activity_type_other, ActivityIcon.UNKNOWN, true),
-    PADDLING("paddling", R.string.activity_type_paddling, ActivityIcon.UNKNOWN, true),
-    PARA_GLIDING("para gliding", R.string.activity_type_para_gliding, ActivityIcon.UNKNOWN, true),
-    RC_AIRPLANE("RC airplane", R.string.activity_type_rc_airplane, ActivityIcon.AIRPLANE, true),
-    RC_BOAT("RC boat", R.string.activity_type_rc_boat, ActivityIcon.BOAT, true),
-    RC_HELICOPTER("RC helicopter", R.string.activity_type_rc_helicopter, ActivityIcon.UNKNOWN, true),
-    RIDING("riding", R.string.activity_type_horse_back_riding, ActivityIcon.UNKNOWN, true),
-    ROAD_BIKING("road biking", R.string.activity_type_road_biking, ActivityIcon.BIKE, true),
-    ROLLER_SKIING("roller skiing", R.string.activity_type_roller_skiing, ActivityIcon.UNKNOWN, true),
-    ROWING("rowing", R.string.activity_type_rowing, ActivityIcon.UNKNOWN, true),
-    RUNNING("running", R.string.activity_type_running, ActivityIcon.RUN, false),
-    SAILING("sailing", R.string.activity_type_sailing, ActivityIcon.SAILING, true),
-    KICKSCOOTER("kickscooter", R.string.activity_type_kickscooter, ActivityIcon.KICKSCOOTER, true),
-    SEAPLANE("seaplane", R.string.activity_type_seaplane, ActivityIcon.AIRPLANE, true),
-    SKATE_BOARDING("skate boarding", R.string.activity_type_skate_boarding, ActivityIcon.SKATE_BOARDING, true),
-    SKATING("skating", R.string.activity_type_skating, ActivityIcon.UNKNOWN, true),
-    SKIING("skiing", R.string.activity_type_skiing, ActivityIcon.SKI, true),
-    SKY_JUMPING("sky jumping", R.string.activity_type_sky_jumping, ActivityIcon.UNKNOWN, true),
-    SLED("sled", R.string.activity_type_sled, ActivityIcon.UNKNOWN, true),
-    SNOW_BOARDING("snow boarding", R.string.activity_type_snow_boarding, ActivityIcon.SNOW_BOARDING, true),
-    SNOW_SHOEING("snow shoeing", R.string.activity_type_snow_shoeing, ActivityIcon.UNKNOWN, true),
-    SPEED_WALKING("speed walking", R.string.activity_type_speed_walking, ActivityIcon.WALK, false),
-    STREET_RUNNING("street running", R.string.activity_type_street_running, ActivityIcon.RUN, false),
-    SURFING("surfing", R.string.activity_type_surfing, ActivityIcon.UNKNOWN, true),
-    TRACK_CYCLING("track cycling", R.string.activity_type_track_cycling, ActivityIcon.BIKE, true),
-    TRACK_RUNNING("track running", R.string.activity_type_trail_running, ActivityIcon.RUN, false),
-    TRAIL_HIKING("trail hiking", R.string.activity_type_trail_hiking, ActivityIcon.WALK, false),
-    TRAIL_RUNNING("trail running", R.string.activity_type_trail_running, ActivityIcon.RUN, false),
-    TRAIN("train", R.string.activity_type_train, ActivityIcon.UNKNOWN, true),
-    ULTIMATE_FRISBEE("ultimate frisbee", R.string.activity_type_ultimate_frisbee, ActivityIcon.UNKNOWN, true),
-    WAKEBOARDING("wakeboarding", R.string.activity_type_wakeboarding, ActivityIcon.UNKNOWN, true),
-    WALKING("walking", R.string.activity_type_walking, ActivityIcon.WALK, false),
-    WATER_SKIING("water skiing", R.string.activity_type_water_skiing, ActivityIcon.UNKNOWN, true),
-    WIND_SURFING("wind surfing", R.string.activity_type_wind_surfing, ActivityIcon.UNKNOWN, true),
-    SWIMMING("swimming", R.string.activity_type_swimming, ActivityIcon.SWIMMING, false),
-    SWIMMING_OPEN("swimming in open water", R.string.activity_type_swimming_open, ActivityIcon.SWIMMING_OPEN, false),
-    WORKOUT("workout", R.string.activity_type_workout, ActivityIcon.WORKOUT, false),
-    UNKNOWN("unknown", R.string.activity_type_unknown, ActivityIcon.UNKNOWN, true);
+    AIRPLANE("airplane", R.string.activity_type_airplane, R.drawable.ic_activity_flight_24dp, true),
+    ATV("ATV", R.string.activity_type_atv,  R.drawable.ic_activity_drive_24dp, true),
+    BIKING("biking", R.string.activity_type_biking, R.drawable.ic_activity_bike_24dp, true),
+    BLIMP("blimp", R.string.activity_type_blimp, ActivityIcon.ICON_UNKNOWN, true),
+    BOAT("boat", R.string.activity_type_boat, R.drawable.ic_activity_boat_24dp, true),
+    CLIMBING("climbing", R.string.activity_type_climbing, R.drawable.ic_activity_climbing_24dp, false),
+    COMMERCIAL_AIRPLANE("commercial airplane", R.string.activity_type_commercial_airplane, R.drawable.ic_activity_flight_24dp, true),
+    CROSS_COUNTRY_SKIING("cross-country skiing", R.string.activity_type_cross_country_skiing, R.drawable.ic_activity_skiing_24dp, true),
+    CYCLING("cycling", R.string.activity_type_cycling, R.drawable.ic_activity_bike_24dp, true),
+    DIRT_BIKE("dirt bike", R.string.activity_type_dirt_bike, R.drawable.ic_activity_mtb_24dp, true),
+    DONKEY_BACK_RIDING("donkey back riding", R.string.activity_type_donkey_back_riding, ActivityIcon.ICON_UNKNOWN, true),
+    DRIVING("driving", R.string.activity_type_driving,  R.drawable.ic_activity_drive_24dp, true),
+    DRIVING_BUS("driving bus", R.string.activity_type_driving_bus,  R.drawable.ic_activity_drive_24dp, true),
+    DRIVING_CAR("driving car", R.string.activity_type_driving_car,  R.drawable.ic_activity_drive_24dp, true),
+    ESCOOTER("escooter", R.string.activity_type_escooter, R.drawable.ic_activity_escooter_24dp, true),
+    FERRY("ferry", R.string.activity_type_ferry, R.drawable.ic_activity_boat_24dp, true),
+    FRISBEE("frisbee", R.string.activity_type_frisbee, ActivityIcon.ICON_UNKNOWN, true),
+    GLIDING("gliding", R.string.activity_type_gliding, ActivityIcon.ICON_UNKNOWN, true),
+    HANG_GLIDING("hang gliding", R.string.activity_type_hang_gliding, ActivityIcon.ICON_UNKNOWN, true),
+    HELICOPTER("helicopter", R.string.activity_type_helicopter, ActivityIcon.ICON_UNKNOWN, true),
+    HIKING("hiking", R.string.activity_type_hiking, R.drawable.ic_activity_walk_24dp, false),
+    HORSE_BACK_RIDING("horse back riding", R.string.activity_type_horse_back_riding, ActivityIcon.ICON_UNKNOWN, true),
+    HOT_AIR_BALLOON("hot air balloon", R.string.activity_type_hot_air_balloon, ActivityIcon.ICON_UNKNOWN, true),
+    ICE_SAILING("ice sailing", R.string.activity_type_ice_sailing, ActivityIcon.ICON_UNKNOWN, true),
+    INLINE_SKATING("inline skating", R.string.activity_type_inline_skating, R.drawable.ic_activity_inline_skating_24dp, true),
+    KAYAKING("kayaking", R.string.activity_type_kayaking, R.drawable.ic_activity_mtb_24dp, true),
+    KITE_SURFING("kite surfing", R.string.activity_type_kite_surfing, ActivityIcon.ICON_UNKNOWN, true),
+    LAND_SAILING("land sailing", R.string.activity_type_land_sailing, ActivityIcon.ICON_UNKNOWN, true),
+    MIXED_TYPE("mixed type", R.string.activity_type_mixed_type, ActivityIcon.ICON_UNKNOWN, true),
+    MOTOR_BIKE("motor bike", R.string.activity_type_motor_bike, R.drawable.ic_activity_mtb_24dp, true),
+    MOTOR_BOATING("motor boating", R.string.activity_type_motor_boating, R.drawable.ic_activity_boat_24dp, true),
+    MOUNTAIN_BIKING("mountain biking", R.string.activity_type_mountain_biking, R.drawable.ic_activity_mtb_24dp, true),
+    OFF_TRAIL_HIKING("off trail hiking", R.string.activity_type_hiking, R.drawable.ic_activity_walk_24dp, false),
+    OTHER("other", R.string.activity_type_other, ActivityIcon.ICON_UNKNOWN, true),
+    PADDLING("paddling", R.string.activity_type_paddling, ActivityIcon.ICON_UNKNOWN, true),
+    PARA_GLIDING("para gliding", R.string.activity_type_para_gliding, ActivityIcon.ICON_UNKNOWN, true),
+    RC_AIRPLANE("RC airplane", R.string.activity_type_rc_airplane, R.drawable.ic_activity_flight_24dp, true),
+    RC_BOAT("RC boat", R.string.activity_type_rc_boat, R.drawable.ic_activity_boat_24dp, true),
+    RC_HELICOPTER("RC helicopter", R.string.activity_type_rc_helicopter, ActivityIcon.ICON_UNKNOWN, true),
+    RIDING("riding", R.string.activity_type_horse_back_riding, ActivityIcon.ICON_UNKNOWN, true),
+    ROAD_BIKING("road biking", R.string.activity_type_road_biking, R.drawable.ic_activity_bike_24dp, true),
+    ROLLER_SKIING("roller skiing", R.string.activity_type_roller_skiing, ActivityIcon.ICON_UNKNOWN, true),
+    ROWING("rowing", R.string.activity_type_rowing, ActivityIcon.ICON_UNKNOWN, true),
+    RUNNING("running", R.string.activity_type_running, R.drawable.ic_activity_run_24dp, false),
+    SAILING("sailing", R.string.activity_type_sailing, R.drawable.ic_activity_sailing_24dp, true),
+    KICKSCOOTER("kickscooter", R.string.activity_type_kickscooter, R.drawable.ic_activity_scooter_24dp, true),
+    SEAPLANE("seaplane", R.string.activity_type_seaplane, R.drawable.ic_activity_flight_24dp, true),
+    SKATE_BOARDING("skateboarding", R.string.activity_type_skate_boarding, R.drawable.ic_activity_skateboarding_24dp, true),
+    SKATING("skating", R.string.activity_type_skating, ActivityIcon.ICON_UNKNOWN, true),
+    SKIING("skiing", R.string.activity_type_skiing, R.drawable.ic_activity_skiing_24dp, true),
+    SKY_JUMPING("sky jumping", R.string.activity_type_sky_jumping, ActivityIcon.ICON_UNKNOWN, true),
+    SLED("sled", R.string.activity_type_sled, ActivityIcon.ICON_UNKNOWN, true),
+    SNOW_BOARDING("snowboarding", R.string.activity_type_snow_boarding, R.drawable.ic_activity_snowboarding_24dp, true),
+    SNOW_SHOEING("snow shoeing", R.string.activity_type_snow_shoeing, ActivityIcon.ICON_UNKNOWN, true),
+    SPEED_WALKING("speed walking", R.string.activity_type_speed_walking, R.drawable.ic_activity_walk_24dp, false),
+    STREET_RUNNING("street running", R.string.activity_type_street_running, R.drawable.ic_activity_run_24dp, false),
+    SURFING("surfing", R.string.activity_type_surfing, ActivityIcon.ICON_UNKNOWN, true),
+    TRACK_CYCLING("track cycling", R.string.activity_type_track_cycling, R.drawable.ic_activity_bike_24dp, true),
+    TRACK_RUNNING("track running", R.string.activity_type_trail_running, R.drawable.ic_activity_run_24dp, false),
+    TRAIL_HIKING("trail hiking", R.string.activity_type_trail_hiking, R.drawable.ic_activity_walk_24dp, false),
+    TRAIL_RUNNING("trail running", R.string.activity_type_trail_running, R.drawable.ic_activity_run_24dp, false),
+    TRAIN("train", R.string.activity_type_train, ActivityIcon.ICON_UNKNOWN, true),
+    ULTIMATE_FRISBEE("ultimate frisbee", R.string.activity_type_ultimate_frisbee, ActivityIcon.ICON_UNKNOWN, true),
+    WAKEBOARDING("wakeboarding", R.string.activity_type_wakeboarding, ActivityIcon.ICON_UNKNOWN, true),
+    WALKING("walking", R.string.activity_type_walking, R.drawable.ic_activity_walk_24dp, false),
+    WATER_SKIING("water skiing", R.string.activity_type_water_skiing, ActivityIcon.ICON_UNKNOWN, true),
+    WIND_SURFING("wind surfing", R.string.activity_type_wind_surfing, ActivityIcon.ICON_UNKNOWN, true),
+    SWIMMING("swimming", R.string.activity_type_swimming, R.drawable.ic_activity_swimming_24dp, false),
+    SWIMMING_OPEN("swimming in open water", R.string.activity_type_swimming_open, R.drawable.ic_activity_swimming_open_24dp, false),
+    WORKOUT("workout", R.string.activity_type_workout, R.drawable.ic_activity_workout_24dp, false),
+    UNKNOWN("unknown", R.string.activity_type_unknown, ActivityIcon.ICON_UNKNOWN, true);
 
     final String id;
 
-    final ActivityIcon icon;
+    final int iconDrawableId;
     final boolean showSpeedPreferred;
     final int localizedStringId;
 
-    ActivityType(String id, int localizedStringId, ActivityIcon icon, boolean showSpeedPreferred) {
+    ActivityType(String id, int localizedStringId, int iconDrawableId, boolean showSpeedPreferred) {
         this.id = id;
         this.localizedStringId = localizedStringId;
-        this.icon = icon;
+        this.iconDrawableId = iconDrawableId;
         this.showSpeedPreferred = showSpeedPreferred;
     }
 
@@ -101,13 +101,8 @@ public enum ActivityType {
         return id;
     }
 
-    @Deprecated
-    public String getIconId() {
-        return icon.iconId;
-    }
-
     public int getIconDrawableId() {
-        return icon.iconDrawableId;
+        return iconDrawableId;
     }
 
     public int getLocalizedStringId() {
@@ -126,12 +121,9 @@ public enum ActivityType {
     }
 
     @NonNull
-    public static ActivityType findBy(String iconId) {
-        if (ActivityIcon.UNKNOWN.iconId.equals(iconId)) {
-            return ActivityType.UNKNOWN;
-        }
+    public static ActivityType findBy(String activityTypeId) {
         return Arrays.stream(ActivityType.values()).filter(
-                        it -> it.icon.iconId.equals(iconId)
+                        it -> it.id.equals(activityTypeId)
                 ).findFirst()
                 .orElse(ActivityType.UNKNOWN);
     }

--- a/src/main/java/de/dennisguse/opentracks/data/models/ActivityType.java
+++ b/src/main/java/de/dennisguse/opentracks/data/models/ActivityType.java
@@ -7,7 +7,6 @@ import androidx.annotation.NonNull;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.R;
 
@@ -123,7 +122,7 @@ public enum ActivityType {
         return Arrays.stream(values())
                 .map(ActivityType::getLocalizedStringId)
                 .map(context::getString)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @NonNull

--- a/src/main/java/de/dennisguse/opentracks/data/models/Track.java
+++ b/src/main/java/de/dennisguse/opentracks/data/models/Track.java
@@ -101,8 +101,8 @@ public class Track {
         return activityTypeLocalized;
     }
 
-    public void setActivityTypeLocalized(String activityType) {
-        this.activityTypeLocalized = activityType;
+    public void setActivityTypeLocalized(String activityTypeLocalized) {
+        this.activityTypeLocalized = activityTypeLocalized;
     }
 
     public ActivityType getActivityType() {

--- a/src/main/java/de/dennisguse/opentracks/data/tables/TracksColumns.java
+++ b/src/main/java/de/dennisguse/opentracks/data/tables/TracksColumns.java
@@ -39,7 +39,11 @@ public interface TracksColumns extends BaseColumns {
     String UUID = "uuid"; // identifier to make tracks globally unique (prevent re-import)
     String NAME = "name"; // track name
     String DESCRIPTION = "description"; // track description
+    /** see {@link de.dennisguse.opentracks.data.models.ActivityType}.id */
+    String ACTIVITY_TYPE = "activity_type";
     String ACTIVITY_TYPE_LOCALIZED = "category"; // track activity type
+    @Deprecated
+    String ICON = "icon"; // track activity type icon
     String STARTTIME = "starttime"; // track start time
     String STARTTIME_OFFSET = "starttime_offset"; // in plus/minus in seconds
     String STOPTIME = "stoptime"; // track stop time
@@ -57,7 +61,6 @@ public interface TracksColumns extends BaseColumns {
     String MAX_ALTITUDE = "maxelevation"; // maximum altitude //TODO RENAME column
     String ALTITUDE_GAIN = "elevationgain"; // altitude gain //TODO RENAME column
     String ALTITUDE_LOSS = "elevationloss"; // altitude loss //TODO RENAME column
-    String ICON = "icon"; // track activity type icon //TODO DEPRECATED
 
     String CREATE_TABLE = "CREATE TABLE " + TABLE_NAME + " ("
             + _ID + " INTEGER PRIMARY KEY AUTOINCREMENT, "
@@ -79,7 +82,8 @@ public interface TracksColumns extends BaseColumns {
             + ICON + " TEXT, "
             + UUID + " BLOB, "
             + ALTITUDE_LOSS + " FLOAT, "
-            + STARTTIME_OFFSET + " INTEGER)";
+            + STARTTIME_OFFSET + " INTEGER, "
+            + ACTIVITY_TYPE + " TEXT)";
 
     String CREATE_TABLE_INDEX = "CREATE UNIQUE INDEX " + TABLE_NAME + "_" + UUID + "_index ON " + TABLE_NAME + "(" + UUID + ")";
 

--- a/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/fragments/StatisticsRecordedFragment.java
@@ -188,10 +188,9 @@ public class StatisticsRecordedFragment extends Fragment {
         {
             Context context = getContext();
             String localizedActivityType = track.getActivityTypeLocalized();
-            String trackIconValue = ActivityType.findByLocalizedString(context, localizedActivityType)
-                    .getIconId();
-            viewBinding.statsActivityTypeIcon.setImageDrawable(ContextCompat.getDrawable(getContext(), ActivityType.findBy(trackIconValue)
-                    .getIconDrawableId()));
+            int iconDrawableId = ActivityType.findByLocalizedString(context, localizedActivityType)
+                    .getIconDrawableId();
+            viewBinding.statsActivityTypeIcon.setImageDrawable(ContextCompat.getDrawable(getContext(), iconDrawableId));
         }
 
         // Set time and start datetime

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportActivity.java
@@ -32,7 +32,6 @@ import androidx.fragment.app.FragmentActivity;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.ContentProviderUtils;
@@ -231,9 +230,9 @@ public class ExportActivity extends FragmentActivity implements ExportService.Ex
         exportTasks = new ArrayList<>();
         if (allInOneFile) {
             String filename = "OpenTracks-Backup";
-            exportTasks.add(new ExportTask(filename, trackFileFormat, tracks.stream().map(Track::getId).collect(Collectors.toList())));
+            exportTasks.add(new ExportTask(filename, trackFileFormat, tracks.stream().map(Track::getId).toList()));
         } else {
-            exportTasks.addAll(tracks.stream().map(it -> new ExportTask(null, trackFileFormat, List.of(it.getId()))).collect(Collectors.toList()));
+            exportTasks.addAll(tracks.stream().map(it -> new ExportTask(null, trackFileFormat, List.of(it.getId()))).toList());
         }
         trackExportTotalCount = exportTasks.size();
     }

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
@@ -261,7 +261,7 @@ public class GPXTrackExporter implements TrackExporter {
         printWriter.println("<time>" + StringUtils.formatDateTimeIso8601(marker.getTime(), zoneOffset) + "</time>");
         printWriter.println("<name>" + StringUtils.formatCData(marker.getName()) + "</name>");
         printWriter.println("<desc>" + StringUtils.formatCData(marker.getDescription()) + "</desc>");
-        printWriter.println("<type>" + StringUtils.formatCData(marker.getCategory()) + "</type>");
+        printWriter.println("<type>" + StringUtils.formatCData(marker.getCategory()) + "</type>"); //TODO This is localized; may be better to export in English only. See #1608
         printWriter.println("</wpt>");
     }
 
@@ -269,11 +269,15 @@ public class GPXTrackExporter implements TrackExporter {
         printWriter.println("<trk>");
         printWriter.println("<name>" + StringUtils.formatCData(track.getName()) + "</name>");
         printWriter.println("<desc>" + StringUtils.formatCData(track.getDescription()) + "</desc>");
-        printWriter.println("<type>" + StringUtils.formatCData(track.getActivityTypeLocalized()) + "</type>");
+        printWriter.println("<type>" + StringUtils.formatCData(track.getActivityType().getId()) + "</type>");
 
         printWriter.println("<extensions>");
         printWriter.println("<topografix:color>c0c0c0</topografix:color>");
         printWriter.println("<opentracks:trackid>" + track.getUuid() + "</opentracks:trackid>");
+
+        if (track.getActivityTypeLocalized() != null || !track.getActivityTypeLocalized().isBlank()) {
+            printWriter.println("<opentracks:typeTranslated>" + StringUtils.formatCData(track.getActivityTypeLocalized()) + "</opentracks:typeTranslated>");
+        }
 
         TrackStatistics trackStatistics = track.getTrackStatistics();
         printWriter.println("<gpxtrkx:TrackStatsExtension>");

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
@@ -295,7 +295,6 @@ public class KMLTrackExporter implements TrackExporter {
 
         printWriter.println("<name>" + StringUtils.formatCData(track.getName()) + "</name>");
         printWriter.println("<description>" + StringUtils.formatCData(track.getDescription()) + "</description>");
-        printWriter.println("<icon>" + StringUtils.formatCData(track.getActivityType().getIconId()) + "</icon>");
         printWriter.println("<opentracks:trackid>" + track.getUuid() + "</opentracks:trackid>");
 
         printWriter.println("<styleUrl>#" + TRACK_STYLE + "</styleUrl>");

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.ContentProviderUtils;
 import de.dennisguse.opentracks.data.TrackPointIterator;
+import de.dennisguse.opentracks.data.models.ActivityType;
 import de.dennisguse.opentracks.data.models.Marker;
 import de.dennisguse.opentracks.data.models.Track;
 import de.dennisguse.opentracks.data.models.TrackPoint;
@@ -59,7 +60,8 @@ public class KMLTrackExporter implements TrackExporter {
     private static final String TRACK_STYLE = "track";
     private static final String SCHEMA_ID = "schema";
 
-    public static final String EXTENDED_DATA_TYPE_ACTIVITYTYPE = "type";
+    public static final String EXTENDED_DATA_TYPE_LOCALIZED = "type";
+    public static final String EXTENDED_DATA_ACTIVITY_TYPE = "activityType";
 
     public static final String EXTENDED_DATA_TYPE_TRACKPOINT = "trackpoint_type";
     public static final String EXTENDED_DATA_TYPE_SPEED = "speed";
@@ -298,12 +300,12 @@ public class KMLTrackExporter implements TrackExporter {
         printWriter.println("<opentracks:trackid>" + track.getUuid() + "</opentracks:trackid>");
 
         printWriter.println("<styleUrl>#" + TRACK_STYLE + "</styleUrl>");
-        writeActivityType(track.getActivityTypeLocalized());
+        writeActivityType(track.getActivityType());
+        writeTypeLocalized(track.getActivityTypeLocalized());
         printWriter.println("<MultiTrack>");
         printWriter.println("<altitudeMode>absolute</altitudeMode>");
         printWriter.println("<interpolate>1</interpolate>");
     }
-
 
     private void writeEndTrack() {
         printWriter.println("</MultiTrack>");
@@ -416,7 +418,7 @@ public class KMLTrackExporter implements TrackExporter {
             printWriter.println("<description>" + StringUtils.formatCData(description) + "</description>");
             printWriter.println("<TimeStamp><when>" + getTime(zoneOffset, location) + "</when></TimeStamp>");
             printWriter.println("<styleUrl>#" + KMLTrackExporter.MARKER_STYLE + "</styleUrl>");
-            writeActivityType(activityType);
+            writeTypeLocalized(activityType);
             printWriter.println("<Point>");
             printWriter.println("<coordinates>" + getCoordinates(location, ",") + "</coordinates>");
             printWriter.println("</Point>");
@@ -437,7 +439,7 @@ public class KMLTrackExporter implements TrackExporter {
         printWriter.println("</Camera>");
         printWriter.println("<TimeStamp><when>" + getTime(zoneOffset, marker.getLocation()) + "</when></TimeStamp>");
         printWriter.println("<styleUrl>#" + MARKER_STYLE + "</styleUrl>");
-        writeActivityType(marker.getCategory());
+        writeTypeLocalized(marker.getCategory());
 
         if (exportPhotos) {
             printWriter.println("<Icon><href>" + KmzTrackExporter.buildKmzImageFilePath(marker) + "</href></Icon>");
@@ -492,12 +494,21 @@ public class KMLTrackExporter implements TrackExporter {
         return result;
     }
 
-    private void writeActivityType(String activityTypeLocalized) {
-        if (activityTypeLocalized == null || "".equals(activityTypeLocalized)) {
+    private void writeTypeLocalized(String localizedValue) {
+        if (localizedValue == null || localizedValue.equals("")) {
             return;
         }
         printWriter.println("<ExtendedData>");
-        printWriter.println("<Data name=\"" + EXTENDED_DATA_TYPE_ACTIVITYTYPE + "\"><value>" + StringUtils.formatCData(activityTypeLocalized) + "</value></Data>");
+        printWriter.println("<Data name=\"" + EXTENDED_DATA_TYPE_LOCALIZED + "\"><value>" + StringUtils.formatCData(localizedValue) + "</value></Data>");
+        printWriter.println("</ExtendedData>");
+    }
+
+    private void writeActivityType(ActivityType value) {
+        if (value == null) {
+            return;
+        }
+        printWriter.println("<ExtendedData>");
+        printWriter.println("<Data name=\"" + EXTENDED_DATA_ACTIVITY_TYPE + "\"><value>" + StringUtils.formatCData(value.getId()) + "</value></Data>");
         printWriter.println("</ExtendedData>");
     }
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportActivity.java
@@ -32,7 +32,6 @@ import androidx.lifecycle.ViewModelProvider;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.TrackRecordedActivity;
@@ -100,7 +99,7 @@ public class ImportActivity extends FragmentActivity {
             documentFiles = new ArrayList<>();
             documentFiles.add(DocumentFile.fromTreeUri(this, documentUris.get(0)));
         } else {
-            documentFiles = documentUris.stream().map(it -> DocumentFile.fromSingleUri(this, it)).collect(Collectors.toList());
+            documentFiles = documentUris.stream().map(it -> DocumentFile.fromSingleUri(this, it)).toList();
         }
 
         initViews();

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportViewModel.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportViewModel.java
@@ -12,7 +12,6 @@ import androidx.lifecycle.MutableLiveData;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.models.Track;
@@ -50,7 +49,7 @@ public class ImportViewModel extends AndroidViewModel implements ImportServiceRe
         List<ArrayList<DocumentFile>> nestedFileList = documentFiles.stream()
                 .map(FileUtils::getFiles)
                 // TODO flatMap(Collection::stream) fails with ClassCastException; try in the future again
-                .collect(Collectors.toList());
+                .toList();
 
         List<DocumentFile> fileList = new ArrayList<>();
         nestedFileList.forEach(fileList::addAll);

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/TrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/TrackImporter.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.ContentProviderUtils;
@@ -223,7 +222,7 @@ public class TrackImporter {
     private void matchMarkers2TrackPoints(Track.Id trackId) {
         List<TrackPoint> trackPointsWithLocation = trackPoints.stream()
                 .filter(TrackPoint::hasLocation)
-                .collect(Collectors.toList());
+                .toList();
 
         List<Marker> todoMarkers = new LinkedList<>(markers);
         List<Marker> doneMarkers = new LinkedList<>();
@@ -241,7 +240,7 @@ public class TrackImporter {
                             && trackPoint.getLongitude() == it.getLongitude()
                             && trackPoint.getTime().equals(it.getTime())
                     )
-                    .collect(Collectors.toList());
+                    .toList();
 
             TrackStatistics statistics = updater.getTrackStatistics();
             for (Marker marker : matchedMarkers) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/TrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/TrackImporter.java
@@ -105,7 +105,6 @@ public class TrackImporter {
         if (activityTypeLocalized != null) {
             track.setActivityTypeLocalized(activityTypeLocalized);
         }
-
         ActivityType activityType;
         if (activityTypeId == null) {
             activityType = ActivityType.findByLocalizedString(context, activityTypeLocalized);

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/TrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/TrackImporter.java
@@ -109,7 +109,7 @@ public class TrackImporter {
 
         ActivityType activityType;
         if (activityTypeId == null) {
-            activityType = ActivityType.findByLocalizedString(context, activityTypeId);
+            activityType = ActivityType.findByLocalizedString(context, activityTypeLocalized);
         } else {
             activityType = ActivityType.findBy(activityTypeId);
         }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -724,7 +724,7 @@ public class PreferencesUtils {
                 R.array.stats_custom_layout_fields_default_value_16,
                 R.array.stats_custom_layout_fields_default_value_17,
                 R.array.stats_custom_layout_fields_default_value_18
-        ).map(id -> resources.obtainTypedArray(id)).collect(Collectors.toList());
+        ).map(id -> resources.obtainTypedArray(id)).toList();
     }
 
     @SuppressLint("ResourceType")
@@ -799,7 +799,7 @@ public class PreferencesUtils {
     }
 
     public static List<String> getAllCustomLayoutNames() {
-        return getAllCustomLayouts().stream().map(RecordingLayout::getName).collect(Collectors.toList());
+        return getAllCustomLayouts().stream().map(RecordingLayout::getName).toList();
     }
 
     public static void resetCustomLayoutPreferences() {

--- a/src/main/java/de/dennisguse/opentracks/settings/bluetooth/BluetoothLeSensorPreference.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/bluetooth/BluetoothLeSensorPreference.java
@@ -23,7 +23,6 @@ import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.sensors.BluetoothUtils;
@@ -136,7 +135,7 @@ public abstract class BluetoothLeSensorPreference extends DialogPreference {
             b.putParcelableArrayList(ARG_BLE_SERVICE_UUIDS, new ArrayList<>(sensorUUIDs.stream()
                     .map(ServiceMeasurementUUID::serviceUUID)
                     .map(ParcelUuid::new)
-                    .collect(Collectors.toList())));
+                    .toList()));
             fragment.setArguments(b);
             return fragment;
         }
@@ -202,7 +201,7 @@ public abstract class BluetoothLeSensorPreference extends DialogPreference {
             if (PreferencesUtils.getBluetoothFilterEnabled()) {
                 scanFilter = serviceUUIDs.stream()
                         .map(it -> new ScanFilter.Builder().setServiceUuid(it).build())
-                        .collect(Collectors.toList());
+                        .toList();
             }
 
             ScanSettings.Builder scanSettingsBuilder = new ScanSettings.Builder();

--- a/src/main/java/de/dennisguse/opentracks/ui/customRecordingLayout/RecordingLayout.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/customRecordingLayout/RecordingLayout.java
@@ -68,7 +68,7 @@ public class RecordingLayout implements Parcelable {
 
     public RecordingLayout toRecordingLayout(boolean visibility) {
         RecordingLayout result = new RecordingLayout(this.getName());
-        result.addFields(dataFields.stream().filter(f -> f.isVisible() == visibility).collect(Collectors.toList()));
+        result.addFields(dataFields.stream().filter(f -> f.isVisible() == visibility).toList());
         return result;
     }
 

--- a/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.data.ContentProviderUtils;
 import de.dennisguse.opentracks.data.models.Track;
@@ -54,7 +53,7 @@ public class ExportUtils {
 
     public static void exportTrack(Context context, DocumentFile directory, ExportTask exportTask) {
         ContentProviderUtils contentProviderUtils = new ContentProviderUtils(context);
-        List<Track> tracks = exportTask.getTrackIds().stream().map(contentProviderUtils::getTrack).collect(Collectors.toList());
+        List<Track> tracks = exportTask.getTrackIds().stream().map(contentProviderUtils::getTrack).toList();
         Uri exportDocumentFileUri;
         if (tracks.size() == 1) {
             exportDocumentFileUri = getExportDocumentFileUri(context, tracks.get(0), exportTask.getTrackFileFormat(), directory);


### PR DESCRIPTION
GPXs `<type>` doesn't specify if it should contain localized or non-localized (i.e., English) content, but most applications use the non-localized approach.
OpenTracks was doing the former and actually didn't store a non-localized activity type at all, but rather just the information about the icon.

What has been done:
1. Introduced `Track.activityType` in addition to `Track.activityTypeLocalized`
2. Removed ActivityIcon as the icon identifier is superseeded by ActivityType
3. Implemented database migration to determine TracksColumn.ActivityType (first using activityTypeLocalized and then icon (sadly it cannot be perfect)
4. KML now export and import activityType and activityTypeLocalized
5. KML does not export/import icon anymore
6. GPX now export `<type>` as activityType while the import should be able to handle activityType OR activityTypeLocalized (BREAKING CHANGE)
    
As usual there are likely some edgy edge cases.

PS/ KML parsing using SAX is just horrible.