### PR TITLE
Bugfix: on idle detection reset movement-based sensor data.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/sensors/sensorData/Aggregator.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/sensorData/Aggregator.java
@@ -55,7 +55,9 @@ public abstract class Aggregator<Input, Output> {
     /**
      * Reset long term aggregated values (more than derived from previous SensorData). e.g. overall distance.
      */
-    public void reset() {}
+    public void reset() {
+        value = getNoneValue();
+    }
 
     /**
      * Is the data recent considering the current time.

--- a/src/main/java/de/dennisguse/opentracks/sensors/sensorData/AggregatorBarometer.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/sensorData/AggregatorBarometer.java
@@ -37,10 +37,5 @@ public class AggregatorBarometer extends Aggregator<AtmosphericPressure, Altitud
         return new AltitudeGainLoss(0f, 0f);
     }
 
-    @Override
-    public void reset() {
-        value = getNoneValue();
-    }
-
     public record Data(Altitude gain, Altitude loss) {}
 }

--- a/src/main/java/de/dennisguse/opentracks/sensors/sensorData/AggregatorGPS.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/sensorData/AggregatorGPS.java
@@ -16,11 +16,6 @@ public class AggregatorGPS extends Aggregator<Position, Position> {
         value = current.value();
     }
 
-    @Override
-    public void reset() {
-        value = null;
-    }
-
     @NonNull
     @Override
     protected Position getNoneValue() {

--- a/src/main/java/de/dennisguse/opentracks/sensors/sensorData/AggregatorHeartRate.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/sensorData/AggregatorHeartRate.java
@@ -15,6 +15,11 @@ public class AggregatorHeartRate extends Aggregator<HeartRate, HeartRate> {
         this.value = current.value();
     }
 
+    @Override
+    public void reset() {
+        // We don't need to reset the heart rate as this value is valid for a certain amount of time: and it is not an aggregate.
+    }
+
     @NonNull
     @Override
     protected HeartRate getNoneValue() {


### PR DESCRIPTION
When becoming idle, reset the sensor data, so it is only stored once.
If after becoming idle, the sensors report new data that's fine.

Fixes #1995.