### PR TITLE
Enabled edge-to-edge rendering and applied navbar insets

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/AbstractActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/AbstractActivity.java
@@ -50,8 +50,12 @@ public abstract class AbstractActivity extends AppCompatActivity {
         View rootView = getRootView();
         setContentView(rootView);
 
+        apply_insets(rootView);
+    }
+
+    private void apply_insets(View rootView) {
         View bottom_app_bar = findViewById(R.id.bottom_app_bar);
-        if (bottom_app_bar != null) {
+        if (rootView != null) {
             // Apply navbar insets to the whole content
             ViewCompat.setOnApplyWindowInsetsListener(rootView, (view, windowInsets) -> {
                 Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
@@ -61,6 +65,8 @@ public abstract class AbstractActivity extends AppCompatActivity {
                 // Return the insets to apply to the next view (BottomAppBar)
                 return windowInsets;
             });
+        }
+        if (bottom_app_bar != null) {
             // Apply status and navbar insets to BottomAppBar
             // WARNING: this is called twice for bottomappbar.xml
             ViewCompat.setOnApplyWindowInsetsListener(bottom_app_bar, (view, windowInsets) -> {

--- a/src/main/java/de/dennisguse/opentracks/AbstractActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/AbstractActivity.java
@@ -16,11 +16,16 @@
 
 package de.dennisguse.opentracks;
 
+import android.content.res.TypedArray;
 import android.os.Bundle;
 import android.view.View;
 
 import androidx.appcompat.app.AppCompatActivity;
-
+import androidx.activity.EdgeToEdge;
+import androidx.core.graphics.Insets;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.ViewCompat;
+import android.view.ViewGroup.LayoutParams;
 import de.dennisguse.opentracks.services.announcement.TTSManager;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
 
@@ -35,12 +40,45 @@ public abstract class AbstractActivity extends AppCompatActivity {
             setTheme(R.style.OpenTracksThemeOled);
         }
 
+        // Enable edge-to-edge rendering
+        EdgeToEdge.enable(this);
         super.onCreate(savedInstanceState);
 
         // Set volume control stream for text to speech
         setVolumeControlStream(TTSManager.AUDIO_STREAM);
 
-        setContentView(getRootView());
+        View rootView = getRootView();
+        setContentView(rootView);
+
+        View bottom_app_bar = findViewById(R.id.bottom_app_bar);
+        if (bottom_app_bar != null) {
+            // Apply navbar insets to the whole content
+            ViewCompat.setOnApplyWindowInsetsListener(rootView, (view, windowInsets) -> {
+                Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+                // Apply the insets as a padding to the view.
+                // Don't need to set the top inset for some reason (?)
+                view.setPadding(insets.left, 0, insets.right, 0);
+                // Return the insets to apply to the next view (BottomAppBar)
+                return windowInsets;
+            });
+            // Apply status and navbar insets to BottomAppBar
+            // WARNING: this is called twice for bottomappbar.xml
+            ViewCompat.setOnApplyWindowInsetsListener(bottom_app_bar, (view, windowInsets) -> {
+                Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+                // Apply the insets as a padding to the view.
+                view.setPadding(0, 0, 0, insets.bottom);
+                // Set new height to account for the inset
+                LayoutParams layout = view.getLayoutParams();
+                // Get actionBar height attribute
+                final TypedArray arr = obtainStyledAttributes(new int[] { com.google.android.material.R.attr.actionBarSize });
+                int actionBarHeight = (int) arr.getDimension(0, 0f);
+                arr.recycle();
+                layout.height = insets.bottom + actionBarHeight;
+                view.setLayoutParams(layout);
+                // Return CONSUMED if you don't want the window insets to keep passing down to descendant views.
+                return WindowInsetsCompat.CONSUMED;
+            });
+        }
     }
 
     @Override


### PR DESCRIPTION
Starting on Android 15, the system forces edge-to-edge rendering on all apps.
This app did account for that, so the BottomAppBar was rendering under the navbar, making it unusable.

Solution: Enable edge-to-edge rendering and apply insets to BottomAppBar and the other content.

Some tests fail, but its always inconsistent on which ones fail.

This PR resolves issues #2073 and #2103.
Solution found in [this article](https://developer.android.com/develop/ui/views/layout/edge-to-edge#java).