### PR TITLE
WIP - add settings toggles for chart series (#1297)

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartFragment.java
@@ -86,6 +86,7 @@ public class ChartFragment extends Fragment implements TrackDataHub.Listener {
                     });
                 }
             }
+
             if (PreferencesUtils.isKey(R.string.stats_rate_key, key)) {
                 boolean reportSpeed = PreferencesUtils.isReportSpeed(activityTypeLocalized);
                 if (reportSpeed != viewBinding.chartView.getReportSpeed()) {
@@ -98,6 +99,21 @@ public class ChartFragment extends Fragment implements TrackDataHub.Listener {
                         }
                     });
                 }
+            }
+
+            if (PreferencesUtils.isKey(R.string.chart_display_elevation_key, key)) {
+                viewBinding.chartView.setShowElevation(PreferencesUtils.shouldShowElevation());
+                refreshChart();
+            }
+
+            if (PreferencesUtils.isKey(R.string.chart_display_pace_or_speed_key, key)) {
+                viewBinding.chartView.setShowPaceOrSpeed(PreferencesUtils.shouldShowPaceOrSpeed());
+                refreshChart();
+            }
+
+            if (PreferencesUtils.isKey(R.string.chart_display_heart_rate_key, key)) {
+                viewBinding.chartView.setShowHeartRate(PreferencesUtils.shouldShowHeartRate());
+                refreshChart();
             }
         }
     };
@@ -272,5 +288,14 @@ public class ChartFragment extends Fragment implements TrackDataHub.Listener {
         if (fragmentActivity != null) {
             fragmentActivity.runOnUiThread(runnable);
         }
+    }
+
+    private void refreshChart() {
+        runOnUiThread(() -> {
+            if (isResumed()) {
+                viewBinding.chartView.invalidate();
+                viewBinding.chartView.requestLayout();
+            }
+        });
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -318,6 +318,21 @@ public class PreferencesUtils {
         return getBoolean(R.string.stats_fullscreen_while_recording_key, DEFAULT);
     }
 
+    public static boolean shouldShowElevation() {
+        final boolean DEFAULT = resources.getBoolean(R.bool.chart_display_elevation_default);
+        return getBoolean(R.string.chart_display_elevation_key, DEFAULT);
+    }
+
+    public static boolean shouldShowPaceOrSpeed() {
+        final boolean DEFAULT = resources.getBoolean(R.bool.chart_display_pace_or_speed_default);
+        return getBoolean(R.string.chart_display_pace_or_speed_key, DEFAULT);
+    }
+
+    public static boolean shouldShowHeartRate() {
+        final boolean DEFAULT = resources.getBoolean(R.bool.chart_display_heart_rate_default);
+        return getBoolean(R.string.chart_display_heart_rate_key, DEFAULT);
+    }
+
     public static boolean shouldUseDynamicColors() {
         final boolean DEFAULT = resources.getBoolean(R.bool.settings_ui_dynamic_colors_default);
         return getBoolean(R.string.settings_ui_dynamic_colors_key, DEFAULT);

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Do not translate anything in this file directly. -->
-    <string name="stats_show_on_lockscreen_while_recording_key" translatable="false">trackdetail_show_on_lockscreen_while_recording</string>
-    <bool name="stats_show_on_lockscreen_while_recording_default" translatable="false">false</bool>
-
-    <string name="stats_keep_screen_on_while_recording_key" translatable="false">trackdetail_keep_screen_on_while_recording</string>
-    <bool name="stats_keep_screen_on_while_recording_default" translatable="false">false</bool>
-
-    <string name="stats_fullscreen_while_recording_key" translatable="false">trackdetail_fullscreen_while_recording</string>
-    <bool name="stats_fullscreen_while_recording_default" translatable="false">false</bool>
 
     <!-- Main settings -->
     <string name="settings_defaults_key" translatable="false">settingsDefaults</string>
@@ -279,8 +271,31 @@
     <string name="show_introduction_screen_key" translatable="false">showIntroduction</string>
     <bool name="show_introduction_screen_default">true</bool>
 
+    <!-- User Interface Settings -->
+
     <string name="settings_ui_dynamic_colors_key" translatable="false">uiDynamicColors</string>
     <bool name="settings_ui_dynamic_colors_default" translatable="false">false</bool>
+
+    <!-- Recording Settings -->
+    <string name="stats_show_on_lockscreen_while_recording_key" translatable="false">trackdetail_show_on_lockscreen_while_recording</string>
+    <bool name="stats_show_on_lockscreen_while_recording_default" translatable="false">false</bool>
+
+    <string name="stats_keep_screen_on_while_recording_key" translatable="false">trackdetail_keep_screen_on_while_recording</string>
+    <bool name="stats_keep_screen_on_while_recording_default" translatable="false">false</bool>
+
+    <string name="stats_fullscreen_while_recording_key" translatable="false">trackdetail_fullscreen_while_recording</string>
+    <bool name="stats_fullscreen_while_recording_default" translatable="false">false</bool>
+
+    <!-- Chart Settings -->
+    <string name="chart_display_elevation_key" translatable="false">chart_display_elevation</string>
+    <bool name="chart_display_elevation_default" translatable="false">true</bool>
+
+    <string name="chart_display_pace_or_speed_key" translatable="false">chart_display_pace_or_speed</string>
+    <bool name="chart_display_pace_or_speed_default" translatable="false">true</bool>
+
+    <string name="chart_display_heart_rate_key" translatable="false">chart_display_heart_rate</string>
+    <bool name="chart_display_heart_rate_default" translatable="false">true</bool>
+
 
     <!-- androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode() -->
     <string name="locale_key" translatable="false">localeKey</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -344,6 +344,11 @@ limitations under the License.
     <!-- Settings Chart -->
     <string name="settings_chart_by_distance">By distance</string>
     <string name="settings_chart_by_time">By time</string>
+    <string name="settings_charts_title">Charts</string>
+    <string name="settings_chart_display_elevation_title">Display elevation</string>
+    <string name="settings_chart_display_pace_or_speed_title">Display pace or speed</string>
+    <string name="settings_chart_display_heart_rate_title">Display heart rate</string>
+
     <!-- Settings Recording -->
     <string name="settings_recording_title">Recording</string>
     <string name="settings_theme_switch_restart">Theme changes may require a manual restart.</string>

--- a/src/main/res/xml/settings_user_interface.xml
+++ b/src/main/res/xml/settings_user_interface.xml
@@ -58,4 +58,23 @@
             android:title="@string/settings_recording_fullscreen_on_while_recording_title" />
     </PreferenceCategory>
 
+    <PreferenceCategory app:title="@string/settings_charts_title">
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_activity_climbing_24dp"
+            android:defaultValue="@bool/chart_display_elevation_default"
+            android:key="@string/chart_display_elevation_key"
+            android:title="@string/settings_chart_display_elevation_title" />
+
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_activity_snowboarding_24dp"
+            android:defaultValue="@bool/chart_display_pace_or_speed_default"
+            android:key="@string/chart_display_pace_or_speed_key"
+            android:title="@string/settings_chart_display_pace_or_speed_title" />
+
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_activity_workout_24dp"
+            android:defaultValue="@bool/chart_display_heart_rate_default"
+            android:key="@string/chart_display_heart_rate_key"
+            android:title="@string/settings_chart_display_heart_rate_title" />
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Description
Adds toggles to the User Interface section of the app Settings that allow the user to display or hide the three series available in the chart: Elevation, Speed/Pace, and Heart Rate. As a user of a heart rate monitor primarily during strength workouts and combat sports, the distance and elevation graphs are not helpful to me - in addition, their scale means that I am not able to easily see my exact heart rate. This should allow users in a similar situation to better determine exactly what is most helpful for them to be seen on the graph.

<img width="285" alt="image" src="https://github.com/user-attachments/assets/109d5ec1-092a-4fc0-8e08-e1dcb157943d" />
<img width="411" alt="image" src="https://github.com/user-attachments/assets/d6da65af-fc08-4aa3-87fe-1d24a7812f21" />


## Related Issues
- #1297 
- #2040 
