### PR TITLE
Marker: hold unique reference to TrackPoint.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
@@ -379,12 +379,11 @@ public class ContentProviderUtils {
         int trackIdIndex = cursor.getColumnIndexOrThrow(MarkerColumns.TRACKID);
         int lengthIndex = cursor.getColumnIndexOrThrow(MarkerColumns.LENGTH);
         int durationIndex = cursor.getColumnIndexOrThrow(MarkerColumns.DURATION);
+
         int longitudeIndex = cursor.getColumnIndexOrThrow(MarkerColumns.LONGITUDE);
         int latitudeIndex = cursor.getColumnIndexOrThrow(MarkerColumns.LATITUDE);
         int timeIndex = cursor.getColumnIndexOrThrow(MarkerColumns.TIME);
         int altitudeIndex = cursor.getColumnIndexOrThrow(MarkerColumns.ALTITUDE);
-        int accuracyIndex = cursor.getColumnIndexOrThrow(MarkerColumns.ACCURACY);
-        int bearingIndex = cursor.getColumnIndexOrThrow(MarkerColumns.BEARING);
         int photoUrlIndex = cursor.getColumnIndexOrThrow(MarkerColumns.PHOTOURL);
 
         Track.Id trackId = new Track.Id(cursor.getLong(trackIdIndex));
@@ -397,13 +396,6 @@ public class ContentProviderUtils {
         if (!cursor.isNull(altitudeIndex)) {
             marker.setAltitude(Altitude.WGS84.of(cursor.getFloat(altitudeIndex)));
         }
-        if (!cursor.isNull(accuracyIndex)) {
-            marker.setAccuracy(Distance.of(cursor.getFloat(accuracyIndex)));
-        }
-        if (!cursor.isNull(bearingIndex)) {
-            marker.setBearing(cursor.getFloat(bearingIndex));
-        }
-
         if (!cursor.isNull(idIndex)) {
             marker.setId(new Marker.Id(cursor.getLong(idIndex)));
         }
@@ -542,21 +534,9 @@ public class ContentProviderUtils {
         values.put(MarkerColumns.CATEGORY, marker.getCategory());
         values.put(MarkerColumns.ICON, marker.getIcon());
         values.put(MarkerColumns.TRACKID, marker.getTrackId().id());
+        values.put(MarkerColumns.TRACKPOINTID, marker.getTrackId().id());
         values.put(MarkerColumns.LENGTH, marker.getLength().toM());
         values.put(MarkerColumns.DURATION, marker.getDuration().toMillis());
-
-        values.put(MarkerColumns.LONGITUDE, (int) (marker.getLongitude() * 1E6));
-        values.put(MarkerColumns.LATITUDE, (int) (marker.getLatitude() * 1E6));
-        values.put(MarkerColumns.TIME, marker.getTime().toEpochMilli());
-        if (marker.hasAltitude()) {
-            values.put(MarkerColumns.ALTITUDE, marker.getAltitude().toM());
-        }
-        if (marker.hasAccuracy()) {
-            values.put(MarkerColumns.ACCURACY, marker.getAccuracy().toM());
-        }
-        if (marker.hasBearing()) {
-            values.put(MarkerColumns.BEARING, marker.getBearing());
-        }
 
         values.put(MarkerColumns.PHOTOURL, marker.getPhotoUrl());
         return values;

--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -265,16 +265,16 @@ public class CustomContentProvider extends ContentProvider {
                 return db.rawQuery(SENSOR_STATS_QUERY, new String[]{String.valueOf(trackId), String.valueOf(trackId)});
             }
             case MARKERS -> {
-                queryBuilder.setTables(MarkerColumns.TABLE_NAME);
+                queryBuilder.setTables(MarkerColumns.TABLE_NAME_JOINED);
                 sortOrder = sort != null ? sort : MarkerColumns.DEFAULT_SORT_ORDER;
             }
             case MARKERS_BY_ID -> {
-                queryBuilder.setTables(MarkerColumns.TABLE_NAME);
-                queryBuilder.appendWhere(MarkerColumns._ID + "=" + ContentUris.parseId(url));
+                queryBuilder.setTables(MarkerColumns.TABLE_NAME_JOINED);
+                queryBuilder.appendWhere(MarkerColumns.TABLE_NAME + "." + MarkerColumns._ID + "=" + ContentUris.parseId(url));
             }
             case MARKERS_BY_TRACKID -> {
-                queryBuilder.setTables(MarkerColumns.TABLE_NAME);
-                queryBuilder.appendWhere(MarkerColumns.TRACKID + " IN (" + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
+                queryBuilder.setTables(MarkerColumns.TABLE_NAME_JOINED);
+                queryBuilder.appendWhere(MarkerColumns.TABLE_NAME + "." + MarkerColumns.TRACKID + " IN (" + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
             }
             default -> throw new IllegalArgumentException("Unknown url " + url);
         }
@@ -317,7 +317,7 @@ public class CustomContentProvider extends ContentProvider {
             }
             case MARKERS_BY_ID -> {
                 table = MarkerColumns.TABLE_NAME;
-                whereClause = MarkerColumns._ID + "=" + ContentUris.parseId(url);
+                whereClause = MarkerColumns.TABLE_NAME + "." + MarkerColumns._ID + "=" + ContentUris.parseId(url);
                 if (!TextUtils.isEmpty(where)) {
                     whereClause += " AND (" + where + ")";
                 }
@@ -366,9 +366,9 @@ public class CustomContentProvider extends ContentProvider {
     private Uri insertTrackPoint(Uri url, ContentValues values) {
         boolean hasTime = values.containsKey(TrackPointsColumns.TIME);
         if (!hasTime) {
-            throw new IllegalArgumentException("Latitude, longitude, and time values are required.");
+            throw new IllegalArgumentException("Time is required.");
         }
-        long rowId = db.insert(TrackPointsColumns.TABLE_NAME, TrackPointsColumns._ID, values);
+        long rowId = db.insertOrThrow(TrackPointsColumns.TABLE_NAME, TrackPointsColumns._ID, values);
         if (rowId >= 0) {
             return ContentUris.appendId(TrackPointsColumns.CONTENT_URI_BY_ID.buildUpon(), rowId).build();
         }
@@ -376,7 +376,7 @@ public class CustomContentProvider extends ContentProvider {
     }
 
     private Uri insertTrack(Uri url, ContentValues contentValues) {
-        long rowId = db.insert(TracksColumns.TABLE_NAME, TracksColumns._ID, contentValues);
+        long rowId = db.insertOrThrow(TracksColumns.TABLE_NAME, TracksColumns._ID, contentValues);
         if (rowId >= 0) {
             return ContentUris.appendId(TracksColumns.CONTENT_URI.buildUpon(), rowId).build();
         }
@@ -384,7 +384,7 @@ public class CustomContentProvider extends ContentProvider {
     }
 
     private Uri insertMarker(Uri url, ContentValues contentValues) {
-        long rowId = db.insert(MarkerColumns.TABLE_NAME, MarkerColumns._ID, contentValues);
+        long rowId = db.insertOrThrow(MarkerColumns.TABLE_NAME, MarkerColumns._ID, contentValues);
         if (rowId >= 0) {
             return ContentUris.appendId(MarkerColumns.CONTENT_URI.buildUpon(), rowId).build();
         }

--- a/src/main/java/de/dennisguse/opentracks/data/models/Marker.java
+++ b/src/main/java/de/dennisguse/opentracks/data/models/Marker.java
@@ -51,7 +51,6 @@ public final class Marker {
     @Deprecated //Not needed
     private Distance accuracy;
     private Altitude altitude;
-    private Float bearing;
 
     //TODO It is the distance from the track starting point; rename to something more meaningful
     private Distance length;
@@ -96,9 +95,7 @@ public final class Marker {
     public void setTrackPoint(TrackPoint trackPoint) {
         this.latitude = trackPoint.getLatitude();
         this.longitude = trackPoint.getLongitude();
-        if (trackPoint.hasHorizontalAccuracy()) this.accuracy = trackPoint.getHorizontalAccuracy();
         if (trackPoint.hasAltitude()) this.altitude = trackPoint.getAltitude();
-        if (trackPoint.hasBearing()) this.bearing = trackPoint.getBearing();
     }
 
     /**
@@ -169,12 +166,6 @@ public final class Marker {
             location.setLatitude(latitude);
             location.setLongitude(longitude);
         }
-        if (hasBearing()) {
-            location.setBearing(bearing);
-        }
-        if (hasAccuracy()) {
-            location.setAccuracy((float) accuracy.toM());
-        }
         if (hasAltitude()) {
             location.setAltitude(altitude.toM());
         }
@@ -198,18 +189,6 @@ public final class Marker {
         this.longitude = longitude;
     }
 
-    public boolean hasAccuracy() {
-        return accuracy != null;
-    }
-
-    public Distance getAccuracy() {
-        return accuracy;
-    }
-
-    public void setAccuracy(Distance accuracy) {
-        this.accuracy = accuracy;
-    }
-
     public boolean hasAltitude() {
         return altitude != null;
     }
@@ -220,18 +199,6 @@ public final class Marker {
 
     public void setAltitude(Altitude altitude) {
         this.altitude = altitude;
-    }
-
-    public boolean hasBearing() {
-        return bearing != null;
-    }
-
-    public Float getBearing() {
-        return bearing;
-    }
-
-    public void setBearing(float bearing) {
-        this.bearing = bearing;
     }
 
     public Distance getLength() {

--- a/src/main/java/de/dennisguse/opentracks/data/tables/MarkerColumns.java
+++ b/src/main/java/de/dennisguse/opentracks/data/tables/MarkerColumns.java
@@ -29,6 +29,9 @@ import de.dennisguse.opentracks.data.ContentProviderUtils;
 public interface MarkerColumns extends BaseColumns {
 
     String TABLE_NAME = "markers";
+
+    String TABLE_NAME_JOINED = MarkerColumns.TABLE_NAME + " LEFT JOIN " + TrackPointsColumns.TABLE_NAME + " ON (" + TrackPointsColumns._ID + "=" + MarkerColumns._ID + ")";
+
     Uri CONTENT_URI = Uri.parse(ContentProviderUtils.CONTENT_BASE_URI + "/" + TABLE_NAME);
     Uri CONTENT_URI_BY_TRACKID = Uri.parse(ContentProviderUtils.CONTENT_BASE_URI + "/" + TABLE_NAME + "/trackid");
     String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.de.dennisguse.waypoint";
@@ -41,36 +44,32 @@ public interface MarkerColumns extends BaseColumns {
     String CATEGORY = "category"; // marker category
     String ICON = "icon"; // marker icon
     String TRACKID = "trackid"; // track id
+    String TRACKPOINTID = "trackpointid";
 
     String LENGTH = "length"; // length of the track (without smoothing)
     String DURATION = "duration"; // total duration of the track from the beginning until now
-
-    String LONGITUDE = "longitude"; // longitude
-    String LATITUDE = "latitude"; // latitude
-    String TIME = "time"; // time
-    String ALTITUDE = "elevation"; // altitude //TODO RENAME column
-    String ACCURACY = "accuracy"; // accuracy
-    String BEARING = "bearing"; // bearing
-
     String PHOTOURL = "photoUrl"; // url for the photo
+
+    // Fetched from {@link TrackPointsColumns}.
+    String LONGITUDE = TrackPointsColumns.LONGITUDE;
+    String LATITUDE = TrackPointsColumns.LATITUDE;
+    String TIME = TrackPointsColumns.TIME;
+    String ALTITUDE = TrackPointsColumns.ALTITUDE;
+
 
     String CREATE_TABLE = "CREATE TABLE " + TABLE_NAME + " ("
             + _ID + " INTEGER PRIMARY KEY AUTOINCREMENT, "
+            + TRACKID + " INTEGER NOT NULL, "
+            + TRACKPOINTID + " INTEGER NOT NULL, "
             + NAME + " TEXT, "
             + DESCRIPTION + " TEXT, "
             + CATEGORY + " TEXT, "
             + ICON + " TEXT, "
-            + TRACKID + " INTEGER NOT NULL, "
             + LENGTH + " FLOAT, "
             + DURATION + " INTEGER, "
-            + LONGITUDE + " INTEGER, "
-            + LATITUDE + " INTEGER, "
-            + TIME + " INTEGER, "
-            + ALTITUDE + " FLOAT, "
-            + ACCURACY + " FLOAT, "
-            + BEARING + " FLOAT, "
             + PHOTOURL + " TEXT, "
-            + "FOREIGN KEY (" + TRACKID + ") REFERENCES " + TracksColumns.TABLE_NAME + "(" + TracksColumns._ID + ") ON UPDATE CASCADE ON DELETE CASCADE"
+            + "FOREIGN KEY (" + TRACKID + ") REFERENCES " + TracksColumns.TABLE_NAME + "(" + TracksColumns._ID + ") ON UPDATE CASCADE ON DELETE CASCADE, "
+            + "FOREIGN KEY (" + TRACKPOINTID + ") REFERENCES " + TrackPointsColumns.TABLE_NAME + "(" + TrackPointsColumns._ID + ") ON UPDATE CASCADE ON DELETE CASCADE"
             + ")";
 
     String CREATE_TABLE_INDEX = "CREATE INDEX " + TABLE_NAME + "_" + TRACKID + "_index ON " + TABLE_NAME + "(" + TRACKID + ")";


### PR DESCRIPTION
OpenTracks only allows to create Markers if a valid location is available (i.e., a TrackPoint with location was stored).
However, in the current implementation the TrackPoint and Marker tables are independent (i.e., Markers also store lat/lng, altitude etc) and they are just indirectly linked together by `time`.
In addition, Markers have the `duration` and `length` (here distance) for being rendered on the charts.

This PR changes this on database level by adding a reference for each Marker to one TrackPoint.

**However:** Both GPX and KML allow to import Markers that are not related to any TrackPoint within a Track.

This implies that people might have Markers that cannot be linked to a TrackPoint - they might not even be close to any TrackPoint (in time as well as location).
Even worse people might have imported such Tracks on purpose to show the Markers with OSMDashboard or just to store all their tracking data in OpenTracks (from other application).

**Question:** Should OpenTracks internal data model reflect how OpenTracks works or rather keep the existing functionality?

PS/ I am not even sure that the functionality was intended this way...