### PR TITLE
Center icons in marker-list and track-list search bar

### DIFF
--- a/src/main/res/layout/marker_list.xml
+++ b/src/main/res/layout/marker_list.xml
@@ -25,7 +25,7 @@ limitations under the License.
         <com.google.android.material.search.SearchBar
             android:id="@+id/marker_list_toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
+            android:layout_height="wrap_content"
             app:navigationIcon="@drawable/ic_marker_show_24dp"
             app:layout_behavior="@string/searchbar_scrolling_view_behavior"
             app:menu="@menu/marker_list" />

--- a/src/main/res/layout/track_list.xml
+++ b/src/main/res/layout/track_list.xml
@@ -25,7 +25,7 @@ limitations under the License.
         <com.google.android.material.search.SearchBar
             android:id="@+id/track_list_toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
+            android:layout_height="wrap_content"
             app:navigationIcon="@drawable/ic_logo_color_24dp"
             app:layout_behavior="@string/searchbar_scrolling_view_behavior"
             app:menu="@menu/track_list" />


### PR DESCRIPTION
Fixes #1962

The icons in the search bar of the track-list and marker-list views are now centered.