### PR TITLE
clarify that announcer's "distance interval" corresponds to "lap length"

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -406,7 +406,7 @@ limitations under the License.
     <string name="settings_night_mode_option_night">Night</string>
 
     <string name="settings_announcements_totaltime_frequency">Time interval</string>
-    <string name="settings_announcements_distance_frequency">Distance interval</string>
+    <string name="settings_announcements_distance_frequency">Lap length</string>
     <string name="settings_announcements_average_heart_rate">Average heart rate</string>
     <string name="settings_announcements_lap_heart_rate">Lap heart rate</string>
     <string name="settings_announcements_average_speed_pace">Average speed/pace</string>


### PR DESCRIPTION
 This fixes #1801 the most easy way. It does not implement announcer's
 interval statistics over time intervals. Instead, it only clarifies
 that "lap" quantities in the announcer are related to lap length.
 Therefore they will not work if there is no lap length defined.

# Thanks for your contribution.

**Link to the the issue**
#1801

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
