### PR TITLE
more compact chart titles

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartValueSeries.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartValueSeries.java
@@ -80,7 +80,7 @@ abstract class ChartValueSeries {
         // Make copies of the stroke paint with the default thickness
         titlePaint = new Paint(strokePaint);
         titlePaint.setTextSize(fontSizeMedium);
-        titlePaint.setTextAlign(Align.CENTER);
+        titlePaint.setTextAlign(Align.LEFT);
         titlePaint.setStyle(Style.FILL_AND_STROKE);
 
         markerPaint = new Paint(strokePaint);


### PR DESCRIPTION
 titles need to take less vertical space for charts to be legible
 in landscape mode when more channels (data series) are available
 Fixes #1807

**Link to the the issue**
https://github.com/OpenTracksApp/OpenTracks/issues/1807

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
