### PR TITLE
add Magene PES P505 to the list of tested BLE cycling power sensors

### DIFF
--- a/README_TESTED_SENSORS.md
+++ b/README_TESTED_SENSORS.md
@@ -44,6 +44,7 @@ For cycling (incl. cadence):
 * QUARQ Red DZero Powermeter
 * Tacx Satori Smart
 * Wahoo Kickr v4.0
+* Magene PES P505
 * Rotor 2INpower DM Road (only supports power measurement, cadence measurement is proprietary @ firmware v1.061)
 
 For running:


### PR DESCRIPTION
OpenTracks accepts power and cadence information form this sensor but it was not in the tested list.
The sensor supports power, cadence, balance, smoothness. Only power and cadence are read by OpenTracks. Good enough.