### PR TITLE
do not report units in the announcer

### DIFF
--- a/src/main/res/values-b+es+419/strings.xml
+++ b/src/main/res/values-b+es+419/strings.xml
@@ -472,7 +472,6 @@
     <string name="settings_public_api_dashboard_enabled_title">Transferencia automática de datos</string>
     <string name="settings_public_api_dashboard_enabled_summary_off">Los datos grabados no se compartirán automáticamente con otras aplicaciones.</string>
     <string name="settings_public_api_dashboard_enabled_summary_on">Una aplicación que ha iniciado una grabación puede también acceder a los datos grabados.</string>
-    <string name="voice_per_kilometer">por kilometro</string>
     <string name="voice_per_mile">por milla</string>
     <string name="lap_time">Tiempo de vuelta</string>
     <string name="pace">Ritmo</string>
@@ -480,6 +479,5 @@
     <string name="speed">Velocidad</string>
     <string name="total_distance">Distancia total</string>
     <string name="average_heart_rate">Ritmo cardíaco promedio</string>
-    <string name="current_heart_rate">Ritmo cardíaco actual</string>
     <string name="settings_export_filename_title">Formato del nombre del archivo</string>
 </resources>

--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -509,13 +509,11 @@ limitations under the License.
     <string name="export_dir_not_writable">" (nelze zapisovat!)"</string>
     <string name="generic_today">Dnes</string>
     <string name="no_compatible_file_manager_installed">Není nainstalován kompatibilní správce souborů</string>
-    <string name="voice_per_kilometer">za kilometr</string>
     <string name="lap_time">Čas kola</string>
     <string name="lap_speed">Rychlost kola</string>
     <string name="speed">Rychlost</string>
     <string name="total_distance">Celková vzdálenost</string>
     <string name="average_heart_rate">Průměrný srdeční tep</string>
-    <string name="current_heart_rate">Aktuální srdeční tep</string>
     <string name="settings_public_api_enabled_summary_on">Ostatní nainstalované aplikace mohou nahrávání spustit nebo zastavit.</string>
     <string name="voice_per_mile">za míli</string>
     <string name="activity_type_swimming">plavání</string>
@@ -580,9 +578,7 @@ limitations under the License.
     <string name="sensor_state_heart_rate_unit">bpm</string>
     <string name="sensor_state_power_unit">W</string>
     <string name="voiceSecondsPlural">{n, plural, =1 {1 sekunda} few {{n,number} sekundy} other {{n,number} sekund} }</string>
-    <string name="voiceSpeedKilometersPerHourPlural">{n, plural, =1 {1 kilometr za hodinu} few {{n,number,#.0} kilometry za hodinu} other {{n,number,#.0} kilometrů za hodinu} }</string>
     <string name="voiceSpeedMilesPerHourPlural">{n, plural, =1 {1 míle za hodinu} few {{n,number,#.0} míle za hodinu} other {{n,number,#.0} mil za hodinu} }</string>
-    <string name="voiceDistanceKilometersPlural">{n, plural, =1 {1 kilometr} few {{n,number,#.0} kilometry} other {{n,number,#.0} kilometrů} }</string>
     <string name="sensor_state_power_max">Maximální výkon</string>
     <string name="settings_announcements_idle_category_title">Oznámení o nečinnosti</string>
     <string name="activity_type_kickscooter">skútr</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -345,12 +345,6 @@ Meldet das GPS-Gerät ungenaue Daten (z.B. Standort, Geschwindigkeit, Höhe), ka
         other {{n} Sekunden}
         }
     </string>
-    <string name="voiceSpeedKilometersPerHourPlural">
-        { n, plural,
-        =1 {1 Kilometer pro Stunde}
-        other {{n,number,#.0} Kilometer pro Stunde}
-        }
-    </string>
     <string name="voiceSpeedMilesPerHourPlural">
         { n, plural,
         =1 {1 Meile pro Stunde}
@@ -536,7 +530,6 @@ Meldet das GPS-Gerät ungenaue Daten (z.B. Standort, Geschwindigkeit, Höhe), ka
     <string name="settings_public_api_enabled_title">Öffentliche API</string>
     <string name="track_discarding">Verwerfe Track</string>
     <string name="average_heart_rate">Durchschnittlicher Puls</string>
-    <string name="current_heart_rate">Aktueller Puls</string>
     <string name="export_cannot_write_to_dir">Kann nicht in Export-Verzeichnis schreiben.</string>
     <string name="stats_sensors_cadence">Trittfrequenz</string>
     <string name="voiceDistanceMilesPlural">
@@ -548,17 +541,10 @@ Meldet das GPS-Gerät ungenaue Daten (z.B. Standort, Geschwindigkeit, Höhe), ka
     <string name="field_set_primary">Primär</string>
     <string name="voice_per_mile">pro Meile</string>
     <string name="lap_time">Rundenzeit</string>
-    <string name="voice_per_kilometer">pro Kilometer</string>
     <string name="pace">Tempo</string>
     <string name="lap_speed">Rundengeschwindigkeit</string>
     <string name="speed">Geschwindigkeit</string>
     <string name="total_distance">Gesamtstrecke</string>
-    <string name="voiceDistanceKilometersPlural">
-        { n, plural,
-        =1 {1 Kilometer}
-        other {{n,number,#.0} Kilometer}
-        }
-    </string>
     <string name="no_compatible_file_manager_installed">Kein kompatibler Dateimanager installiert</string>
     <string name="aggregated_stats_filter_no_results">Es gibt keine Aktivitäten für diesen Filter</string>
     <string name="settings_announcements_summary">Zeit, Entfernung, Sprachgeschwindigkeit</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -339,13 +339,6 @@ limitations under the License.
         other {{n} segundos}
         }
     </string>
-    <string name="voiceSpeedKilometersPerHourPlural">
-        { n, plural,
-        one {{n,number,#.0} kilómetro por hora}
-        many {{n,number,#.0} kilómetros por hora}
-        other {{n,number,#.0} kilómetros por hora}
-        }
-    </string>
     <string name="voiceSpeedMilesPerHourPlural">
         { n, plural,
         one {{n,number,#.0} milla por hora}
@@ -559,20 +552,12 @@ limitations under the License.
     <string name="settings_public_api_dashboard_enabled_title">Transferencia automática de datos</string>
     <string name="settings_public_api_dashboard_enabled_summary_on">Una aplicación que ha iniciado una grabación puede también acceder a los datos grabados.</string>
     <string name="settings_public_api_dashboard_enabled_summary_off">Los datos grabados no se compartirán automáticamente con otras aplicaciones.</string>
-    <string name="voice_per_kilometer">por kilometro</string>
     <string name="voice_per_mile">por milla</string>
     <string name="lap_time">Tiempo de vuelta</string>
     <string name="pace">Ritmo</string>
     <string name="lap_speed">Velocidad de vuelta</string>
     <string name="speed">Velocidad</string>
     <string name="total_distance">Distancia total</string>
-    <string name="voiceDistanceKilometersPlural">
-        { n, plural,
-        one {{n,number,#.0} kilomètre}
-        many {{n,number,#.0} kilomètres}
-        other {{n,number,#.0} kilomètres}
-        }
-    </string>
     <string name="voiceDistanceMilesPlural">
         { n, plural,
         one {{n,number,#.0} milla}
@@ -581,7 +566,6 @@ limitations under the License.
         }
     </string>
     <string name="average_heart_rate">Ritmo cardíaco promedio</string>
-    <string name="current_heart_rate">Ritmo cardíaco actual</string>
     <string name="settings_export_filename_title">Formato del nombre del archivo</string>
     <string name="help_data_google_play_services_content">No</string>
     <string name="description_pace_nautical">Ritmo (min/NM)</string>

--- a/src/main/res/values-fi/strings.xml
+++ b/src/main/res/values-fi/strings.xml
@@ -502,7 +502,6 @@ limitations under the License.
     <string name="settings_sensor_bluetooth_service_filter_on">Näytä vain Bluetooth-laitteet, jotka ilmoittavat tarvittavat palvelut</string>
     <string name="settings_public_api_dashboard_enabled_summary_off">Tallennettuja tietoja ei jaeta automaattisesti muiden sovellusten kanssa.</string>
     <string name="voice_per_mile">per maili</string>
-    <string name="voice_per_kilometer">kilometriä kohti</string>
     <string name="lap_time">Kierrosaika</string>
     <string name="pace">Tahti</string>
     <string name="aggregated_stats_filter_no_results">Määritetylle suodattimelle ei ole toimintoja</string>
@@ -516,7 +515,6 @@ limitations under the License.
     <string name="menu_filter">Suodatin</string>
     <string name="stats_sensors_cadence">Kadenssi</string>
     <string name="stats_clock">Kello</string>
-    <string name="current_heart_rate">Nykyinen syke</string>
     <string name="average_heart_rate">Keskimääräinen syke</string>
     <string name="speed">Nopeus</string>
     <string name="lap_speed">Kierrosnopeus</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -341,13 +341,6 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
         other {{n} secondes}
         }
     </string>
-    <string name="voiceSpeedKilometersPerHourPlural">
-        { n, plural,
-        one {{n,number,#.0} kilomètre-heure}
-        many {{n,number,#.0} kilomètres-heure}
-        other {{n,number,#.0} kilomètres-heure}
-        }
-    </string>
     <string name="voiceSpeedMilesPerHourPlural">
         { n, plural,
         one {{n,number,#.0} mile par heure}
@@ -549,7 +542,6 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
     <string name="no_compatible_file_manager_installed">Aucun gestionnaire de fichiers compatible n\'est installé</string>
     <string name="settings_public_api_enabled_title">API publique</string>
     <string name="average_heart_rate">Fréquence cardiaque moyenne</string>
-    <string name="current_heart_rate">Fréquence cardiaque actuelle</string>
     <string name="voiceDistanceMilesPlural">
         { n, plural,
         one {{n,number,#.0} mile}
@@ -562,13 +554,6 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
     <string name="settings_public_api_dashboard_enabled_summary_off">Les données enregistrées ne seront pas automatiquement partagées avec d\'autres applications.</string>
     <string name="settings_public_api_enabled_summary_on">D\'autres applications installées peuvent démarrer ou arrêter les enregistrements.</string>
     <string name="settings_public_api_enabled_summary_off">Seul OpenTracks peut démarrer et arrêter les enregistrements.</string>
-    <string name="voiceDistanceKilometersPlural">
-        { n, plural,
-        one {{n,number,#.0} kilomètre}
-        many {{n,number,#.0} kilomètres}
-        other {{n,number,#.0} kilomètres}
-        }
-    </string>
     <string name="total_distance">Distance totale</string>
     <string name="activity_type_swimming">natation</string>
     <string name="activity_type_swimming_open">natation en eau libre</string>
@@ -577,7 +562,6 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
     <string name="gps_recording_status">%1$s : %2$s</string>
     <string name="settings_api_title">API publique</string>
     <string name="settings_public_api_disabled_toast">L\'API publique d\'OpenTracks est désactivé : Elle peut être activé dans les paramètres.</string>
-    <string name="voice_per_kilometer">par kilomètre</string>
     <string name="voice_per_mile">par mile</string>
     <string name="pace">Rythme</string>
     <string name="lap_speed">Vitesse par tour</string>

--- a/src/main/res/values-ga/strings.xml
+++ b/src/main/res/values-ga/strings.xml
@@ -479,12 +479,10 @@
     <string name="value_integer_second">%1$d s</string>
     <string name="aggregated_stats_empty_message">Taifead do chéad rian chun staitisticí comhiomlánaithe a fheiceáil</string>
     <string name="value_smallest_recommended">is lú (molta)</string>
-    <string name="voice_per_kilometer">in aghaidh an chiliméadair</string>
     <string name="voice_per_mile">in aghaidh an mhíle</string>
     <string name="voice_per_nautical_mile">in aghaidh an mhuirmhíle</string>
     <string name="speed">Meánluas ag gluaiseacht</string>
     <string name="average_heart_rate">Meánráta croí</string>
-    <string name="current_heart_rate">Ráta croí reatha</string>
     <string name="waypoint_type_barbecue">beárbaiciú</string>
     <string name="waypoint_type_cafe">caifé</string>
     <string name="waypoint_type_fire_station">stáisiún Dóiteáin</string>

--- a/src/main/res/values-gl/strings.xml
+++ b/src/main/res/values-gl/strings.xml
@@ -522,12 +522,10 @@ Se o GPS informa sobre datos pouco precisos (ex.: localización, velocidade, ele
     <string name="settings_public_api_dashboard_enabled_title">Transferencia automática de datos</string>
     <string name="settings_public_api_dashboard_enabled_summary_on">Unha aplicación que inicie unha gravación pode acceder tamén aos datos gravados.</string>
     <string name="settings_public_api_dashboard_enabled_summary_off">Os datos gravados non serán compartidos automáticamente con outras apps.</string>
-    <string name="voice_per_kilometer">por quilómetro</string>
     <string name="voice_per_mile">por milla</string>
     <string name="pace">Ritmo</string>
     <string name="speed">Vel. media en movemento</string>
     <string name="average_heart_rate">Pulso medio</string>
-    <string name="current_heart_rate">Pulso actual</string>
     <string name="activity_type_swimming">nadando</string>
     <string name="activity_type_swimming_open">nadar en augas abertas</string>
     <string name="activity_type_workout">adestramento</string>
@@ -574,10 +572,8 @@ Se o GPS informa sobre datos pouco precisos (ex.: localización, velocidade, ele
     <string name="settings_stats_units_imperial_meter">Imperial (mi, m)</string>
     <string name="voiceHoursPlural">{n, plural, =1 {1 hora} other {{n,number} horas} }</string>
     <string name="voiceSpeedMKnotsPlural">{n, plural, =1 {1 nó} other {{n,number,#.0} nós} }</string>
-    <string name="voiceDistanceKilometersPlural">{n, plural, =1 {1 quilómetro} other {{n,number,#.0} quilómetros} }</string>
     <string name="voiceDistanceMilesPlural">{n, plural, =1 {1 milla} other {{n,number,#.0} millas} }</string>
     <string name="voiceMinutesPlural">{n, plural, =1 {1 minutos} other {{n,number} minutos} }</string>
-    <string name="voiceSpeedKilometersPerHourPlural">{n, plural, =1 {1 quilómetro por hora} other {{n,number,#.0} quilómetros por hora} }</string>
     <string name="voiceSecondsPlural">{n, plural, =1 {1 segundo} other {{n,number} segundos} }</string>
     <string name="voiceSpeedMilesPerHourPlural">{n, plural, =1 {1 milla por hora} other {{n,number,#.0} millas por hora} }</string>
     <string name="voiceDistanceNauticalMilesPlural">{n, plural, =1 {1 milla náutica} other {{n,number,#.0} millas náuticas} }</string>

--- a/src/main/res/values-hr/strings.xml
+++ b/src/main/res/values-hr/strings.xml
@@ -398,11 +398,9 @@ limitations under the License.
     <string name="voiceDistanceMilesPlural">{n, plural, =1 {1 milja} few {{n,number,#.0} milje} other {{n,number,#.0} milja} }</string>
     <string name="settings_night_mode_title">Tema sučelja</string>
     <string name="image_discard">Odbaci</string>
-    <string name="voiceSpeedKilometersPerHourPlural">{n, plural, =1 {1 kilometar na sat} few {{n,number} kilometra na sat} other {{n,number} kilometara na sat} }</string>
     <string name="generic_completed">Završeno</string>
     <string name="generic_filter">Filtar</string>
     <string name="import_file_imported">Datoteka %1$s je uvezena</string>
-    <string name="current_heart_rate">Trenutačni puls</string>
     <string name="about_url">Web stranica projekta: <a href="%1$s">%1$s</a></string>
     <string name="no_compatible_file_manager_installed">Nije instaliran nijedan kompatibilni upravljač datoteka</string>
     <string name="settings_public_api_enabled_summary_on">Druge instalirane aplikacije mogu pokrenuti ili prekinuti snimanja.</string>
@@ -518,7 +516,6 @@ limitations under the License.
     <string name="settings_announcements_idle_title">Neaktivnost</string>
     <string name="settings_reset_summary">Resetiraj postavke na standardne vrijednosti</string>
     <string name="description_speed_source_gps">GPS</string>
-    <string name="voice_per_kilometer">po kilometru</string>
     <string name="settings_recording_customize_layout_title">Prilagodi raspored snimanja</string>
     <string name="unit_knots">čv</string>
     <string name="stats_sensors_cadence">Ritam</string>
@@ -548,7 +545,6 @@ limitations under the License.
     <string name="generic_overwrite">Prepiši</string>
     <string name="import_unable_to_import_file">Nije moguće uvesti datoteku: %1$s</string>
     <string name="stats_sensors_power">Snaga</string>
-    <string name="voiceDistanceKilometersPlural">{n, plural, =1 {1 kilometar} few {{n,number,#.0} kilometra} other {{n,number,#.0} kilometara} }</string>
     <string name="import_progress_summary_exists_msg">Već postoji</string>
     <string name="generic_separator_done_total">/</string>
     <string name="total_distance">Ukupna udaljenost</string>

--- a/src/main/res/values-hu/strings.xml
+++ b/src/main/res/values-hu/strings.xml
@@ -482,7 +482,6 @@ limitations under the License.
     <string name="settings_public_api_dashboard_enabled_summary_on">A felvételt elindító alkalmazás szintén hozzáférhet a rögzített adatokhoz.</string>
     <string name="stats_sensors_heart_rate">Pulzusszám</string>
     <string name="stats_clock">Óra</string>
-    <string name="current_heart_rate">Jelenlegi pulzusszám</string>
     <string name="average_heart_rate">Átlagos pulzusszám</string>
     <string name="settings_sensor_bluetooth_service_filter_on">Csak azokat a Bluetooth-eszközöket jelenítse meg, amelyek bejelentik a szükséges szolgáltatásokat</string>
     <string name="settings_import_section">Behozatal</string>

--- a/src/main/res/values-nb/strings.xml
+++ b/src/main/res/values-nb/strings.xml
@@ -518,14 +518,12 @@ limitations under the License.
     <string name="settings_public_api_dashboard_enabled_title">Automatisk dataoverføring</string>
     <string name="settings_public_api_dashboard_enabled_summary_on">Et program som startet et opptak kan også få tilgang til de registrerte dataene.</string>
     <string name="settings_public_api_dashboard_enabled_summary_off">Registrerte data blir ikke delt automatisk med andre programmer.</string>
-    <string name="voice_per_kilometer">per kilometer</string>
     <string name="voice_per_mile">per engelsk mil</string>
     <string name="lap_time">Rundetid</string>
     <string name="pace">Tempo</string>
     <string name="lap_speed">Rundehastighet</string>
     <string name="speed">Gjen. forflytningshastighet</string>
     <string name="total_distance">Total distanse</string>
-    <string name="current_heart_rate">Gjeldende puls</string>
     <string name="settings_export_filename_title">Format på filnavnet</string>
     <string name="error_crash_title">%1$s krasjet</string>
     <string name="share_crash_report">Del krasjrapport</string>
@@ -566,9 +564,7 @@ limitations under the License.
     <string name="voiceHoursPlural">{n, plural, =1 {1 time} other {{n,number} timer} }</string>
     <string name="voiceMinutesPlural">{n, plural, =1 {1 minutt} other {{n,number} minutter} }</string>
     <string name="voiceSecondsPlural">{n, plural, =1 {1 sekund} other {{n,number} sekunder} }</string>
-    <string name="voiceSpeedKilometersPerHourPlural">{n, plural, =1 {1 kilometer i timen} other {{n,number,#.0} kilometer i timen} }</string>
     <string name="voiceSpeedMKnotsPlural">{n, plural, =1 {1 knop} other {{n,number,#.0} knop} }</string>
-    <string name="voiceDistanceKilometersPlural">{n, plural, =1 {1 kilometer} other {{n,number,#.0} kilometer} }</string>
     <string name="voiceDistanceNauticalMilesPlural">{n, plural, =1 {1 nautisk mil} other {{n,number,#.0} nautiske mil} }</string>
     <string name="sensor_state_cadence_unit">o/min</string>
     <string name="sensor_state_heart_rate_unit">slag/min</string>

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -480,7 +480,6 @@ Als het GPS-apparaat onnauwkeurige gegevens rapporteert (bijv. locatie, snelheid
     <string name="speed">Snelheid</string>
     <string name="total_distance">Totale afstand</string>
     <string name="average_heart_rate">Gemiddelde hartslag</string>
-    <string name="current_heart_rate">Actuele hartslag</string>
     <string name="settings_cycling_sensor">Fietsen</string>
     <string name="settings_running_sensor">Hardlopen</string>
     <string name="settings_import_section">Invoer</string>
@@ -572,12 +571,10 @@ Als het GPS-apparaat onnauwkeurige gegevens rapporteert (bijv. locatie, snelheid
     <string name="voiceDistanceMilesPlural">{n, plural, =1 {1 mijl} other {{n,number,#.0} mijlen} }</string>
     <string name="voiceHoursPlural">{n, plural, =1 {1 uur} other {{n,number} uren} }</string>
     <string name="voiceDistanceNauticalMilesPlural">{n, plural, =1 {1 nautisch mijl} other {{n,number,#.0} nautische mijlen} }</string>
-    <string name="voiceDistanceKilometersPlural">{n, plural, =1 {1 kilometer} other {{n,number,#.0} kilometers} }</string>
     <string name="sensor_state_power_unit">W</string>
     <string name="settings_sensor_bluetooth_service_filter_off">Alle ontdekbare Bluetooth-apparaten weergeven</string>
     <string name="voiceSpeedMKnotsPlural">{n, plural, =1 {1 knoop} other {{n,number,#.0} knopen} }</string>
     <string name="voiceSpeedMilesPerHourPlural">{n, plural, =1 {1 mijl per uur} other {{n,number,#.0} mijlen per uur} }</string>
-    <string name="voiceSpeedKilometersPerHourPlural">{n, plural, =1 {1 kilometer per uur} other {{n,number,#.0} kilometer per uur} }</string>
     <string name="voiceSecondsPlural">{n, plural, =1 {1 seconde} other {{n,number} seconden} }</string>
     <string name="voiceMinutesPlural">{n, plural, =1 {1 minuut} other {{n,number} minuten} }</string>
     <string name="settings_sensor_bluetooth_service_filter_title">Bluetooth-apparaten filteren</string>
@@ -594,6 +591,5 @@ Als het GPS-apparaat onnauwkeurige gegevens rapporteert (bijv. locatie, snelheid
     <string name="permission_recording_failed">OpenTracks heeft toestemming nodig om toegang te krijgen tot zowel uw locatie als nabijgelegen apparaten.</string>
     <string name="sensor_state_heart_rate_unit">/min</string>
     <string name="sensor_state_cadence_unit">/min</string>
-    <string name="voice_per_kilometer">/km</string>
     <string name="bluetooth_sensor_summary">%1$s (%2$s)</string>
 </resources>

--- a/src/main/res/values-pt-rBR/strings.xml
+++ b/src/main/res/values-pt-rBR/strings.xml
@@ -475,11 +475,9 @@
     <string name="generic_dismiss">Dispensar</string>
     <string name="settings_api_title">API pública</string>
     <string name="settings_public_api_dashboard_enabled_title">Transferência automática de dados</string>
-    <string name="voice_per_kilometer">por quilômetro</string>
     <string name="voice_per_mile">por milha</string>
     <string name="lap_speed">Velocidade da volta</string>
     <string name="total_distance">Distância total</string>
-    <string name="current_heart_rate">Frequência cardíaca atual</string>
     <string name="settings_export_filename_title">Formato do nome do arquivo</string>
     <string name="settings_announcements_average_heart_rate">Frequência cardíaca média</string>
     <string name="settings_announcements_lap_heart_rate">Frequência cardíaca da volta</string>

--- a/src/main/res/values-pt-rPT/strings.xml
+++ b/src/main/res/values-pt-rPT/strings.xml
@@ -306,7 +306,6 @@
     <string name="location_latitude_longitude">%1$s, %2$s</string>
     <string name="value_integer_knots">%1$d nós</string>
     <string name="average_heart_rate">Frequência cardíaca média</string>
-    <string name="current_heart_rate">Frequência cardíaca atual</string>
     <string name="share_image_subject">Gostaria de compartilhar uma imagem consigo</string>
     <string name="field_remove_from_layout">Remover</string>
     <string name="about_libraries">Bibliotecas</string>
@@ -484,7 +483,6 @@
     <string name="value_float_knots">%1$.1f nós</string>
     <string name="value_float_mile_hour_recommended">%1$.1f mi/h (Recomendado)</string>
     <string name="value_float_knots_recommended">%1$.1f nós (recomendado)</string>
-    <string name="voice_per_kilometer">por quilômetro</string>
     <string name="voice_per_mile">por milha</string>
     <string name="voice_per_nautical_mile">por milha náutica</string>
     <string name="lap_time">Tempo da volta</string>

--- a/src/main/res/values-pt/strings.xml
+++ b/src/main/res/values-pt/strings.xml
@@ -277,13 +277,6 @@ limitations under the License.
         other {{n} segundos}
         }
     </string>
-    <string name="voiceSpeedKilometersPerHourPlural">
-        { n, plural,
-        one {{n,number,#.0} quilômetro por hora}
-        many {{n,number,#.0} quilómetros por hora}
-        other {{n,number,#.0} quilómetros por hora}
-        }
-    </string>
     <string name="voiceSpeedMilesPerHourPlural">
         { n, plural,
         one {{n,number,#.0} milha por hora}
@@ -493,7 +486,6 @@ limitations under the License.
     <string name="value_float_mile_hour">%1$.1f mi/h</string>
     <string name="value_float_knots">%1$.1f nós</string>
     <string name="value_float_mile_hour_recommended">%1$.1f mi/h (Recomendado)</string>
-    <string name="voice_per_kilometer">por quilômetro</string>
     <string name="voiceSpeedMKnotsPlural">
         { n, plural,
         one {{n,number,#.0} nó}
@@ -516,14 +508,6 @@ limitations under the License.
     </string>
     <string name="total_distance">Distância total</string>
     <string name="average_heart_rate">Frequência cardíaca média</string>
-    <string name="voiceDistanceKilometersPlural">
-        { n, plural,
-        one {{n,number,#.0} quilómetro}
-        many {{n,number,#.0} quilómetros}
-        other {{n,number,#.0} quilómetros}
-        }
-    </string>
-    <string name="current_heart_rate">Frequência cardíaca atual</string>
     <string name="share_image_subject">Gostaria de compartilhar uma imagem consigo</string>
     <string name="share_image_body">Acho que pode estar interessado nesta imagem.</string>
     <string name="hold_to_stop">Segure para parar</string>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -491,7 +491,6 @@ limitations under the License.
     <string name="stats_sensors_heart_rate">Пульс</string>
     <string name="stats_sensors_power">Мощность</string>
     <string name="value_float_mile_hour">%1$.1f миль/ч</string>
-    <string name="voice_per_kilometer">за километр</string>
     <string name="voice_per_mile">за милю</string>
     <string name="lap_time">Время круга</string>
     <string name="pace">Темп</string>
@@ -499,7 +498,6 @@ limitations under the License.
     <string name="speed">Средняя скорость в движении</string>
     <string name="total_distance">Общее расстояние</string>
     <string name="average_heart_rate">Средний пульс</string>
-    <string name="current_heart_rate">Текущий пульс</string>
     <string name="generic_filter">Фильтр</string>
     <string name="generic_from">с</string>
     <string name="settings_export_section">Экспорт</string>
@@ -563,7 +561,6 @@ limitations under the License.
     <string name="settings_stats_units_imperial_meter">Британская система (мили, метры)</string>
     <string name="voiceSpeedMilesPerHourPlural">{n, plural, =1 {1 mile per hour} other {{n,number,#.0} miles per hour} }</string>
     <string name="voiceDistanceMilesPlural">{n, plural, =1 {1 mile} other {{n,number,#.0} miles} }</string>
-    <string name="voiceSpeedKilometersPerHourPlural">{n, plural, =1 {1 kilometer per hour} other {{n,number,#.0} kilometers per hour} }</string>
     <string name="voice_on_device_speaker_title">Использовать динамик устройства</string>
     <string name="settings_ui_dynamic_colors_title">Динамические цвета</string>
     <string name="settings_sensor_heart_rate_max">Зоны: макс. пульс (уд/мин)</string>
@@ -590,5 +587,4 @@ limitations under the License.
     <string name="voiceSpeedMKnotsPlural">{n, plural, =1 {1 knot} other {{n,number,#.0} knots} }</string>
     <string name="value_int_seconds">%1$d сек (рекомендуется)</string>
     <string name="settings_sensor_bluetooth_service_filter_title">Фильтровать устройства Bluetooth</string>
-    <string name="voiceDistanceKilometersPlural">{n, plural, =1 {1 kilometer} other {{n,number,#.0} kilometers} }</string>
 </resources>

--- a/src/main/res/values-sl/strings.xml
+++ b/src/main/res/values-sl/strings.xml
@@ -353,7 +353,6 @@ limitations under the License.
     <string name="location_latitude_longitude">%1$s, %2$s</string>
     <string name="location_coordinate">%1$s°</string>
     <string name="track_distance_notification">Razdalja: %1$s</string>
-    <string name="voice_per_kilometer">na kilometer</string>
     <string name="average_heart_rate">Povprečni srčni utrip</string>
     <string name="import_parser_error">Napaka analizatorja: %1$s</string>
     <string name="settings_sensor_cycling_cadence">Kadenca</string>
@@ -443,7 +442,6 @@ limitations under the License.
     <string name="settings_sensor_wheel_circumference">Obod kolesa (mm)</string>
     <string name="settings_night_mode_option_system">Sistem</string>
     <string name="settings_public_api_disabled_toast">OpenTracks Public API je onemogočen: omogočite ga lahko v nastavitvah.</string>
-    <string name="current_heart_rate">Trenutni srčni utrip</string>
     <string name="lap_time">Čas kroga</string>
     <string name="track_detail_intervals_tab">Intervali</string>
     <string name="track_delete_not_recording">Te sledi ni mogoče izbrisati, saj je trenutno posneta.</string>

--- a/src/main/res/values-tr/strings.xml
+++ b/src/main/res/values-tr/strings.xml
@@ -489,7 +489,6 @@ limitations under the License.
     <string name="lap_time">Tur zamanı</string>
     <string name="pace">Tempo</string>
     <string name="lap_speed">Tur hızı</string>
-    <string name="voice_per_kilometer">kilometre başına</string>
     <string name="voice_per_mile">mil başına</string>
     <string name="average_heart_rate">Ortalama kalp atış hızı</string>
     <string name="total_distance">Toplam mesafe</string>
@@ -509,7 +508,6 @@ limitations under the License.
     <string name="value_float_mile_hour_recommended">%1$.1f mi/s (önerilen)</string>
     <string name="speed">Hız</string>
     <string name="settings_recording_fullscreen_on_while_recording_title">Tam ekran</string>
-    <string name="current_heart_rate">Şu anki kalp atış hızı</string>
     <string name="field_set_primary">Birincil</string>
     <string name="field_set_secondary">İkincil</string>
     <string name="settings_sensor_bluetooth_service_filter_on">Yalnızca gerekli hizmetleri bildiren Bluetooth cihazlarını göster</string>

--- a/src/main/res/values-uk/strings.xml
+++ b/src/main/res/values-uk/strings.xml
@@ -545,7 +545,6 @@ limitations under the License.
     <string name="settings_sensor_heart_rate_max">Зони: максимальна частота серцевих скорочень (уд/хв)</string>
     <string name="settings_stats_units_nautical">Морська (морські милі, фут)</string>
     <string name="settings_api_summary">API дистанційного керування та статистики для інших програм</string>
-    <string name="voice_per_kilometer">за кілометр</string>
     <string name="pace">Темп</string>
     <string name="lap_speed">Швидкість за коло</string>
     <string name="speed">Середня швидкість руху</string>
@@ -564,7 +563,6 @@ limitations under the License.
     <string name="value_integer_knots">%1$d вузлів</string>
     <string name="value_float_knots">%1$.1f вузлів</string>
     <string name="total_distance">Загальна відстань</string>
-    <string name="current_heart_rate">Поточний пульс</string>
     <string name="show_on_dashboard">OpenTracks Dashboard API</string>
     <string name="introduction_osm_dashboard">Сам OpenTracks не надає карти. Установіть OSMDashboard, щоб переглядати свої записи на карті.</string>
     <string name="show_on_dashboard_not_installed">Не встановлено програму, що підтримує OpenTracks Dashboard API.</string>

--- a/src/main/res/values-vi/strings.xml
+++ b/src/main/res/values-vi/strings.xml
@@ -513,7 +513,6 @@ limitations under the License.
     <string name="gps_recording_status">%1$s: %2$s</string>
     <string name="gps_recording_without_signal">OpenTracks đang ghi lại mà không có dữ liệu GPS.</string>
     <string name="activity_type_swimming_open">bơi trong mở nước</string>
-    <string name="voice_per_kilometer">mỗi km</string>
     <string name="total_distance">Tổng khoảng cách</string>
     <string name="settings_public_api_disabled_toast">API công khai OpenTracks bị tắt: nó có thể được bật trong cài đặt.</string>
     <string name="voice_per_mile">mỗi dặm</string>
@@ -522,7 +521,6 @@ limitations under the License.
     <string name="lap_speed">Vòng tốc độ</string>
     <string name="speed">Tốc độ di chuyển trung bình</string>
     <string name="average_heart_rate">Nhịp tim trung bình</string>
-    <string name="current_heart_rate">Hiện tại nhịp tim</string>
     <string name="settings_public_api_dashboard_enabled_summary_on">Một ứng dụng bắt đầu ghi hình cũng có thể truy cập vào dữ liệu ghi lại.</string>
     <string name="settings_public_api_dashboard_enabled_summary_off">Ghi lại dữ liệu sẽ không được miễn phí tự động với các ứng dụng khác.</string>
     <string name="settings_public_api_dashboard_enabled_title">Chuyển dữ liệu tự động</string>
@@ -563,7 +561,6 @@ limitations under the License.
     <string name="settings_stats_units_imperial_meter">Hệ Anh (dặm, mét)</string>
     <string name="voiceSpeedMilesPerHourPlural">{n, số nhiều, =1 {1 dặm trên giờ} khác {{n, số,#.0} dặm trên giờ} }</string>
     <string name="voiceDistanceMilesPlural">{n, số nhiều, =1 {1 dặm} khác {{n,số,#.0} dặm} }</string>
-    <string name="voiceSpeedKilometersPerHourPlural">{n, số nhiều, =1 {1 kilômet trên giờ} khác {{n, số,#.0} kilômet trên giờ} }</string>
     <string name="voice_on_device_speaker_title">Sử dụng loa của thiết bị</string>
     <string name="settings_ui_dynamic_colors_title">Màu sắc linh động</string>
     <string name="settings_sensor_heart_rate_max">Vùng: Nhịp tim tối đa (bpm)</string>
@@ -586,6 +583,5 @@ limitations under the License.
     <string name="voiceSpeedMKnotsPlural">{n, số nhiều, =1 {1 nút} khác {{n,số,#.0} các nút} }</string>
     <string name="value_int_seconds">%1$d s (khuyến khích)</string>
     <string name="settings_sensor_bluetooth_service_filter_title">Lọc thiết bị Bluetooth</string>
-    <string name="voiceDistanceKilometersPlural">{n, số nhiều, =1 {1 kilômet} khác {{n,số,#.0} kilômet} }</string>
     <string name="permission_recording_failed">OpenTracks yêu cầu quyền truy cập vào vị trí của bạn cũng như các thiết bị lân cận.</string>
 </resources>

--- a/src/main/res/values-zh-rTW/strings.xml
+++ b/src/main/res/values-zh-rTW/strings.xml
@@ -494,7 +494,6 @@ limitations under the License.
     <string name="value_off">關閉</string>
     <string name="value_smallest_recommended">最小（建議值）</string>
     <!-- Voice -->
-    <string name="voice_per_kilometer">每公里</string>
     <string name="voice_per_mile">每英里</string>
     <string name="voice_per_nautical_mile">每海里</string>
     <string name="lap_time">單圈時間</string>
@@ -503,7 +502,6 @@ limitations under the License.
     <string name="speed">平均移動速度</string>
     <string name="total_distance">總距離</string>
     <string name="average_heart_rate">平均心率</string>
-    <string name="current_heart_rate">目前心率</string>
     <!-- Waypoint Type -->
     <string name="waypoint_type_atm">提款機</string>
     <string name="waypoint_type_bank">銀行</string>
@@ -590,7 +588,6 @@ limitations under the License.
     <string name="settings_announcements_idle_category_title">閒置播報</string>
     <string name="voiceSpeedMilesPerHourPlural">{ n, plural, other {每小時 {n,number,#.0} 英里} }</string>
     <string name="voiceDistanceMilesPlural">{ n, plural, other {{n,number,#.0} 英里} }</string>
-    <string name="voiceSpeedKilometersPerHourPlural">{ n, plural, other {每小時 {n,number,#.0} 公里} }</string>
     <string name="sensor_state_power_max">最大功率</string>
     <string name="activity_type_kickscooter">速克達</string>
     <string name="voiceSecondsPlural">{ n, plural, other {{n} 秒} }</string>
@@ -600,7 +597,6 @@ limitations under the License.
     <string name="settings_recording_idle_timeout_title">閒置閾值</string>
     <string name="voiceSpeedMKnotsPlural">{ n, plural, other {{n,number,#.0} 節} }</string>
     <string name="value_int_seconds">%1$d 秒（建議值）</string>
-    <string name="voiceDistanceKilometersPlural">{ n, plural, other {{n,number,#.0} 公里} }</string>
     <string name="settings_ui_dynamic_colors_title">動態色彩</string>
     <string name="settings_recording_title">紀錄</string>
     <string name="settings_ui_dynamic_colors_summary">使用使用者自訂的動態色彩（僅限 Android 12+；需要手動重新啟動）</string>

--- a/src/main/res/values-zh/strings.xml
+++ b/src/main/res/values-zh/strings.xml
@@ -288,11 +288,6 @@ limitations under the License.
         other {{n} 秒}
         }
     </string>
-    <string name="voiceSpeedKilometersPerHourPlural">
-        { n, plural,
-        other {每小时 {n,number,#.0} 公里}
-        }
-    </string>
     <string name="voiceSpeedMilesPerHourPlural">
         { n, plural,
         other {每小时 {n,number,#.0} 英里}
@@ -430,7 +425,6 @@ limitations under the License.
     <string name="import_parser_error">解析器错误：%1$s</string>
     <string name="import_unable_to_import_file">无法导入文件：%1$s</string>
     <string name="menu_select_layout">选择布局</string>
-    <string name="voice_per_kilometer">每公里</string>
     <string name="track_delete_number_of_tracks">%1$d 条路线</string>
     <string name="stats_clock">时钟</string>
     <string name="export_error_post_workout">健身后导出失败，请检查导出文件夹。</string>
@@ -471,7 +465,6 @@ limitations under the License.
     <string name="value_float_knots">%1$.1f 节</string>
     <string name="value_float_knots_recommended">%1$.1f 节（推荐）</string>
     <string name="total_distance">总距离</string>
-    <string name="current_heart_rate">当前心率</string>
     <string name="sensor_state_cadence_max">最大踏频</string>
     <string name="sensor_state_heart_rate_avg">平均心率</string>
     <string name="sensor_state_heart_rate_max">最大心率</string>
@@ -490,11 +483,6 @@ limitations under the License.
     <string name="track_distance_notification">距离：%1$s</string>
     <string name="value_float_mile_hour_recommended">%1$.1f 英里/小时（推荐）</string>
     <string name="lap_time">单圈用时</string>
-    <string name="voiceDistanceKilometersPlural">
-        { n, plural,
-        other {{n,number,#.0} 公里}
-        }
-    </string>
     <string name="voiceDistanceMilesPlural">
         { n, plural,
         other {{n,number,#.0} 英里}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -582,12 +582,6 @@ limitations under the License.
         other {{n,number} seconds}
         }
     </string>
-    <string name="voiceSpeedKilometersPerHourPlural">
-        {n, plural,
-        =1 {1 kilometer per hour}
-        other {{n,number,#.0} kilometers per hour}
-        }
-    </string>
     <string name="voiceSpeedMilesPerHourPlural">
         {n, plural,
         =1 {1 mile per hour}
@@ -601,20 +595,13 @@ limitations under the License.
         }
     </string>
     <string name="voice_on_device_speaker_title">Use the device\'s speaker</string>
-    <string name="voice_per_kilometer">per kilometer</string>
     <string name="voice_per_mile">per mile</string>
     <string name="voice_per_nautical_mile">per nautical mile</string>
     <string name="lap_time">Lap time</string>
     <string name="pace">Pace</string>
     <string name="lap_speed">Lap speed</string>
-    <string name="speed">Average moving speed</string>
+    <string name="speed">Speed</string>
     <string name="total_distance">Total distance</string>
-    <string name="voiceDistanceKilometersPlural">
-        {n, plural,
-        =1 {1 kilometer}
-        other {{n,number,#.0} kilometers}
-        }
-    </string>
     <string name="voiceDistanceMilesPlural">
         {n, plural,
         =1 {1 mile}
@@ -628,7 +615,6 @@ limitations under the License.
         }
     </string>
     <string name="average_heart_rate">Average heart rate</string>
-    <string name="current_heart_rate">Current heart rate</string>
     <!-- Waypoint Type -->
     <string name="waypoint_type_atm">ATM</string>
     <string name="waypoint_type_bank">bank</string>
@@ -709,4 +695,8 @@ limitations under the License.
     <string name="always">Always</string>
 
     <string name="introduction_osm_dashboard">OpenTracks itself does not provide a map. Please install OSMDashboard to view your recordings on a map.</string>
+    <string name="moving_time">Moving time</string>
+    <string name="average_speed">Average speed</string>
+    <string name="average_pace">Average pace</string>
+    <string name="heart_rate">Heart rate</string>
 </resources>


### PR DESCRIPTION
 Fixes #1805

# Thanks for your contribution.

**Describe the pull request**
This solves #1805. It is tested on my phone except the heart rate stuff. I do not have heart rate monitor. I removed the translation strings which were used in power announcer and which are not used any more anywhere after this PR. There are about a hundred of other unused translation strings. I did not touch those. I needed to add some translation strings (see res/values/strings.xml). Only default English version was added for those.

**Link to the the issue**
#1805

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).