### PR TITLE
fix NPE at null barometer after unregister listener

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/sensors/driver/BarometerInternal.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/driver/BarometerInternal.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 import de.dennisguse.opentracks.data.models.AtmosphericPressure;
 import de.dennisguse.opentracks.sensors.GainManager;
 
-public class BarometerInternal {
+public class BarometerInternal implements SensorEventListener {
 
     private static final String TAG = BarometerInternal.class.getSimpleName();
 
@@ -21,22 +21,20 @@ public class BarometerInternal {
 
     private GainManager observer;
 
-    private final SensorEventListener listener = new SensorEventListener() {
-        @Override
-        public void onSensorChanged(SensorEvent event) {
-            if (!isConnected()) {
-                Log.w(TAG, "Not connected to sensor, cannot process data.");
-                return;
-            }
-
-            observer.onSensorValueChanged(AtmosphericPressure.ofHPA(event.values[0]));
+    @Override
+    public void onSensorChanged(SensorEvent event) {
+        if (!isConnected()) {
+            Log.w(TAG, "Not connected to sensor, cannot process data.");
+            return;
         }
 
-        @Override
-        public void onAccuracyChanged(Sensor sensor, int accuracy) {
-            Log.w(TAG, "Sensor accuracy changes are (currently) ignored.");
-        }
-    };
+        observer.onSensorValueChanged(AtmosphericPressure.ofHPA(event.values[0]));
+    }
+
+    @Override
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {
+        Log.w(TAG, "Sensor accuracy changes are (currently) ignored.");
+    }
 
     public void connect(Context context, Handler handler, GainManager observer) {
         SensorManager sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
@@ -46,7 +44,7 @@ public class BarometerInternal {
             this.observer = null;
         }
 
-        if (sensorManager.registerListener(listener, pressureSensor, SAMPLING_PERIOD, handler)) {
+        if (sensorManager.registerListener(this, pressureSensor, SAMPLING_PERIOD, handler)) {
             this.observer = observer;
             return;
         }
@@ -56,7 +54,7 @@ public class BarometerInternal {
 
     public void disconnect(Context context) {
         SensorManager sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
-        sensorManager.unregisterListener(listener);
+        sensorManager.unregisterListener(this);
         observer = null;
     }
 


### PR DESCRIPTION
I experimented a little bit. I'm not sure what happens here, but I guess the internal Object Instance of the SensorEventListener doesn't "see" the null observer right away. When I implement the SensorEventListener interface directly on the BarometerInternal the NPE is fixed.