### PR TITLE
When adding markers: use initial location (instead of later when saved)

### DIFF
--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0-beta06'
+        classpath 'com.android.tools.build:gradle:8.2.0-rc01'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0-rc01'
+        classpath 'com.android.tools.build:gradle:8.2.0-beta06'
     }
 }
 

--- a/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerEditActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerEditActivity.java
@@ -77,6 +77,8 @@ public class MarkerEditActivity extends AbstractActivity {
     // UI elements
     private MarkerEditBinding viewBinding;
 
+    private boolean isNewMarker;
+
     @Override
     protected View getRootView() {
         viewBinding = MarkerEditBinding.inflate(getLayoutInflater());
@@ -108,7 +110,7 @@ public class MarkerEditActivity extends AbstractActivity {
             finish();
         });
 
-        boolean isNewMarker = markerId == null;
+        isNewMarker = markerId == null;
         if (!isNewMarker) {
             viewBinding.markerEditToolbar.setTitle(R.string.menu_edit);
         }
@@ -122,7 +124,9 @@ public class MarkerEditActivity extends AbstractActivity {
 
         viewModel = new ViewModelProvider(this).get(MarkerEditViewModel.class);
 
-        viewModel.getTrackRecordingServiceConnection().addMarker(getApplication(), null, null,null,null);
+        if (isNewMarker) {
+            viewModel.getTrackRecordingServiceConnection().addMarker(getApplication(), null, null, null, null);
+        }
 
         viewModel.getMarkerData(trackId, markerId).observe(this, data -> {
             marker = data;
@@ -170,6 +174,15 @@ public class MarkerEditActivity extends AbstractActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
+
+        if (isNewMarker) {
+            //Delete the marker of the list
+            //final Marker.Id markerId = marker.getId();
+            //final Context context = this;
+            //final FragmentActivity fragmentActivity = getActivity();
+            //ContentProviderUtils contentProviderUtils = new ContentProviderUtils(fragmentActivity);
+            //contentProviderUtils.deleteMarker(context, markerId);
+        }
 
         trackId = null;
         viewBinding = null;

--- a/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerEditActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerEditActivity.java
@@ -121,6 +121,9 @@ public class MarkerEditActivity extends AbstractActivity {
         });
 
         viewModel = new ViewModelProvider(this).get(MarkerEditViewModel.class);
+
+        viewModel.getTrackRecordingServiceConnection().addMarker(getApplication(), null, null,null,null);
+
         viewModel.getMarkerData(trackId, markerId).observe(this, data -> {
             marker = data;
             viewBinding.markerEditName.setText(marker.getName());

--- a/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerEditViewModel.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/markers/MarkerEditViewModel.java
@@ -47,6 +47,10 @@ public class MarkerEditViewModel extends AndroidViewModel {
         return markerData;
     }
 
+    protected TrackRecordingServiceConnection getTrackRecordingServiceConnection() {
+        return trackRecordingServiceConnection;
+    }
+
     @Override
     protected void onCleared() {
         super.onCleared();


### PR DESCRIPTION
I have worked on the issue "When adding markers: use initial location (instead of later when saved)".

My code should create the matker when the activity of editing the marker were launched, without the information about the marker's title, type and description being filled. For that, I add a code to create a marker in the function onCreate() of the class MarkerEditActivity. I use the function addMarker of the class TrackRecordingServiceConnection because it has access to the location of the device. 

Link to the issue : https://github.com/OpenTracksApp/OpenTracks/issues/1393

Many thanks for your help,

Sophie

