### PR TITLE
Bugfix: Track list not updating recording status correctly.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/ui/TrackListAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/TrackListAdapter.java
@@ -92,10 +92,12 @@ public class TrackListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
     public void updateRecordingStatus(RecordingStatus recordingStatus) {
         this.recordingStatus = recordingStatus;
+        this.notifyDataSetChanged();
     }
 
     public void updateUnitSystem(UnitSystem unitSystem) {
         this.unitSystem = unitSystem;
+        this.notifyDataSetChanged();
     }
 
     @Override


### PR DESCRIPTION
One should react to underlying data changes if it changes, right?

Fixes #1934.
Fixes #1982.