### PR TITLE
Bugfix: PublicAPI stop should not start TrackRecordingService in fore…

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/publicapi/PublicApiTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/publicapi/PublicApiTest.java
@@ -1,0 +1,56 @@
+package de.dennisguse.opentracks.publicapi;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import de.dennisguse.opentracks.R;
+import de.dennisguse.opentracks.TestUtil;
+import de.dennisguse.opentracks.settings.PreferencesUtils;
+import de.dennisguse.opentracks.util.IntentUtils;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class PublicApiTest {
+
+    @Rule
+    public GrantPermissionRule mGrantPermissionRule = TestUtil.createGrantPermissionRule();
+
+    private final Context context = ApplicationProvider.getApplicationContext();
+
+    @Test
+    public void StartTest() {
+        PreferencesUtils.setBoolean(R.string.publicapi_enabled_key, true);
+
+        context.startActivity(IntentUtils.newIntent(context, StartRecording.class));
+    }
+
+    @Test
+    public void StartStopTest() throws InterruptedException {
+        PreferencesUtils.setBoolean(R.string.publicapi_enabled_key, true);
+
+        context.startActivity(IntentUtils.newIntent(context, StartRecording.class));
+
+        Thread.sleep(5000);
+
+        context.startActivity(IntentUtils.newIntent(context, StopRecording.class));
+    }
+
+    @Test
+    public void StopAndWait() throws InterruptedException {
+        PreferencesUtils.setBoolean(R.string.publicapi_enabled_key, true);
+
+        context.startActivity(IntentUtils.newIntent(context, StopRecording.class));
+
+        Thread.sleep(10000);
+
+        //No ForegroundServiceDidNotStartInTimeException should be happening.
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceConnection.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceConnection.java
@@ -26,7 +26,6 @@ import android.os.RemoteException;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 
 import de.dennisguse.opentracks.BuildConfig;
 
@@ -81,7 +80,8 @@ public class TrackRecordingServiceConnection {
         }
 
         Log.i(TAG, "Binding the service.");
-        int flags = BuildConfig.DEBUG ? Context.BIND_DEBUG_UNBIND : 0;
+
+        int flags = Context.BIND_AUTO_CREATE + (BuildConfig.DEBUG ? Context.BIND_DEBUG_UNBIND : 0);
         context.bindService(new Intent(context, TrackRecordingService.class), serviceConnection, flags);
     }
 
@@ -142,6 +142,6 @@ public class TrackRecordingServiceConnection {
         new TrackRecordingServiceConnection(withUnbind)
                 .bind(context);
 
-        ContextCompat.startForegroundService(context, new Intent(context, TrackRecordingService.class));
+        // ContextCompat.startForegroundService(context, new Intent(context, TrackRecordingService.class));
     }
 }


### PR DESCRIPTION
…ground.

Actually, TrackRecordingService will start in foreground if needed.

Fixes #1850.
