### PR TITLE
Bugfix: PublicAPI StartRecording recorded no data.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/publicapi/PublicApiTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/publicapi/PublicApiTest.java
@@ -31,13 +31,7 @@ public class PublicApiTest {
 
     private final Context context = ApplicationProvider.getApplicationContext();
 
-    @Test
-    public void StartTest() {
-        PreferencesUtils.setBoolean(R.string.publicapi_enabled_key, true);
-
-        context.startActivity(IntentUtils.newIntent(context, StartRecording.class));
-    }
-
+    //NOTE: this doesn't check if the TrackRecordingService was started in foreground.
     @Test
     public void StartStopTest() throws InterruptedException {
         PreferencesUtils.setBoolean(R.string.publicapi_enabled_key, true);

--- a/src/main/java/de/dennisguse/opentracks/publicapi/AbstractAPIActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/publicapi/AbstractAPIActivity.java
@@ -33,11 +33,15 @@ public abstract class AbstractAPIActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         SplashScreen splashScreen = SplashScreen.installSplashScreen(this);
         super.onCreate(savedInstanceState);
-        splashScreen.setKeepOnScreenCondition(() -> true );
+        splashScreen.setKeepOnScreenCondition(() -> true);
 
         if (PreferencesUtils.isPublicAPIenabled()) {
             Log.i(TAG, "Received and trying to execute requested action.");
-            TrackRecordingServiceConnection.execute(this, serviceConnectedCallback);
+            if (requiresForeground()) {
+                TrackRecordingServiceConnection.executeForeground(this, serviceConnectedCallback);
+            } else {
+                TrackRecordingServiceConnection.execute(this, serviceConnectedCallback);
+            }
         } else {
             Toast.makeText(this, getString(R.string.settings_public_api_disabled_toast), Toast.LENGTH_LONG).show();
             Log.w(TAG, "Public API is disabled; ignoring request.");
@@ -48,4 +52,8 @@ public abstract class AbstractAPIActivity extends AppCompatActivity {
     protected abstract void execute(TrackRecordingService service);
 
     protected abstract boolean isPostExecuteStopService();
+
+    protected boolean requiresForeground() {
+        return false;
+    }
 }

--- a/src/main/java/de/dennisguse/opentracks/publicapi/StartRecording.java
+++ b/src/main/java/de/dennisguse/opentracks/publicapi/StartRecording.java
@@ -62,4 +62,9 @@ public class StartRecording extends AbstractAPIActivity {
     protected boolean isPostExecuteStopService() {
         return false;
     }
+
+    @Override
+    protected boolean requiresForeground() {
+        return true;
+    }
 }


### PR DESCRIPTION
Problem was that the TrackRecordingService was not started as a ForegroundService anymore.

Fixes #1904.