### PR TITLE
fix #1769 export overwrite existing files

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
@@ -68,7 +68,7 @@ public class ExportUtils {
         }
 
         TrackExporter trackExporter = exportTask.getTrackFileFormat().createTrackExporter(context, contentProviderUtils);
-        try (OutputStream outputStream = context.getContentResolver().openOutputStream(exportDocumentFileUri)) {
+        try (OutputStream outputStream = context.getContentResolver().openOutputStream(exportDocumentFileUri, "wt")) {
             if (!trackExporter.writeTrack(tracks, outputStream)) {
                 if (!DocumentFile.fromSingleUri(context, exportDocumentFileUri).delete()) {
                     throw new RuntimeException("Unable to delete exportDocumentFile");


### PR DESCRIPTION
Found the cause of the broken .gpx exports. 
As the tracks were duplicates (from test ex- and imports). The export all function wrote two times to the same file. The second time the content was slightly less bytes, so the first file was only partly overwritten resulting in a broken xml file.

We need to make sure the target file is properly overwritten (truncated at the beginning).

Solution:
https://stackoverflow.com/questions/56902845/how-to-properly-overwrite-content-of-file-using-android-storage-access-framework

@dennisguse do we have to do anything else if two tracks result in the same filename and overwriting each other while exporting? 