### PR TITLE
Fix crash in overeager translations

### DIFF
--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -637,7 +637,7 @@ Meldet das GPS-Gerät ungenaue Daten (z.B. Standort, Geschwindigkeit, Höhe), ka
     <string name="settings_announcements_unit">Distanz/Geschwindigkeits Einheit</string>
     <string name="power_x_watt">Leistung {x, plural, =1 {1 Watt} other {# Watt} }</string>
     <string name="power">Leistung</string>
-    <string name="voiceDistance">{n, plural, =1 {1 } anderes {{n,number,#.0}} }</string>
+    <string name="voiceDistance">{n, plural, =1 {1 } other {{n,number,#.0}} }</string>
     <string name="settings_recording_min_sampling_interval_title">Abtastzeitintervall</string>
     <string name="voiceIdle">Untätig werden.</string>
     <string name="voice_announce_lap_power_key">StimmeAnkündigungLapPower</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -657,11 +657,11 @@ Si le dispositif GPS signale des données inexactes (par exemple, la localisatio
     <string name="permission_recording_failed">OpenTracks a besoin de la permission d\'accéder à votre localisation ainsi qu\'aux appareils à proximité.</string>
     <string name="create_marker_error">Impossible de créer un marqueur. Veuillez réessayer.</string>
     <string name="power">Puissance</string>
-    <string name="power_x_watt">Puissance {x, plural, =1 {1 watt} autres {# watt} }</string>
+    <string name="power_x_watt">Puissance {x, plural, =1 {1 watt} other {# watt} }</string>
     <string name="settings_announcements_lap_power">Puissance par tour</string>
     <string name="activity_type_kickscooter">trottinette</string>
-    <string name="voiceSpeed">{n, plural, =1 {1} autres {{n,number,#.0}} }</string>
-    <string name="voiceDistance">{n, plural, =1 {1 } autres {{n,number,#.0}} }</string>
+    <string name="voiceSpeed">{n, plural, =1 {1} other {{n,number,#.0}} }</string>
+    <string name="voiceDistance">{n, plural, =1 {1 } other {{n,number,#.0}} }</string>
     <string name="settings_locale_system_default">Paramètres par défaut du système</string>
     <string name="settings_locale_title">Langue</string>
     <string name="stats_gain_loss">Gain et perte</string>

--- a/src/main/res/values-ga/strings.xml
+++ b/src/main/res/values-ga/strings.xml
@@ -507,11 +507,11 @@
     <string name="settings_announcements_unit">Aonad faid/luas</string>
     <string name="value_internal_sensor">Braiteoir inmheánach</string>
     <string name="voiceIdle">Ag éirí díomhaoin.</string>
-    <string name="voiceSecondsPlural">{n, iolra, =1 {1 soicind} eile {{ n,uimhir} soicind} }</string>
-    <string name="voiceSpeedKilometersPerHourPlural">{n, iolra, =1 {1 chiliméadar in aghaidh na huaire} eile {{ n,uimhir, #.0} ciliméadar san uair} }</string>
-    <string name="voiceSpeedMKnotsPlural">{n, iolra, =1 {1 snaidhm} eile {{ n,uimhir, #.0} snaidhm} }</string>
-    <string name="voiceDistanceNauticalMilesPlural">{n, iolra, =1 {1 mhuirmhíle} eile {{ n,uimhir, #.0} muirmhíle} }</string>
-    <string name="voiceDistance">{n, iolra, =1 {1 } eile {{ n,uimhir, #.0}} }</string>
+    <string name="voiceSecondsPlural">{n, plural, =1 {1 soicind} other {{ n,number} soicind} }</string>
+    <string name="voiceSpeedKilometersPerHourPlural">{n, plural, =1 {1 chiliméadar in aghaidh na huaire} other {{ n,number, #.0} ciliméadar san uair} }</string>
+    <string name="voiceSpeedMKnotsPlural">{n, plural, =1 {1 snaidhm} other {{ n,number, #.0} snaidhm} }</string>
+    <string name="voiceDistanceNauticalMilesPlural">{n, plural, =1 {1 mhuirmhíle} other {{ n,number, #.0} muirmhíle} }</string>
+    <string name="voiceDistance">{n, plural, =1 {1 } other {{ n,number, #.0}} }</string>
     <string name="settings_recording_min_sampling_interval_title">Eatramh ama samplála</string>
     <string name="sensor_state_cadence_unit">rpm</string>
     <string name="sensor_state_heart_rate_unit">bpm</string>
@@ -527,20 +527,20 @@
     <string name="settings_api_summary">Cianrialú agus staitisticí API le haghaidh aipeanna eile</string>
     <string name="create_marker_error">Ní féidir marcóir a chruthú. Déan iarracht arís.</string>
     <string name="sensor_state_power_unit">W</string>
-    <string name="voiceMinutesPlural">{n, iolra, =1 {1 nóiméad} eile {{ n,uimhir} nóiméad} }</string>
-    <string name="voiceDistanceKilometersPlural">{n, iolra, =1 {1 chiliméadar} eile {{ n,uimhir, #.0} ciliméadar} }</string>
+    <string name="voiceMinutesPlural">{n, plural, =1 {1 nóiméad} other {{ n,number} nóiméad} }</string>
+    <string name="voiceDistanceKilometersPlural">{n, plural, =1 {1 chiliméadar} other {{ n,number, #.0} ciliméadar} }</string>
     <string name="sensor_state_power_max">Cumhacht Max</string>
     <string name="bluetooth_sensor_summary">%1$s (%2$s)</string>
-    <string name="voiceHoursPlural">{n, iolra, =1 {1 uair} eile {{ n,uimhir} uair an chloig} }</string>
-    <string name="voiceDistanceMilesPlural">{n, iolra, =1 {1 mhíle} eile {{ n,uimhir, #.0} míle} }</string>
+    <string name="voiceHoursPlural">{n, plural, =1 {1 uair} other {{ n,number} uair an chloig} }</string>
+    <string name="voiceDistanceMilesPlural">{n, plural, =1 {1 mhíle} other {{ n,number, #.0} míle} }</string>
     <string name="no_compatible_camera_installed">Níl feidhmchlár ceamara comhoiriúnach suiteáilte</string>
-    <string name="voiceSpeedMilesPerHourPlural">{n, iolra, =1 {1 mhíle san uair} eile {{ n,uimhir, #.0} míle san uair} }</string>
-    <string name="voiceSpeed">{n, iolra, =1 {1} eile {{ n,uimhir, #.0}} }</string>
+    <string name="voiceSpeedMilesPerHourPlural">{n, plural, =1 {1 mhíle san uair} other {{ n,number, #.0} míle san uair} }</string>
+    <string name="voiceSpeed">{n, plural, =1 {1} other {{ n,number, #.0}} }</string>
     <string name="voice_on_device_speaker_title">Úsáid cainteoir an ghléis</string>
     <string name="no_compatible_gallery_installed">Níl feidhmchlár gailearaí íomhá comhoiriúnach suiteáilte</string>
     <string name="settings_recording_location_distance_summary">%1$s idir suíomhanna taifeadta</string>
     <string name="settings_announcements_lap_power">Cumhacht glúine</string>
-    <string name="power_x_watt">Cumhacht {x, iolra, = 1 {1 vata} eile {# vata} }</string>
+    <string name="power_x_watt">Cumhacht {x, plural, = 1 {1 vata} other {# vata} }</string>
     <string name="empty">" "</string>
     <string name="settings_locale_system_default">Réamhshocrú córais</string>
     <string name="settings_locale_title">Teanga</string>

--- a/src/main/res/values-ta/strings.xml
+++ b/src/main/res/values-ta/strings.xml
@@ -65,7 +65,7 @@
     <string name="settings_recording_location_distance_summary">பதிவுசெய்யப்பட்ட இடங்களுக்கு இடையில் %1$s</string>
     <string name="voice_announce_lap_power_key">VoiceAnnouncelappower</string>
     <string name="settings_announcements_lap_power">மடியில் ஆற்றல்</string>
-    <string name="power_x_watt">ஆற்றல் {x, பன்மை, = 1 {1 watt} பிற {# வாட்ச்}}</string>
+    <string name="power_x_watt">ஆற்றல் {x, plural, = 1 {1 watt} other {# வாட்ச்}}</string>
     <string name="power">விசை</string>
     <string name="help_feature_content">* சி.பி.எச் தடங்களை உருவாக்கவும்\n * இதய துடிப்பு சென்சார் பயன்படுத்தவும் (புளூடூத் லு மட்டும்)\n * குரல் அறிவிப்புகள் (நேரம் அல்லது தூரத்தின் அடிப்படையில்)\n * குறிப்பான்களை உருவாக்கு (படங்கள் உள்ளிட்டவை)\n * முற்றிலும் ஆஃப்லைனில் வேலை செய்கிறது\n * வரைபடத்தில் தடங்களைக் காண்பி (கீழே காண்க)</string>
     <string name="help_track_map_title">வரைபடத்தில் ஒரு பாதையை எவ்வாறு காண்பிப்பது?</string>
@@ -411,13 +411,13 @@
     <string name="value_smallest_recommended">சிறியது (பரிந்துரைக்கப்படுகிறது)</string>
     <string name="value_int_seconds">%1$d கள் (பரிந்துரைக்கப்படுகிறது)</string>
     <string name="voiceIdle">சும்மா ஆக.</string>
-    <string name="voiceHoursPlural">{n, பன்மை, = 1 {1 hour} பிற {{n, எண்} மணிநேரம்}}</string>
-    <string name="voiceMinutesPlural">{n, பன்மை, = 1 {1 minute} பிற {{n, எண்} நிமிடங்கள்}}</string>
-    <string name="voiceSecondsPlural">{n, பன்மை, = 1 {1 second} பிற {{n, எண்} விநாடிகள்}}</string>
-    <string name="voiceSpeedKilometersPerHourPlural">{n, பன்மை, = 1 {1 kilometer per hour} பிற {{n, எண்,#. 0} ஒரு மணி நேரத்திற்கு கிலோமீட்டர்}}</string>
-    <string name="voiceSpeedMKnotsPlural">{n, பன்மை, = 1 {1 knot} பிற {{n, எண்,#. 0} முடிச்சுகள்}}</string>
-    <string name="voiceSpeedMilesPerHourPlural">{n, பன்மை, = 1 {1 mile per hour} பிற {{n, எண்,#. 0} ஒரு மணி நேரத்திற்கு மைல்கள்}}</string>
-    <string name="voiceSpeed">{n, பன்மை, = 1 {1} பிற {{n, எண்,#. 0}}}</string>
+    <string name="voiceHoursPlural">{n, plural, = 1 {1 hour} other {{n,number} மணிநேரம்}}</string>
+    <string name="voiceMinutesPlural">{n, plural, = 1 {1 minute} other {{n,number} நிமிடங்கள்}}</string>
+    <string name="voiceSecondsPlural">{n, plural, = 1 {1 second} other {{n,number} விநாடிகள்}}</string>
+    <string name="voiceSpeedKilometersPerHourPlural">{n, plural, = 1 {1 kilometer per hour} other {{n,number,#. 0} ஒரு மணி நேரத்திற்கு கிலோமீட்டர்}}</string>
+    <string name="voiceSpeedMKnotsPlural">{n, plural, = 1 {1 knot} other {{n,number,#. 0} முடிச்சுகள்}}</string>
+    <string name="voiceSpeedMilesPerHourPlural">{n, plural, = 1 {1 mile per hour} other {{n,number,#. 0} ஒரு மணி நேரத்திற்கு மைல்கள்}}</string>
+    <string name="voiceSpeed">{n, plural, = 1 {1} other {{n,number,#. 0}}}</string>
     <string name="voice_on_device_speaker_title">சாதனத்தின் ச்பீக்கரைப் பயன்படுத்தவும்</string>
     <string name="voice_per_kilometer">ஒரு கிலோமீட்டருக்கு</string>
     <string name="voice_per_nautical_mile">ஒரு கடல் மைலுக்கு</string>
@@ -426,10 +426,10 @@
     <string name="lap_speed">மடியில் விரைவு</string>
     <string name="speed">சராசரி நகரும் விரைவு</string>
     <string name="total_distance">மொத்த தூரம்</string>
-    <string name="voiceDistanceKilometersPlural">{n, பன்மை, = 1 {1 kilometer} பிற {{n, எண்,#. 0} கிலோமீட்டர்}}</string>
-    <string name="voiceDistanceMilesPlural">{n, பன்மை, = 1 {1 mile} பிற {{n, எண்,#. 0} மைல்கள்}}</string>
-    <string name="voiceDistanceNauticalMilesPlural">{n, பன்மை, = 1 {1 nautical mile} பிற {{n, எண்,#. 0} கடல் மைல்கள்}}</string>
-    <string name="voiceDistance">{n, பன்மை, = 1 {1 } பிற {{n, எண்,#. 0}}}</string>
+    <string name="voiceDistanceKilometersPlural">{n, plural, = 1 {1 kilometer} other {{n,number,#. 0} கிலோமீட்டர்}}</string>
+    <string name="voiceDistanceMilesPlural">{n, plural, = 1 {1 mile} other {{n,number,#. 0} மைல்கள்}}</string>
+    <string name="voiceDistanceNauticalMilesPlural">{n, plural, = 1 {1 nautical mile} other {{n,number,#. 0} கடல் மைல்கள்}}</string>
+    <string name="voiceDistance">{n, plural, = 1 {1 } other {{n,number,#. 0}}}</string>
     <string name="average_heart_rate">சராசரி இதய துடிப்பு</string>
     <string name="current_heart_rate">தற்போதைய இதய துடிப்பு</string>
     <string name="lap_heart_rate">மடியில் இதய துடிப்பு</string>


### PR DESCRIPTION
**Describe the pull request**

This fixes #2097: translation of template keywords.

**Link to the the issue**

#2097

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)). :heavy_check_mark: 