### PR TITLE
KMZ importer allows arbitrary file names for kml (was doc.kml).

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
@@ -37,7 +37,6 @@ import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.ContentProviderUtils;
 import de.dennisguse.opentracks.data.models.Marker;
 import de.dennisguse.opentracks.data.models.Track;
-import de.dennisguse.opentracks.io.file.exporter.KmzTrackExporter;
 import de.dennisguse.opentracks.util.FileUtils;
 
 /**
@@ -48,6 +47,8 @@ import de.dennisguse.opentracks.util.FileUtils;
 public class KmzTrackImporter {
 
     private static final String TAG = KmzTrackImporter.class.getSimpleName();
+
+    private static final String KML_FILE_EXTENSION = ".kml";
 
     private static final List<String> KMZ_IMAGES_EXT = List.of("jpeg", "jpg", "png");
 
@@ -156,7 +157,7 @@ public class KmzTrackImporter {
                 }
 
                 String fileName = zipEntry.getName();
-                if (KmzTrackExporter.KMZ_KML_FILE.equals(fileName)) {
+                if (fileName.endsWith(KML_FILE_EXTENSION)) {
                     List<Track.Id> trackId = parseKml(zipInputStream);
                     if (trackId.isEmpty()) {
                         Log.d(TAG, "Unable to parse kml in kmz");

--- a/src/main/res/values-b+es+419/strings.xml
+++ b/src/main/res/values-b+es+419/strings.xml
@@ -316,7 +316,7 @@
         <item quantity="other">Completado con %1$d errores</item>
     </plurals>
     <string name="import_thread_interrupted">Hilo interrumpido</string>
-    <string name="import_no_kml_file_found">No se ha encontrado ningún archivo doc.kml en KMZ</string>
+    <string name="import_no_kml_file_found">No se ha encontrado ningún archivo kml en KMZ</string>
     <string name="sensor_state_power_avg">Potencia promedio</string>
     <string name="sensor_could_not_scan">No se pudieron buscar dispositivos Bluetooth (error %1$i).</string>
     <string name="settings_prevent_reimport_tracks_title">Evitar reimportar los recorridos</string>

--- a/src/main/res/values-bg/strings.xml
+++ b/src/main/res/values-bg/strings.xml
@@ -333,7 +333,7 @@ limitations under the License.
     <string name="track_recording_notification_accuracy">Точност на локацията: %1$s</string>
     <string name="about_version_name">Име на версията: %1$s</string>
     <string name="settings_recording_fullscreen_on_while_recording_summary">По време на запис присъства в режим на цял екран.</string>
-    <string name="import_no_kml_file_found">В KMZ не е открит файл doc.kml</string>
+    <string name="import_no_kml_file_found">В KMZ не е открит файл kml</string>
     <string name="help_gps_troubleshooting_content"> Какво можете да направите:
 \n а) проверете дали GPS е активиран,
 \n б) да подобрите приемането на GPS (например да излезете на открито),

--- a/src/main/res/values-cs/strings.xml
+++ b/src/main/res/values-cs/strings.xml
@@ -379,7 +379,7 @@ limitations under the License.
     <string name="generic_completed">Ukončeno</string>
     <string name="gps_disabled_msg">GPS vypnuto</string>
     <string name="gps_fixed_and_ready">GPS zaměřeno a připraveno</string>
-    <string name="import_no_kml_file_found">Soubor doc.kml nenalezen v KMZ</string>
+    <string name="import_no_kml_file_found">Soubor kml nenalezen v KMZ</string>
     <string name="settings_default_trackfileformat">Formát souboru pro export/sdílení</string>
     <string name="settings_recording_fullscreen_on_while_recording_title">Na celou obrazovku</string>
     <string name="settings_recording_fullscreen_on_while_recording_summary">Při nahrávání využívat celou obrazovku.</string>

--- a/src/main/res/values-da/strings.xml
+++ b/src/main/res/values-da/strings.xml
@@ -390,7 +390,7 @@ limitations under the License.
     <string name="export_track_errors">Filer ikke eksporteret</string>
     <string name="gps_disabled_msg">GPS deaktiveret</string>
     <string name="gps_fixed_and_ready">GPS fastsat og klar</string>
-    <string name="import_no_kml_file_found">Ingen doc.kml-fil fundet i KMZ</string>
+    <string name="import_no_kml_file_found">Ingen kml-fil fundet i KMZ</string>
     <string name="sensor_state_cadence_avg">Gns. kadence</string>
     <string name="sensor_state_cadence_max">Maks. kadence</string>
     <string name="sensor_state_heart_rate_avg">Gns. Puls</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -471,7 +471,7 @@ Meldet das GPS-Gerät ungenaue Daten (z.B. Standort, Geschwindigkeit, Höhe), ka
     <string name="settings_recording_fullscreen_on_while_recording_summary">Anzeige im Vollbildmodus während der Aufzeichnung.</string>
     <string name="sensor_state_heart_rate_avg">Durchschnittlicher Herzfrequenz</string>
     <string name="settings_prevent_reimport_tracks_title">Verhindere den erneuten Import von Strecken(aufzeichnungen)</string>
-    <string name="import_no_kml_file_found">Keine doc.kml Datei im KMZ gefunden</string>
+    <string name="import_no_kml_file_found">Keine kml Datei im KMZ gefunden</string>
     <string name="import_thread_interrupted">Thread unterbrochen</string>
     <string name="import_unable_to_import_file">Importieren der Datei gescheitert: %1$s</string>
     <string name="settings_sensor_cycling_cadence">Trittfrequenz</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -466,7 +466,7 @@ limitations under the License.
     <string name="export_progress_summary_errors_msg">Errores</string>
     <string name="generic_open_track">Abrir recorrido</string>
     <string name="import_progress_summary_exists_msg">Ya existe</string>
-    <string name="import_no_kml_file_found">No se ha encontrado ningún archivo doc.kml en KMZ</string>
+    <string name="import_no_kml_file_found">No se ha encontrado ningún archivo kml en KMZ</string>
     <string name="import_prevent_reimport">Ha configurado evitar la reimportación del recorrido</string>
     <string name="track_distance_notification">Distancia: %1$s</string>
     <string name="track_speed_notification">Velocidad: %1$s</string>

--- a/src/main/res/values-et/strings.xml
+++ b/src/main/res/values-et/strings.xml
@@ -421,7 +421,7 @@ limitations under the License.
     <string name="generic_click_twice_cancel">Tühistamiseks vajutage uuesti tagasi</string>
     <string name="gps_disabled_msg">GPS keelatud</string>
     <string name="import_unsupported_format">Toetamata failivorming</string>
-    <string name="import_no_kml_file_found">doc.kml faili ei leitud KMZ-st</string>
+    <string name="import_no_kml_file_found">kml faili ei leitud KMZ-st</string>
     <string name="import_error_info">%1$s: %2$s</string>
     <string name="import_error_list_dialog_title">Faile pole imporditud</string>
     <string name="import_file_imported">Fail %1$s imporditud</string>

--- a/src/main/res/values-eu/strings.xml
+++ b/src/main/res/values-eu/strings.xml
@@ -427,7 +427,7 @@ GPS gailuak datu okerrak salatzen baditu (adibidez, kokapena, abiadura, kota), O
     <string name="import_progress_summary_errors_msg">Akatsak</string>
     <string name="import_parser_error">Analizatzailea errorea: %1$s</string>
     <string name="import_unable_to_import_file">Ezin izan da inportazio fitxategia: %1$s</string>
-    <string name="import_no_kml_file_found">Ez doc.kml fitxategia aurkitu KMZ</string>
+    <string name="import_no_kml_file_found">Ez kml fitxategia aurkitu KMZ</string>
     <string name="import_error_info">%1$s: %2$s</string>
     <string name="import_progress_summary_exists_msg">Dagoeneko existitzen da</string>
     <string name="import_prevent_reimport">Ezarri duzu saihesteko re-import track</string>

--- a/src/main/res/values-fi/strings.xml
+++ b/src/main/res/values-fi/strings.xml
@@ -386,7 +386,7 @@ limitations under the License.
     <string name="instant_export_enabled_title">Instant post-workout vienti</string>
     <string name="hold_to_stop">Pidä lopettaa</string>
     <string name="gps_fixed_and_ready">GPS kiinteä ja valmis</string>
-    <string name="import_no_kml_file_found">Ei doc.KML tiedosto löytyy KMZ</string>
+    <string name="import_no_kml_file_found">Ei kml tiedosto löytyy KMZ</string>
     <string name="settings_default_export_uri_title">Seuraa vientihakemistoa</string>
     <string name="instant_export_enabled_summary">Vie reitti tiedostoon tallennuksen loputtua</string>
     <string name="settings_sensor_wheel_circumference">Pyörän ympärysmitta (mm)</string>

--- a/src/main/res/values-ga/strings.xml
+++ b/src/main/res/values-ga/strings.xml
@@ -156,7 +156,7 @@
     <string name="import_unsupported_format">Formáid comhaid nach dtacaítear léi</string>
     <string name="import_parser_error">Earráid pharsálaí: %1$s</string>
     <string name="import_unable_to_import_file">Ní féidir an comhad a iompórtáil: %1$s</string>
-    <string name="import_no_kml_file_found">Níor aimsíodh aon chomhad doc.kml i KMZ</string>
+    <string name="import_no_kml_file_found">Níor aimsíodh aon chomhad kml i KMZ</string>
     <string name="import_error_info">%1$s: %2$s</string>
     <string name="import_progress_summary_exists_msg">Atá ann cheana</string>
     <string name="import_progress_summary_errors_msg">Earráidí</string>

--- a/src/main/res/values-gl/strings.xml
+++ b/src/main/res/values-gl/strings.xml
@@ -416,7 +416,7 @@ Se o GPS informa sobre datos pouco precisos (ex.: localización, velocidade, ele
     <string name="instant_export_enabled_summary">Rematou a exportación da ruta á almacenaxe tras a gravación</string>
     <string name="import_thread_interrupted">Fío interrumpido</string>
     <string name="export_progress_summary_new_msg">Exportados os novos ficheiros</string>
-    <string name="import_no_kml_file_found">Non se atopou ficheiro doc.kml en KMZ</string>
+    <string name="import_no_kml_file_found">Non se atopou ficheiro kml en KMZ</string>
     <string name="stats_loss">Perda</string>
     <string name="description_altitude_loss">Perda de altitude: %1$d m (%2$d ft)</string>
     <string name="export_error_post_workout">Fallou a exportación, comproba o directorio de exportación.</string>

--- a/src/main/res/values-hr/strings.xml
+++ b/src/main/res/values-hr/strings.xml
@@ -379,7 +379,7 @@ limitations under the License.
     <string name="settings_public_api_package_title">Ime paketa za javni API</string>
     <string name="sensor_could_not_scan">Neuspjelo traženje Bluetooth uređaja (greška %1$i).</string>
     <string name="help_storage_pictures_content">One se spremaju u internoj memoriji aplikacije (dostupne su samo unutar OpenTracksa).</string>
-    <string name="import_no_kml_file_found">U KMZ-u nije pronađena datoteka doc.kml</string>
+    <string name="import_no_kml_file_found">U KMZ-u nije pronađena datoteka kml</string>
     <string name="settings_announcements_idle_category_title">Najave o neaktivnosti</string>
     <string name="generic_open_track">Otvori rutu</string>
     <string name="sensor_state_power_unit">W</string>

--- a/src/main/res/values-hu/strings.xml
+++ b/src/main/res/values-hu/strings.xml
@@ -384,7 +384,7 @@ limitations under the License.
     <string name="gps_disabled_msg">GPS letiltva</string>
     <string name="gps_fixed_and_ready">GPS rögzítve és készen áll</string>
     <string name="import_unable_to_import_file">Nem sikerült importálni a fájlt: %1$s</string>
-    <string name="import_no_kml_file_found">Nincs doc.kml fájl található a KMZ fájlban</string>
+    <string name="import_no_kml_file_found">Nincs kml fájl található a KMZ fájlban</string>
     <string name="import_error_info">%1$s: %2$s</string>
     <string name="import_file_imported">Fájl %1$s importálva</string>
     <string name="import_prevent_reimport">Beállítottad, hogy megakadályozd az újraimportálást</string>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -425,7 +425,7 @@ Infatti, un\'applicazione deve supportare <i>ACTION_VIEW</i> con MIME <i>applica
     <string name="export_progress_summary_skip_msg">Tracce saltate</string>
     <string name="export_progress_summary_overwrite_msg">Tracce sovrascritte</string>
     <string name="export_progress_summary_new_msg">Nuove tracce esportate</string>
-    <string name="import_no_kml_file_found">Nessun file doc.kml trovato in KMZ</string>
+    <string name="import_no_kml_file_found">Nessun file kml trovato in KMZ</string>
     <string name="import_progress_summary_ok_msg">File importati</string>
     <string name="import_progress_summary_exists_msg">Esiste già</string>
     <string name="import_progress_summary_errors_msg">Errori</string>

--- a/src/main/res/values-kn/strings.xml
+++ b/src/main/res/values-kn/strings.xml
@@ -191,7 +191,7 @@
     <string name="image_discard">ತ್ಯಜಿಸಿ</string>
     <string name="image_track">ಟ್ರ್ಯಾಕ್</string>
     <string name="import_thread_interrupted">ಥ್ರೆಡ್ ಅಡಚಣೆಯಾಗಿದೆ</string>
-    <string name="import_no_kml_file_found">KMZ ನಲ್ಲಿ ಯಾವುದೇ doc.kml ಫೈಲ್ ಕಂಡುಬಂದಿಲ್ಲ</string>
+    <string name="import_no_kml_file_found">KMZ ನಲ್ಲಿ ಯಾವುದೇ kml ಫೈಲ್ ಕಂಡುಬಂದಿಲ್ಲ</string>
     <string name="import_unsupported_format">ಫೈಲ್ ಫಾರ್ಮ್ಯಾಟ್ ಬೆಂಬಲಿತವಾಗಿಲ್ಲ</string>
     <string name="import_parser_error">ಪಾರ್ಸರ್ ದೋಷ: %1$s</string>
     <string name="import_unable_to_import_file">ಫೈಲ್ ಅನ್ನು ಆಮದು ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ: %1$s</string>

--- a/src/main/res/values-lt/strings.xml
+++ b/src/main/res/values-lt/strings.xml
@@ -393,7 +393,7 @@ limitations under the License.
     <string name="sensor_state_heart_rate_max">Maksimalus širdies ritmas</string>
     <string name="help_recording_title">Kaip OpenTracks įrašo duomenis\?</string>
     <string name="settings_recording_fullscreen_on_while_recording_title">Per visą ekraną</string>
-    <string name="import_no_kml_file_found">KMZ nerastas doc.kml failas</string>
+    <string name="import_no_kml_file_found">KMZ nerastas kml failas</string>
     <string name="settings_sensor_wheel_circumference">Rato apskritimas (mm)</string>
     <string name="about_version_code">Versijos kodas: %1$d</string>
     <string name="hold_to_stop">Laikykite sustabdyti</string>

--- a/src/main/res/values-nb/strings.xml
+++ b/src/main/res/values-nb/strings.xml
@@ -414,7 +414,7 @@ limitations under the License.
     <string name="export_error_post_workout">Eksport etter opptak feilet. Sjekk eksportmappen.</string>
     <string name="export_progress_summary_new_msg">Nye filer eksportert</string>
     <string name="import_progress_summary_ok_msg">Filer importert</string>
-    <string name="import_no_kml_file_found">Ingen doc.kml-fil funnet i KMZ</string>
+    <string name="import_no_kml_file_found">Ingen kml-fil funnet i KMZ</string>
     <string name="export_progress_summary_overwrite_msg">Filer overskrevet</string>
     <string name="export_progress_summary_skip_msg">Filer hoppet over</string>
     <string name="export_progress_summary_errors_msg">Feil</string>

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -385,7 +385,7 @@ Als het GPS-apparaat onnauwkeurige gegevens rapporteert (bijv. locatie, snelheid
     <string name="generic_click_twice_cancel">Klik nogmaals terug om te annuleren</string>
     <string name="settings_default_export_uri_title">Spoor export map</string>
     <string name="import_thread_interrupted">Draad onderbroken</string>
-    <string name="import_no_kml_file_found">Geen doc.kml bestand gevonden in KMZ</string>
+    <string name="import_no_kml_file_found">Geen kml bestand gevonden in KMZ</string>
     <string name="settings_recording_fullscreen_on_while_recording_title">Volledig scherm</string>
     <string name="gps_fixed_and_ready">GPS vast en klaar</string>
     <string name="aggregated_stats_empty_message">Neem uw eerste route op om geaggregeerde statistieken te zien</string>

--- a/src/main/res/values-pl/strings.xml
+++ b/src/main/res/values-pl/strings.xml
@@ -431,7 +431,7 @@ limitations under the License.
     <string name="import_progress_summary_exists_msg">Już istnieje</string>
     <string name="import_progress_summary_ok_msg">Pliki importowane</string>
     <string name="import_file_imported">Plik %1$s zaimportowany</string>
-    <string name="import_no_kml_file_found">W pliku KMZ nie znaleziono pliku doc.kml</string>
+    <string name="import_no_kml_file_found">W pliku KMZ nie znaleziono pliku kml</string>
     <string name="import_error_info">%1$s: %2$s</string>
     <string name="track_pace_notification">Prędkość: %1$s</string>
     <string name="track_speed_notification">Szybkość: %1$s</string>

--- a/src/main/res/values-pt-rBR/strings.xml
+++ b/src/main/res/values-pt-rBR/strings.xml
@@ -365,7 +365,7 @@
     <string name="export_error_post_workout">A exportação pós-treino falhou, verifique o diretório de exportação.</string>
     <string name="description_altitude_loss">Perda de elevação: %1$d m (%2$d ft)</string>
     <string name="export_progress_summary_new_msg">Novas trilhas exportadas</string>
-    <string name="import_no_kml_file_found">Nenhum arquivo doc.kml encontrado no KMZ</string>
+    <string name="import_no_kml_file_found">Nenhum arquivo kml encontrado no KMZ</string>
     <string name="settings_prevent_reimport_tracks_title">Impedir a reimportação de trilhas</string>
     <string name="export_progress_summary_overwrite_msg">Trilhas sobrescritas</string>
     <string name="export_progress_summary_skip_msg">Trilhas puladas</string>

--- a/src/main/res/values-pt-rPT/strings.xml
+++ b/src/main/res/values-pt-rPT/strings.xml
@@ -390,7 +390,7 @@
     <string name="import_unsupported_format">Formato de ficheiro não suportado</string>
     <string name="import_parser_error">Erro do analisador: %1$s</string>
     <string name="import_unable_to_import_file">Não foi possível importar o ficheiro: %1$s</string>
-    <string name="import_no_kml_file_found">Nenhum ficheiro doc.kml encontrado no KMZ</string>
+    <string name="import_no_kml_file_found">Nenhum ficheiro kml encontrado no KMZ</string>
     <string name="import_error_info">%1$s: %2$s</string>
     <string name="import_error_list_dialog_title">Ficheiros não importados</string>
     <string name="import_file_imported">Ficheiro %1$s importado</string>

--- a/src/main/res/values-pt/strings.xml
+++ b/src/main/res/values-pt/strings.xml
@@ -426,7 +426,7 @@ limitations under the License.
     <string name="import_unsupported_format">Formato de ficheiro não suportado</string>
     <string name="import_parser_error">Erro do analisador: %1$s</string>
     <string name="import_unable_to_import_file">Não foi possível importar o ficheiro: %1$s</string>
-    <string name="import_no_kml_file_found">Nenhum ficheiro doc.kml encontrado no KMZ</string>
+    <string name="import_no_kml_file_found">Nenhum ficheiro kml encontrado no KMZ</string>
     <string name="import_file_imported">Ficheiro %1$s importado</string>
     <string name="import_prevent_reimport">Definiu evitar reimportar a trilha</string>
     <string name="import_progress_summary_ok_msg">Ficheiros importados</string>

--- a/src/main/res/values-ro/strings.xml
+++ b/src/main/res/values-ro/strings.xml
@@ -395,7 +395,7 @@ limitations under the License.
     <string name="sensor_state_cadence_max">Max Cadență</string>
     <string name="sensor_could_not_scan">Nu a fost posibilă scanarea pentru dispozitive Bluetooth (eroare %1$i).</string>
     <string name="share_image_subject">Aș dori să vă împărtășesc o imagine</string>
-    <string name="import_no_kml_file_found">Nu s-a găsit niciun fișier doc.kml în KMZ</string>
+    <string name="import_no_kml_file_found">Nu s-a găsit niciun fișier kml în KMZ</string>
     <string name="settings_prevent_reimport_tracks_title">Împiedicați reimportul de piese</string>
     <string name="import_progress_summary_ok_msg">Fișierele importate</string>
     <string name="permission_gps_failed">OpenTracks necesită permisiunea de a utiliza GPS.</string>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -352,7 +352,7 @@ limitations under the License.
     <string name="import_file_imported">Файл %1$s импортирован</string>
     <string name="import_error_list_dialog_title">Файлы не импортированы</string>
     <string name="import_error_info">%1$s: %2$s</string>
-    <string name="import_no_kml_file_found">Файл doc.kml не найден в KMZ</string>
+    <string name="import_no_kml_file_found">Файл kml не найден в KMZ</string>
     <string name="import_unable_to_import_file">Невозможно импортировать файл: %1$s</string>
     <string name="import_parser_error">Ошибка обработки: %1$s</string>
     <string name="import_unsupported_format">Неподдерживаемый формат файла</string>

--- a/src/main/res/values-sk/strings.xml
+++ b/src/main/res/values-sk/strings.xml
@@ -396,7 +396,7 @@ limitations under the License.
     <string name="menu_insert_gallery_img">Vložiť obrázok do galérie</string>
     <string name="menu_voice_rate">Rýchlosť hlasu</string>
     <string name="import_unable_to_import_file">Nie je možné importovať súbor: %1$s</string>
-    <string name="import_no_kml_file_found">V KMZ nebol nájdený žiadny súbor doc.kml</string>
+    <string name="import_no_kml_file_found">V KMZ nebol nájdený žiadny súbor kml</string>
     <string name="generic_undo">Zrušiť</string>
     <string name="gps_fixed_and_ready">GPS pevná a pripravená</string>
     <string name="import_error_info">%1$s: %2$s</string>

--- a/src/main/res/values-sv/strings.xml
+++ b/src/main/res/values-sv/strings.xml
@@ -411,7 +411,7 @@ limitations under the License.
     <string name="help_track_export_content"> Spår kan exporteras från inställningarna som KMZ, KML eller GPX. KMZ/KML alla data; GPX endast platser. Spår som delas via <i>delningsikonen</i> delas som KMZ. </string>
     <string name="about_preference_title">Om OpenTracks</string>
     <string name="import_progress_summary_errors_msg">Fel</string>
-    <string name="import_no_kml_file_found">Ingen doc.KML-filen finns i KMZ</string>
+    <string name="import_no_kml_file_found">Ingen kml-filen finns i KMZ</string>
     <string name="import_prevent_reimport">Du har angett förhindra åter importera spår</string>
     <string name="menu_resume_track">Återuppta spår</string>
     <string name="import_unsupported_format">Filformat som inte stöds</string>

--- a/src/main/res/values-tr/strings.xml
+++ b/src/main/res/values-tr/strings.xml
@@ -351,7 +351,7 @@ limitations under the License.
     <string name="import_parser_error">Ayrıştırıcı hatası: %1$s</string>
     <string name="import_unable_to_import_file">Dosya içe aktarılamıyor: %1$s</string>
     <string name="import_unsupported_format">Desteklenmeyen dosya formatı</string>
-    <string name="import_no_kml_file_found">KMZ\'de doc.kml dosyası bulunamadı</string>
+    <string name="import_no_kml_file_found">KMZ\'de kml dosyası bulunamadı</string>
     <string name="import_error_info">%1$s: %2$s</string>
     <string name="import_error_list_dialog_title">Dosyalar içe aktarılmadı</string>
     <string name="menu_filter">Filtrele</string>

--- a/src/main/res/values-uk/strings.xml
+++ b/src/main/res/values-uk/strings.xml
@@ -371,7 +371,7 @@ limitations under the License.
     <string name="import_thread_interrupted">Поток перервано</string>
     <string name="import_unsupported_format">Формат файлу не підтримується</string>
     <string name="import_parser_error">Помилка парсера: %1$s</string>
-    <string name="import_no_kml_file_found">Файл doc.kml не знайдено в KMZ</string>
+    <string name="import_no_kml_file_found">Файл kml не знайдено в KMZ</string>
     <string name="import_error_list_dialog_title">Файли не імпортовано</string>
     <string name="import_error_info">%1$s:%2$s</string>
     <string name="marker_add_photo_canceled">Скасовано, фото-маркування не додано</string>

--- a/src/main/res/values-vi/strings.xml
+++ b/src/main/res/values-vi/strings.xml
@@ -390,7 +390,7 @@ limitations under the License.
     <string name="marker_add_photo_canceled">Đã hủy, không có dấu ảnh nào được thêm</string>
     <string name="generic_completed">Hoàn tất</string>
     <string name="export_progress_summary_errors_msg">Lỗi</string>
-    <string name="import_no_kml_file_found">Không tìm thấy tệp doc.kml nào trong KMZ</string>
+    <string name="import_no_kml_file_found">Không tìm thấy tệp kml nào trong KMZ</string>
     <string name="activity_type_escooter">xe scooter điện</string>
     <plurals name="generic_completed_with_errors">
         <item quantity="other">Đã hoàn tất với %1$d lỗi</item>

--- a/src/main/res/values-zh-rTW/strings.xml
+++ b/src/main/res/values-zh-rTW/strings.xml
@@ -239,7 +239,7 @@ limitations under the License.
     <string name="import_unsupported_format">未支援的檔案格式</string>
     <string name="import_parser_error">分析器錯誤：%1$s</string>
     <string name="import_unable_to_import_file">無法匯入檔案：%1$s</string>
-    <string name="import_no_kml_file_found">在 KMZ 中沒有發現 doc.kml 檔案</string>
+    <string name="import_no_kml_file_found">在 KMZ 中沒有發現 kml 檔案</string>
     <string name="import_error_info">%1$s：%2$s</string>
     <string name="import_error_list_dialog_title">檔案未匯入</string>
     <string name="import_file_imported">檔案 %1$s 已匯入</string>

--- a/src/main/res/values-zh/strings.xml
+++ b/src/main/res/values-zh/strings.xml
@@ -578,7 +578,7 @@ limitations under the License.
     <string name="activity_type_workout">健身</string>
     <string name="generic_today">今天</string>
     <string name="generic_yesterday">昨天</string>
-    <string name="import_no_kml_file_found">在 KMZ 中没有找到 doc.kml 文件</string>
+    <string name="import_no_kml_file_found">在 KMZ 中没有找到 kml 文件</string>
     <string name="import_error_info">%1$s：%2$s</string>
     <string name="import_error_list_dialog_title">文件未导入</string>
     <string name="import_file_imported">文件 %1$s 已导入</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -267,7 +267,7 @@ limitations under the License.
     <string name="import_unsupported_format">Unsupported file format</string>
     <string name="import_parser_error">Parser error: %1$s</string>
     <string name="import_unable_to_import_file">Unable to import file: %1$s</string>
-    <string name="import_no_kml_file_found">No doc.kml file found in KMZ</string>
+    <string name="import_no_kml_file_found">No kml file found in KMZ</string>
     <string name="import_error_info">%1$s: %2$s</string>
     <string name="import_error_list_dialog_title">Files not imported</string>
     <string name="import_file_imported">File %1$s imported</string>


### PR DESCRIPTION
Fixes #1864.
