### PR TITLE
Update README_TESTED_SENSORS.md

### DIFF
--- a/README_TESTED_SENSORS.md
+++ b/README_TESTED_SENSORS.md
@@ -12,6 +12,7 @@
 * Mi Band 3, Amazfit Band 5, Amazfit Bip. These devices are manufactured by Huami, and other Huami devices will very likely work. Theoretically, this sensor must be enabled, but testing reveals that it works even without enabling. For details on how to enable see [Gadgetbridge wiki](https://codeberg.org/Freeyourgadget/Gadgetbridge/wiki/Huami-Heartrate-measurement#bluetooth-heart-rate-sensor)
 * Amazfit Neo. But first you have to enable "Discoverable" and "Activity heart rate sharing" in the official Zepp app. (after pairing with OpenTracks you can disable them again)
 * Garmin HRM-Dual (Reference: 010-12883-00)
+* CYCPLUS H1
 
 ## 0x1816: Cycling Cadence and Speed Service
 


### PR DESCRIPTION
I have thoroughly tested the CYCPLUS H1 heart rate monitor in Opentracks, and I it works flawlessly. It tracks heart rate accurately and it pairs quickly with the app.

**Describe the pull request**
A clear and concise description of what the pull request changes/adds.
This adds the CYCPLUS H1 heart rate monitor to the list of tested devices in README_TESTED_SENSORS.md

**Link to the the issue**
(If available): The link to the issue that this pull request solves.
NA

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
Yes.
