### PR TITLE
Settings: add custom language/locale chooser (SDK33+).

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/settings/LocalePreference.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/LocalePreference.java
@@ -1,0 +1,107 @@
+package de.dennisguse.opentracks.settings;
+
+import android.app.LocaleConfig;
+import android.content.Context;
+import android.os.Build;
+import android.os.LocaleList;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.os.LocaleListCompat;
+import androidx.preference.ListPreference;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Locale;
+
+import de.dennisguse.opentracks.R;
+
+public class LocalePreference extends ListPreference {
+
+    public LocalePreference(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init(context);
+    }
+
+    public LocalePreference(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context);
+    }
+
+    public LocalePreference(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
+    }
+
+    public LocalePreference(@NonNull Context context) {
+        super(context);
+        init(context);
+    }
+
+    private void init(Context context) {
+        setPersistent(false);
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            setEnabled(false);
+            return;
+        }
+        LocaleItem systemDefaultLocale = new LocaleItem("", context.getString(R.string.settings_locale_system_default));
+
+        LocaleItem currentLocale = new LocaleItem(Locale.getDefault().toLanguageTag(), Locale.getDefault().getDisplayName());
+
+        // All available options
+        LocaleList supportedLocales = LocaleConfig.fromContextIgnoringOverride(context).getSupportedLocales();
+        ArrayList<LocaleItem> localeItemsSorting = new ArrayList<>();
+        for (int i = 0; i < supportedLocales.size(); i++) {
+            Locale current = supportedLocales.get(i);
+            localeItemsSorting.add(new LocaleItem(current.toLanguageTag(), current.getDisplayName()));
+        }
+
+        localeItemsSorting.removeIf(current -> current.languageTag.equals(currentLocale.languageTag));
+        localeItemsSorting.sort(Comparator.comparing(o -> o.displayName));
+
+        ArrayList<LocaleItem> localeItemList = new ArrayList<>();
+        localeItemList.add(systemDefaultLocale);
+        localeItemList.add(currentLocale);
+        localeItemList.addAll(localeItemsSorting);
+
+        ArrayList<String> entries = new ArrayList<>();
+        ArrayList<String> entryValues = new ArrayList<>();
+
+        for (LocaleItem current : localeItemList) {
+            entries.add(current.displayName);
+            entryValues.add(current.languageTag);
+        }
+
+        setEntries(entries.toArray(new String[]{}));
+        setEntryValues(entryValues.toArray(new String[]{}));
+
+        if (AppCompatDelegate.getApplicationLocales().equals(LocaleListCompat.getEmptyLocaleList())) {
+            setValue(systemDefaultLocale.languageTag);
+        } else {
+            setValue(currentLocale.languageTag);
+        }
+    }
+
+    @Override
+    public void setOnPreferenceChangeListener(@Nullable OnPreferenceChangeListener onPreferenceChangeListener) {
+        super.setOnPreferenceChangeListener(onPreferenceChangeListener);
+    }
+
+    @Override
+    public boolean callChangeListener(Object newValue) {
+        LocaleListCompat newLocale = LocaleListCompat.getEmptyLocaleList();
+        if (!newValue.equals("")) {
+            newLocale = LocaleListCompat.forLanguageTags((String) newValue);
+        }
+        AppCompatDelegate.setApplicationLocales(newLocale);
+        return super.callChangeListener(newValue);
+    }
+
+    record LocaleItem(
+            String languageTag,
+            String displayName
+    ) {
+    }
+}

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -279,6 +279,9 @@
     <bool name="settings_ui_dynamic_colors_default" translatable="false">false</bool>
 
     <!-- androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode() -->
+    <string name="locale_key" translatable="false">localeKey</string>
+
+    <!-- androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode() -->
     <string name="night_mode_key" translatable="false">nightMode</string>
     <string name="night_mode_default" translatable="false">@string/night_mode_system_value</string>
     <string name="night_mode_no_value" translatable="false">1</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -371,6 +371,9 @@ limitations under the License.
     <string name="settings_recording_track_name_number_option">Number</string>
     <string name="settings_recording_track_name_title">Default track name</string>
     <string name="settings_recording_idle_timeout_title">Idle threshold</string>
+    <string name="settings_locale_title">Language</string>
+    <string name="settings_locale_system_default">System default</string>
+
     <string name="settings_night_mode_title">UI Theme</string>
     <string name="settings_night_mode_option_system">System</string>
     <string name="settings_night_mode_option_day">Day</string>

--- a/src/main/res/xml/settings_user_interface.xml
+++ b/src/main/res/xml/settings_user_interface.xml
@@ -4,6 +4,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/settings_ui_title">
 
+    <de.dennisguse.opentracks.settings.LocalePreference
+        android:key="@string/locale_key"
+        android:persistent="false"
+        android:title="@string/settings_locale_title"
+        app:useSimpleSummaryProvider="true" />
+
     <ListPreference
         android:defaultValue="@string/night_mode_default"
         android:entries="@array/night_mode_options"


### PR DESCRIPTION
Corsican was not available using Android's per-app-language-chooser.

Fixes #1974.

# Thanks for your contribution.

## PLEASE REMOVE
To support us in providing a nice (and fast) open-source experience:
1. Verify that the tests are passing
2. Check that the code is properly formatted (using AndroidStudio's autoformatter)
3. Provide write access to the [branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
4. If the PR is not ready for review, please submit it as a [draft](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
## PLEASE REMOVE

**Describe the pull request**
A clear and concise description of what the pull request changes/adds.

**Link to the the issue**
(If available): The link to the issue that this pull request solves.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
