### PR TITLE
fix(api,service): from intent api, launch record service on foreground

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/publicapi/AbstractAPIActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/publicapi/AbstractAPIActivity.java
@@ -37,7 +37,7 @@ public abstract class AbstractAPIActivity extends AppCompatActivity {
 
         if (PreferencesUtils.isPublicAPIenabled()) {
             Log.i(TAG, "Received and trying to execute requested action.");
-            TrackRecordingServiceConnection.execute(this, serviceConnectedCallback);
+            TrackRecordingServiceConnection.executeForeground(this, serviceConnectedCallback);
         } else {
             Toast.makeText(this, getString(R.string.settings_public_api_disabled_toast), Toast.LENGTH_LONG).show();
             Log.w(TAG, "Public API is disabled; ignoring request.");


### PR DESCRIPTION
Fixes : https://github.com/OpenTracksApp/OpenTracks/issues/1904
As record service uses foreground notification, 
replaces the launch of the the record service from intent api.

Uses
~~~
executeForeground
~~~
Instead of 
~~~
execute
~~~

Please review and ajust (if needed) before merge, as my knowledge of the code base is close to null for now.

Thanks.