### PR TITLE
Bugfix: overestimated distance.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/sensors/sensorData/Aggregator.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/sensorData/Aggregator.java
@@ -44,7 +44,7 @@ public abstract class Aggregator<Input, Output> {
 
     public Output getValue() {
         if (!hasValue()) {
-            return null;
+            return null; //TODO Check if this is a good idea!
         }
         if (isRecent()) {
             return value;

--- a/src/main/java/de/dennisguse/opentracks/sensors/sensorData/AggregatorGPS.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/sensorData/AggregatorGPS.java
@@ -4,7 +4,10 @@ import android.location.Location;
 
 import androidx.annotation.NonNull;
 
-public class AggregatorGPS extends Aggregator<Location, Location> {
+import java.util.Optional;
+
+public class AggregatorGPS extends Aggregator<Location, Optional<Location>> {
+
 
     public AggregatorGPS(String sensorAddress) {
         super(sensorAddress);
@@ -12,7 +15,7 @@ public class AggregatorGPS extends Aggregator<Location, Location> {
 
     @Override
     protected void computeValue(Raw<Location> current) {
-        value = current.value();
+        value = Optional.of(current.value());
     }
 
     @Override
@@ -22,7 +25,7 @@ public class AggregatorGPS extends Aggregator<Location, Location> {
 
     @NonNull
     @Override
-    protected Location getNoneValue() {
-        return new Location("none");
+    protected Optional<Location> getNoneValue() {
+        return Optional.empty();
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/sensors/sensorData/SensorDataSet.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/sensorData/SensorDataSet.java
@@ -152,7 +152,8 @@ public final class SensorDataSet {
 
     public void fillTrackPoint(TrackPoint trackPoint) {
         if (gps != null && gps.hasValue()) {
-            trackPoint.setLocation(gps.getValue());
+            gps.getValue()
+                    .ifPresent(trackPoint::setLocation);
         }
 
         if (getHeartRate() != null) {

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
@@ -197,6 +197,9 @@ public class TrackRecordingManager implements SharedPreferences.OnSharedPreferen
 
         if (trackPoint.hasLocation() && lastStoredTrackPointWithLocation == null) {
             insertTrackPoint(trackPoint, true);
+
+            handler.removeCallbacks(ON_IDLE);
+            handler.postDelayed(ON_IDLE, idleDuration.toMillis());
             return true;
         }
 


### PR DESCRIPTION
A combination of idle trackpoint and stale GPS data, resulted in recording lat=0.0 and lng=0.0; and thus inflating distance as well as GPS-based speed.

Fixes #1898.

Introduced in dfdbc373ff90c37c8fb5fab396f3c470eee65772