### PR TITLE
Fix crash due to BLE sensor data reported after shutdown

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -158,6 +158,7 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
             } else {
                 if (gpsStatusValue.isGpsStarted()) {
                     recordingStatusConnection.unbindAndStop(this);
+                    recordingStatusConnection.startConnection(this); //TODO We need to stay listening!
                 } else {
                     new TrackRecordingServiceConnection((service, connection) -> {
                         service.tryStartSensors();

--- a/src/main/java/de/dennisguse/opentracks/sensors/driver/BarometerInternal.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/driver/BarometerInternal.java
@@ -42,6 +42,7 @@ public class BarometerInternal implements SensorEventListener {
         if (pressureSensor == null) {
             Log.w(TAG, "No pressure sensor available.");
             this.observer = null;
+            return;
         }
 
         if (sensorManager.registerListener(this, pressureSensor, SAMPLING_PERIOD, handler)) {

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -125,6 +125,9 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         if (isRecording()) {
             endCurrentTrack();
         }
+        if (isSensorStarted()) {
+            stopSensors();
+        }
 
         PreferencesUtils.unregisterOnSharedPreferenceChangeListener(this);
 
@@ -248,6 +251,7 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
         stopForeground(true);
         notificationManager.cancelNotification();
         wakeLock = SystemUtils.releaseWakeLock(wakeLock);
+        gpsStatusObservable.postValue(STATUS_GPS_DEFAULT);
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceConnection.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceConnection.java
@@ -127,9 +127,6 @@ public class TrackRecordingServiceConnection implements ServiceConnection, Death
         setTrackRecordingService(null);
     }
 
-    /**
-     * Unbinds and stops the service.
-     */
     public void unbindAndStop(Context context) {
         unbind(context);
         context.stopService(new Intent(context, TrackRecordingService.class));
@@ -153,7 +150,7 @@ public class TrackRecordingServiceConnection implements ServiceConnection, Death
 
     @Override
     public void onServiceConnected(ComponentName className, IBinder service) {
-        Log.i(TAG, "Connected to the service.");
+        Log.i(TAG, "Connected to the service: " + service);
         try {
             service.linkToDeath(this, 0);
         } catch (RemoteException e) {


### PR DESCRIPTION
Problem(s):
* TrackListActivity started sensors and recording (always).
* The TrackRecordingService checked only if a recording was running and NOT if the sensors were already started.

Follow-up:
* Shutdown of sensors may not been correct for quite a while
* Sensor data shouldn't have been affected

Moreover: TrackListActivity's start and stop sensor didn't work correctly.