### PR TITLE
fill the area below a chart curve only when there are at most 2 curves

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartValueSeries.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartValueSeries.java
@@ -136,8 +136,10 @@ abstract class ChartValueSeries {
         return path;
     }
 
-    void drawPath(Canvas canvas) {
-        canvas.drawPath(path, fillPaint);
+    void drawPath(Canvas canvas, boolean shouldFillPathArea) {
+        if (shouldFillPathArea) {
+            canvas.drawPath(path, fillPaint);
+        }
         canvas.drawPath(path, strokePaint);
     }
 

--- a/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
@@ -116,6 +116,7 @@ public class ChartView extends View {
     private int height = 0;
     private int effectiveWidth = 0;
     private int effectiveHeight = 0;
+    private TitleDimensions titleDimensions;
 
     private boolean chartByDistance = false;
     private UnitSystem unitSystem = UnitSystem.defaultUnitSystem();
@@ -622,7 +623,7 @@ public class ChartView extends View {
     private void drawDataSeries(Canvas canvas) {
         for (ChartValueSeries chartValueSeries : seriesList) {
             if (chartValueSeries.isEnabled() && chartValueSeries.hasData()) {
-                chartValueSeries.drawPath(canvas);
+                chartValueSeries.drawPath(canvas, titleDimensions.titlePositions.size() < 3 );
             }
         }
     }
@@ -689,14 +690,13 @@ public class ChartView extends View {
      * @param canvas the canvas
      */
     private void drawSeriesTitles(Canvas canvas) {
-        TitleDimensions td = getTitleDimensions();
-        Iterator<TitlePosition> tpI = td.titlePositions.iterator();
+        Iterator<TitlePosition> tpI = titleDimensions.titlePositions.iterator();
         for (ChartValueSeries chartValueSeries : seriesList) {
             if (chartValueSeries.isEnabled() && chartValueSeries.hasData() || allowIfEmpty(chartValueSeries)) {
                 String title = getContext().getString(chartValueSeries.getTitleId(unitSystem));
                 Paint paint = chartValueSeries.getTitlePaint();
                 TitlePosition tp = tpI.next();
-                int y = topBorder - spacer - (td.lineCount - tp.line) * (td.lineHeight + spacer);
+                int y = topBorder - spacer - (titleDimensions.lineCount - tp.line) * (titleDimensions.lineHeight + spacer);
                 canvas.drawText(title, tp.xPos + getScrollX(), y, paint);
             }
         }
@@ -957,8 +957,8 @@ public class ChartView extends View {
         }
 
         leftBorder = (int) (density * BORDER + markerLength);
-        TitleDimensions td = getTitleDimensions();
-        topBorder = (int) (density * BORDER + td.lineCount * (td.lineHeight + spacer));
+        titleDimensions = getTitleDimensions();
+        topBorder = (int) (density * BORDER + titleDimensions.lineCount * (titleDimensions.lineHeight + spacer));
         Rect xAxisLabelRect = getRect(axisPaint, getXAxisLabel());
         // border + x axis marker + spacer + .5 x axis label
         bottomBorder = (int) (density * BORDER + getRect(xAxisMarkerPaint, "1").height() + spacer + (xAxisLabelRect.height() / 2));


### PR DESCRIPTION
 This makes charts more readable when there are many curves in it.

# Thanks for your contribution.

## PLEASE REMOVE
To support us in providing a nice (and fast) open-source experience:
1. Verify that the tests are passing
2. Check that the code is properly formatted (using AndroidStudio's autoformatter)
3. Provide write access to the [branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
4. If the PR is not ready for review, please submit it as a [draft](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
## PLEASE REMOVE

**Describe the pull request**
Side effects:
Disadvantage: chartDimensions as a new member of ChartView
Advantage: getChartDimensions called only once

**Link to the the issue**
#1823

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).